### PR TITLE
[D401] dual RGB POC

### DIFF
--- a/.claude/skills/nvidia-oot-patch/SKILL.md
+++ b/.claude/skills/nvidia-oot-patch/SKILL.md
@@ -1,0 +1,108 @@
+# nvidia-oot-patch
+
+Generates a formatted patch from the latest commit in the external `nvidia-oot` repository (the patches repo lives under
+`sources_$(cat jetpack_version)/nvidia-oot`), places it into `sources_$(cat jetpack_version)/nvidia-oot/6.0`, and creates a
+symlink in `sources_$(cat jetpack_version)/nvidia-oot/6.2`.
+
+This skill chooses the next numeric 4-digit patch index automatically. It finds the maximal existing `NNNN-` prefix in the
+target `6.0` folder and uses `NNNN+1` for the new patch filename.
+
+Usage (manual):
+
+From the repository root run the sequence below; the commands compute the next index and write the formatted patch using that
+index (they use the `jetpack_version` file in the repo root to locate `sources_<JP>`):
+
+```bash
+# get JetPack tag and external nvidia-oot repo path
+JP=$(cat jetpack_version)
+SRCDIR="sources_${JP}/nvidia-oot"
+
+# compute next 4-digit index and create formatted patch from latest commit in that repo
+MAX=$(ls -1 "${SRCDIR}/6.0" 2>/dev/null | grep -E '^[0-9]{4}-' | sed -E 's/^([0-9]{4}).*/\1/' | sort -n | tail -n1 || echo 0)
+NEXT=$(printf "%04d" $((10#$MAX + 1)))
+git -C "${SRCDIR}" format-patch -1 --stdout > "${SRCDIR}/6.0/${NEXT}-short-desc.patch"
+
+# create or refresh symlink in the 6.2 folder
+ln -sf ../6.0/${NEXT}-short-desc.patch "${SRCDIR}/6.2/${NEXT}-short-desc.patch"
+```
+
+Notes / conventions:
+
+- The apply script (`apply_patches.sh`) expects patches under `${BUILD_SRCS}/nvidia-oot`. For JetPack >= 6.0 `BUILD_SRCS` equals
+	`sources_${JP_INPUT_VERSION}`, so creating patches in `sources_$(cat jetpack_version)/nvidia-oot` places them where the apply
+	workflow will look for them.
+- If `sources_${JP}` is not present (you have not run `./setup_workspace.sh`), you can fall back to the local repository's
+	`nvidia-oot` directory by adding a small check:
+
+```bash
+JP=$(cat jetpack_version)
+SRCDIR="sources_${JP}/nvidia-oot"
+if [[ ! -d "${SRCDIR}" ]]; then
+	SRCDIR="nvidia-oot"
+fi
+```
+
+- Use a numeric 4-digit prefix to match the existing series (for example `0010-...`).
+- Verify the generated filename before committing to avoid accidental collisions if you run the commands concurrently.
+- The skill does not auto-commit; to record the generated patch(s) in git run:
+
+```bash
+git add "${SRCDIR}/6.0/${NEXT}-short-desc.patch" "${SRCDIR}/6.2/${NEXT}-short-desc.patch"
+git commit -m "nvidia-oot: ${NEXT} Add <short description>"
+```
+
+Suggested automation: wrap the commands above in a small script that checks for concurrent runs, accepts a short description to
+populate the filename, and optionally commits the result. Keep the script idempotent and safe to run concurrently by checking for
+existing `${NEXT}` prior to creating the patch.
+
+Validation (recommended)
+
+After generating the patch, validate it does not touch kernel tree files (for example `kernel/realsense/d4xx.c`). The
+`apply_patches.sh` flow expects only the external `nvidia-oot` drivers/header changes under `drivers/` and `include/`.
+Add this quick check to the script to avoid accidentally generating patches from the main repo:
+
+```bash
+# PATCHPATH is the generated patch file path
+if grep -qE '^diff --git (a|b)/kernel/' "${PATCHPATH}"; then
+	echo "ERROR: patch touches kernel/ files — regenerate from the nvidia-oot repo, not the main repo."
+	exit 1
+fi
+
+# More specific guard for the known problematic file
+if grep -q 'kernel/realsense/d4xx.c' "${PATCHPATH}"; then
+	echo "ERROR: patch contains d4xx.c; aborting to avoid applying kernel changes into nvidia-oot."
+	exit 1
+fi
+```
+
+If the validation fails, inspect the commit used to create the patch and re-run the `git -C "${SRCDIR}" format-patch` command
+against the correct `nvidia-oot` repository. The automation script can exit non-zero on validation failure so CI or local checks
+will catch the mistake early.
+
+Move generated patches to top-level `nvidia-oot`
+
+When you have a generated patch that is intended to live in the main repository (the `nvidia-oot/6.0` series), copy it into
+the repository root's `nvidia-oot/6.0` and create a lightweight symlink in `nvidia-oot/6.2` that points at the top-level file.
+Do not auto-commit these filesystem changes from automation — leave them unstaged so you can review before committing.
+
+Example (run from the repo root):
+
+```bash
+# source values from earlier steps (JP, SRCDIR, NEXT, PATCHPATH)
+PATCHNAME="${NEXT}-short-desc.patch"
+PATCHPATH="${SRCDIR}/6.0/${PATCHNAME}"
+
+# copy the generated patch into the main repo top-level nvidia-oot/6.0
+mkdir -p nvidia-oot/6.0 nvidia-oot/6.2
+cp "${PATCHPATH}" nvidia-oot/6.0/
+
+# create or refresh a symlink in the 6.2 folder that points to the top-level patch
+ln -sf ../6.0/${PATCHNAME} nvidia-oot/6.2/${PATCHNAME}
+
+# IMPORTANT: do NOT auto-commit here. Leave the files unstaged for manual review.
+echo "Patch copied to nvidia-oot/6.0 and symlink created in nvidia-oot/6.2 (unstaged)."
+```
+
+This keeps the patch series discoverable in the repository root (so `apply_patches.sh` can find it) while giving you a manual
+checkpoint to inspect the generated contents and remove or adjust any kernel-sourced hunks (for example `kernel/realsense/d4xx.c`)
+before committing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,23 @@ Format — one line per action: `<action> — <model>, effort <tier>` plus a sho
 - **Flag delegation separately.** If the action is better run as a subagent or Workflow, say so and give the model/effort for the subagent, noting that both require explicit user opt-in in this repo.
 - **Re-recommend when scope changes.** If new evidence makes an action riskier (e.g. HW work turns out to be panic-prone), restate the recommendation instead of letting the old one stand.
 
+## SerDes format configuration notes
+
+- `DS5_FW_CSI_PT` (`0x2E`) is the D40x FW CSI-PT mode selector for the OV9782 sensor — not a MIPI wire DT. Written to `DS5_RGB_STREAM_DT` to activate FW CSI passthrough mode. The sole active use is the D401 RAW8 CSI passthrough format (`mbus_code = MEDIA_BUS_FMT_SBGGR8_1X8`):
+  - Write `0x2E` to `dt_addr` — FW activates CSI passthrough mode.
+  - Write `0x2A` (`MIPI_CSI2_TYPE_RAW8`) to `override_addr` — the D401 FW remaps **all** wire DTs (pixel long packets from OV9782 and FW-generated short packets) to RAW8.
+  - Set SerDes PIPE_X_DT = `0x2A` — aligns MAX9296 routing with the actual RAW8 wire DT. In `ds5_configure()`, guard with `mbus_code == MEDIA_BUS_FMT_SBGGR8_1X8` after the standard `data_type1` init, setting `data_type1 = MIPI_CSI2_TYPE_RAW8`.
+  - Before writing `DS5_RGB_RES_WIDTH`, clamp the V4L2 format width (1612) to the OV9782 physical pixel count (1288). The FW expects the sensor pixel count; the V4L2 width stays at 1612 so `bytesperline` accommodates the actual 1612 B/line VDF output.
+- Do **not** call `max9295_set_pipe_bpp()` during stream start. Both the new-pipe branch and unconditional BPP write paths were removed after experiments proved they cause `CAPTURE_CHANNEL_ERROR_COLLISION` in the Tegra VI descriptor engine (~56 extra COLLISION events per run). The default BPP register (`0x30` = enable+16bpp) over-allocates GMSL2 link bandwidth but streaming is functionally correct.
+
+## NVCSI / VI capture notes
+
+- **D401 OV9782 RAW10 dword alignment — RAW8 passthrough is the fix**: The D401 VDF dword-aligns each RAW10 line: 1288px × 10/8 = 1610 B → `ALIGN(1610, 4)` = 1612 B transmitted. A pure RAW10 NVCSI capture path is not viable for this sensor:
+  - The NVCSI RAW10 depacketizer requires `frame_x` to be **8-pixel aligned**. No 8-aligned value gives an expected WC of exactly 1612 B (`frame_x=1288` → 1610 B → `PIXEL_LONG_LINE` → ~20% SOF; `frame_x=1296` → 1620 B → `PIXEL_SHORT_LINE` → unvalidated). Non-8-aligned values (1290, 1292) cause `CAPTURE_CHANNEL_ERROR_COLLISION` and 0% SOF regardless of WC accuracy.
+  - **Correct fix**: use the D401 RAW8 CSI passthrough approach (see SerDes notes above). FW `override_addr=0x2A` remaps all wire DTs to RAW8; NVCSI is configured with `match.datatype=0x2A`, `frame_x=1612` (1 B/pixel → expected WC = 1612 B = actual VDF output). RAW8 has no depacketizer and no pixel-alignment constraint.
+- Do **not** set `dt_enable=1` in the VI capture descriptor — it suppresses DT=0x00 Frame Start packets, causing `sof:0.0` and `PIXEL_INCOMPLETE` on every frame.
+- `frame_x` in `struct vi_frame_config` is in **pixels**, not bytes. NVCSI derives expected WC as `(frame_x × bpp_for_DT) / 8` using integer truncation.
+
 ## Post-patch instruction hygiene
 
 After every confirmed code patch, review `CLAUDE.md` against the final net diff, including any follow-up tuning edits.

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -116,6 +116,9 @@ struct ser_interface {
 #define GMSL_CSI_DT_EMBED 0x12
 #endif
 
+/* D40x FW CSI-PT mode selector for the OV9782 (not a MIPI wire DT). */
+#define DS5_FW_CSI_PT	0x2E
+
 //#define DS5_DRIVER_NAME "DS5 RealSense camera driver"
 #define DS5_DRIVER_NAME "d4xx"
 #define DS5_DRIVER_NAME_AWG "d4xx-awg"
@@ -175,6 +178,7 @@ struct ser_interface {
 #define DS5_RGB_RES_HEIGHT		0x4028
 #define DS5_RGB_FPS				0x402C
 #define DS5_RGB_CONTROL_STATUS 	0x402E
+#define DS5_RGB_OVERRIDE		0x403C
 
 /* SerDes startup I2C readiness polling (defer probe if not responsive) */
 #define DS5_SERDES_STARTUP_TIMEOUT_MS 2000
@@ -1013,6 +1017,7 @@ static const u16 ds5_41x_framerate_to_30[] = {6, 15, 30};
 static const u16 ds5_41x_framerate_to_60_no_15[] = {6, 30, 60};
 static const u16 ds5_41x_framerate_to_60[] = {6, 15, 30, 60};
 static const u16 ds5_41x_framerate_to_90[] = {6, 15, 30, 60, 90};
+static const u16 ds5_raw8_framerate_to_60[] = {5, 10, 15, 30, 60};
 static const u16 ds5_framerate_15_25[] = {15, 25};
 static const u16 ds5_framerate_15_30[] = {15, 30};
 static const u16 ds5_framerate_15_60[] = {15, 30, 60};
@@ -1372,6 +1377,10 @@ static const struct ds5_resolution d45x_calibration_sizes[] = {
 	},
 };
 
+static const struct ds5_resolution raw8_1612x808_sizes[] = {
+	DS5_RES(1612, 808, ds5_raw8_framerate_to_60)
+};
+
 static const struct ds5_resolution ds5_size_imu[] = {
 	{
 	.width = 32,
@@ -1500,6 +1509,11 @@ static const struct ds5_format ds5_y_formats_40x[] = {
 		.mbus_code = MEDIA_BUS_FMT_RGB888_1X24,
 		.n_resolutions = ARRAY_SIZE(d40x_calibration_sizes),
 		.resolutions = d40x_calibration_sizes,
+	}, {
+		.data_type = DS5_FW_CSI_PT,		/* EP3 left OV9782: activates FW CSI-PT mode; FW remaps wire DT to RAW8 */
+		.mbus_code = MEDIA_BUS_FMT_SBGGR8_1X8,
+		.n_resolutions = ARRAY_SIZE(raw8_1612x808_sizes),
+		.resolutions = raw8_1612x808_sizes,
 	},
 };
 
@@ -1550,11 +1564,18 @@ static const struct ds5_format ds5_41x_rgb_format = {
 	.resolutions = ds5_41x_rgb_sizes,
 };
 
-static const struct ds5_format ds5_40x_rgb_format = {
-	.data_type = GMSL_CSI_DT_YUV422_8,	/* UYVY */
-	.mbus_code = MEDIA_BUS_FMT_YUYV8_1X16,
-	.n_resolutions = ARRAY_SIZE(d40x_rgb_sizes),
-	.resolutions = d40x_rgb_sizes,
+static const struct ds5_format ds5_40x_rgb_formats[] = {
+	{
+		.data_type = GMSL_CSI_DT_YUV422_8,	/* UYVY */
+		.mbus_code = MEDIA_BUS_FMT_YUYV8_1X16,
+		.n_resolutions = ARRAY_SIZE(d40x_rgb_sizes),
+		.resolutions = d40x_rgb_sizes,
+	}, {
+		.data_type = DS5_FW_CSI_PT,	/* activates FW CSI-PT mode; FW remaps wire DT to RAW8 */
+		.mbus_code = MEDIA_BUS_FMT_SBGGR8_1X8,
+		.n_resolutions = ARRAY_SIZE(raw8_1612x808_sizes),
+		.resolutions = raw8_1612x808_sizes,
+	},
 };
 
 static const struct ds5_format ds5_rlt_rgb_format = {
@@ -2145,7 +2166,10 @@ static int ds5_configure(struct ds5 *state)
 		sensor = &state->rgb.sensor;
 		dt_addr = DS5_RGB_STREAM_DT;
 		md_addr = DS5_RGB_STREAM_MD;
-		override_addr = 0;
+		/* Only CSI-PT needs the FW DT override; leave the YUYV path on the
+		 * FW default so non-passthrough RGB behaviour is unchanged. */
+		override_addr = sensor->config.format->mbus_code ==
+				MEDIA_BUS_FMT_SBGGR8_1X8 ? DS5_RGB_OVERRIDE : 0;
 		fps_addr = DS5_RGB_FPS;
 		width_addr = DS5_RGB_RES_WIDTH;
 		height_addr = DS5_RGB_RES_HEIGHT;
@@ -2175,6 +2199,12 @@ static int ds5_configure(struct ds5 *state)
 	data_type1 = sensor->config.format->data_type;
 	data_type2 = md_fmt;
 	is_calib = (state->is_y8 && (data_type1 == GMSL_CSI_DT_RGB_888));
+
+	/* D401 RAW8 CSI passthrough: FW remaps all wire DTs to RAW8 on the
+	 * GMSL link; MAX9296 pipe routing must match the actual wire DT.
+	 */
+	if (sensor->config.format->mbus_code == MEDIA_BUS_FMT_SBGGR8_1X8)
+		data_type1 = MIPI_CSI2_TYPE_RAW8;
 
 	vc_id = state->g_ctx.dst_vc;
     if (PIPE_NOT_CONFIGURED == sensor->pipe_id ||
@@ -2257,6 +2287,8 @@ static int ds5_configure(struct ds5 *state)
 		ret = ds5_write(state, dt_addr, dt_value);
 		if (ret < 0)
 			return ret;
+		dev_dbg(&state->client->dev, "FW dt_addr[0x%04x] = 0x%02x\n",
+			dt_addr, dt_value);
 		sensor->cached_dt_value = dt_value;
 	}
 
@@ -2270,10 +2302,18 @@ static int ds5_configure(struct ds5 *state)
 
 	if (override_addr != 0) {
 		dt_value = sensor->config.format->data_type;
+		/* RAW8 CSI passthrough: FW runs in CSI-PT mode (0x2E → dt_addr) and
+		 * remaps all wire DTs to RAW8 via override_addr=0x2A.
+		 */
+		if (sensor->config.format->mbus_code == MEDIA_BUS_FMT_SBGGR8_1X8)
+			dt_value = MIPI_CSI2_TYPE_RAW8;
 		if (sensor->cached_override_value != dt_value) {
 			ret = ds5_write(state, override_addr, dt_value);
 			if (ret < 0)
 				return ret;
+			dev_dbg(&state->client->dev,
+				"FW override_addr[0x%04x] = 0x%02x\n",
+				override_addr, dt_value);
 			sensor->cached_override_value = dt_value;
 		}
 	}
@@ -2287,6 +2327,12 @@ static int ds5_configure(struct ds5 *state)
 	}
 
 	width_value = sensor->config.resolution->width;
+	/* RAW8 CSI passthrough: V4L2 width=1612 (VDF byte-count/line, needed for correct
+	 * DMA surface stride), but the FW width register (DS5_RGB_RES_WIDTH for EP4,
+	 * DS5_IR_RES_WIDTH for EP3) expects the OV9782 physical pixel count. Clamp to 1288.
+	 */
+	if (sensor->config.format->mbus_code == MEDIA_BUS_FMT_SBGGR8_1X8 && width_value == 1612)
+		width_value = 1288;
 	if (sensor->cached_width_value != width_value) {
 		ret = ds5_write(state, width_addr, width_value);
 		if (ret < 0)
@@ -6372,8 +6418,8 @@ static int ds5_fixed_configuration(struct i2c_client *client, struct ds5 *state)
 		sensor->n_formats = DS5_RLT_RGB_N_FORMATS;
 		break;
 	case DS5_DEVICE_TYPE_D40X:
-		sensor->formats = &ds5_40x_rgb_format;
-		sensor->n_formats = DS5_RLT_RGB_N_FORMATS;
+		sensor->formats = ds5_40x_rgb_formats;
+		sensor->n_formats = ARRAY_SIZE(ds5_40x_rgb_formats);
 		break;
 	case DS5_DEVICE_TYPE_D45X:
 		sensor->formats = &ds5_rlt_rgb_format;


### PR DESCRIPTION
[D401] dual RGB POC
- Added RAW8 passthrough.
- Documented the D40x firmware CSI passthrough mode and its usage for the OV9782 sensor, NVCSI capture alignment issues.
- Updated CLAUDE.md and copilot-instructions.md with new configuration details.