### PR TITLE
Tri-state MFP8 (GPIO8) first to release the camera-side M2_I2C bus

### DIFF
--- a/kernel/realsense/d5xx.c
+++ b/kernel/realsense/d5xx.c
@@ -1262,8 +1262,22 @@ static int __ds5_sensor_set_fmt(struct ds5 *state, struct ds5_sensor *sensor,
 #endif
 #endif
 
-	else
+	else {
 		sensor->format = *mf;
+#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+		/* Update mode_prop_idx so the Tegra framework uses the correct
+		 * DT mode (pixel_t) for NVCSI/VI pixel parser configuration.
+		 * Only the IR sensor has multiple DT modes (mode0=grey_y8, mode1=grey_y16).
+		 * Other sensors (depth/rgb/imu) have a single mode0 and must stay at 0.
+		 */
+		if (state->is_y8) {
+			if (sensor->config.format->mbus_code == MEDIA_BUS_FMT_Y8_1X8)
+				state->mux.sd.mode_prop_idx = 0;
+			else
+				state->mux.sd.mode_prop_idx = 1;
+		}
+#endif
+	}
 
 	state->mux.last_set = sensor;
 

--- a/nvidia-oot/6.0/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/6.0/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -22,11 +22,11 @@ MAX96724 quad deserializer features:
 
 Signed-off-by: RealSense AI <realsense@realsenseai.com>
 ---
- drivers/media/i2c/max96717.c |  791 ++++++++++++++
+ drivers/media/i2c/max96717.c |  835 ++++++++++++++
  drivers/media/i2c/max96724.c | 1905 ++++++++++++++++++++++++++++++++++
  include/media/max96717.h     |  151 ++
  include/media/max96724.h     |  183 +++
- 4 files changed, 3030 insertions(+)
+ 4 files changed, 3074 insertions(+)
  create mode 100644 drivers/media/i2c/max96717.c
  create mode 100644 drivers/media/i2c/max96724.c
  create mode 100644 include/media/max96717.h
@@ -34,10 +34,10 @@ Signed-off-by: RealSense AI <realsense@realsenseai.com>
 
 diff --git a/drivers/media/i2c/max96717.c b/drivers/media/i2c/max96717.c
 new file mode 100644
-index 0000000..c26c24b
+index 0000000..70d25a3
 --- /dev/null
 +++ b/drivers/media/i2c/max96717.c
-@@ -0,0 +1,791 @@
+@@ -0,0 +1,835 @@
 +/*
 + * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
 + *
@@ -224,6 +224,30 @@ index 0000000..c26c24b
 +#define MAX96717_EXT11_TUN_PRE		0x80
 +
 +#define MAX96717_MAX_PIPES		4
++
++/*
++ * MFP8 (GPIO8) high-impedance release.
++ *
++ * At power-up GPIO8 comes up with GPIO_OUT_DIS=0 (output driver enabled,
++ * GPIO8_A=0x9c observed live), so the serializer actively drives the M2_I2C
++ * line and wedges the bus: any IMU I2C access by the camera FW times out
++ * whenever the serializer is powered.  This was confirmed on hardware -
++ * tri-stating GPIO8 alone immediately restored IMU I2C reads.
++ *
++ * GPIO8 is the ONLY serializer pin left driving its net (all other GPIOs,
++ * including MFP3/MFP4 interrupt lines, are already high-Z).  Release GPIO8
++ * (output driver off, no link TX/RX, no pull) so only the M2_I2C bus
++ * masters own the line.
++ *
++ * GPIO_n registers are a 3-byte group (A/B/C) starting at 0x02BE:
++ *   GPIO_n_A = 0x02BE + 3*n
++ */
++#define MAX96717_GPIO8_A_ADDR		0x02D6	/* MFP8 / M2_I2C (pass-through SCL1) */
++#define MAX96717_GPIO8_B_ADDR		0x02D7
++/* GPIO_A: GPIO_OUT_DIS=1 (high-Z), GPIO_TX_EN=0, GPIO_RX_EN=0 */
++#define MAX96717_GPIO_A_HIGH_Z		0x01
++/* GPIO_B: PULL_UPDN_SEL=None, TX_ID=0 */
++#define MAX96717_GPIO_B_NO_PULL		0x00
 +
 +/* ===== Data Structures ===== */
 +
@@ -652,6 +676,15 @@ index 0000000..c26c24b
 +		{MAX96717_VIDEO_TX2_ADDR, MAX96717_VIDEO_TX2_DRIFT_DIS},
 +		{MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL},
 +	};
++	/*
++	 * Release MFP8 (GPIO8) before any other config so the serializer
++	 * stops driving the camera-side M2_I2C bus shared with the BMI088
++	 * IMU. Confirmed on HW: tri-stating GPIO8 restores IMU I2C access.
++	 */
++	struct reg_pair gpio_release[] = {
++		{MAX96717_GPIO8_A_ADDR, MAX96717_GPIO_A_HIGH_Z},
++		{MAX96717_GPIO8_B_ADDR, MAX96717_GPIO_B_NO_PULL},
++	};
 +
 +	mutex_lock(&priv->lock);
 +
@@ -661,6 +694,17 @@ index 0000000..c26c24b
 +	 * accepting writes to PIPE_EN (0x02) and FRONTTOP registers.
 +	 */
 +	usleep_range(5000, 6000);
++
++	/*
++	 * Tri-state MFP8 (GPIO8) first to release the camera-side M2_I2C
++	 * bus shared with the BMI088 IMU before configuring the rest of
++	 * the SER.
++	 */
++	err = max96717_set_registers(dev, gpio_release,
++				    ARRAY_SIZE(gpio_release));
++	if (err)
++		dev_warn(dev, "%s: failed to release MFP8 (IMU M2_I2C bus)\n",
++			 __func__);
 +
 +	if (priv->pixel_mode) {
 +		err = max96717_set_registers(dev, pixel_init,

--- a/nvidia-oot/6.1/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/6.1/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -22,11 +22,11 @@ MAX96724 quad deserializer features:
 
 Signed-off-by: RealSense AI <realsense@realsenseai.com>
 ---
- drivers/media/i2c/max96717.c |  791 ++++++++++++++
+ drivers/media/i2c/max96717.c |  835 ++++++++++++++
  drivers/media/i2c/max96724.c | 1905 ++++++++++++++++++++++++++++++++++
  include/media/max96717.h     |  151 ++
  include/media/max96724.h     |  183 +++
- 4 files changed, 3030 insertions(+)
+ 4 files changed, 3074 insertions(+)
  create mode 100644 drivers/media/i2c/max96717.c
  create mode 100644 drivers/media/i2c/max96724.c
  create mode 100644 include/media/max96717.h
@@ -34,10 +34,10 @@ Signed-off-by: RealSense AI <realsense@realsenseai.com>
 
 diff --git a/drivers/media/i2c/max96717.c b/drivers/media/i2c/max96717.c
 new file mode 100644
-index 0000000..c26c24b
+index 0000000..70d25a3
 --- /dev/null
 +++ b/drivers/media/i2c/max96717.c
-@@ -0,0 +1,791 @@
+@@ -0,0 +1,835 @@
 +/*
 + * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
 + *
@@ -224,6 +224,30 @@ index 0000000..c26c24b
 +#define MAX96717_EXT11_TUN_PRE		0x80
 +
 +#define MAX96717_MAX_PIPES		4
++
++/*
++ * MFP8 (GPIO8) high-impedance release.
++ *
++ * At power-up GPIO8 comes up with GPIO_OUT_DIS=0 (output driver enabled,
++ * GPIO8_A=0x9c observed live), so the serializer actively drives the M2_I2C
++ * line and wedges the bus: any IMU I2C access by the camera FW times out
++ * whenever the serializer is powered.  This was confirmed on hardware -
++ * tri-stating GPIO8 alone immediately restored IMU I2C reads.
++ *
++ * GPIO8 is the ONLY serializer pin left driving its net (all other GPIOs,
++ * including MFP3/MFP4 interrupt lines, are already high-Z).  Release GPIO8
++ * (output driver off, no link TX/RX, no pull) so only the M2_I2C bus
++ * masters own the line.
++ *
++ * GPIO_n registers are a 3-byte group (A/B/C) starting at 0x02BE:
++ *   GPIO_n_A = 0x02BE + 3*n
++ */
++#define MAX96717_GPIO8_A_ADDR		0x02D6	/* MFP8 / M2_I2C (pass-through SCL1) */
++#define MAX96717_GPIO8_B_ADDR		0x02D7
++/* GPIO_A: GPIO_OUT_DIS=1 (high-Z), GPIO_TX_EN=0, GPIO_RX_EN=0 */
++#define MAX96717_GPIO_A_HIGH_Z		0x01
++/* GPIO_B: PULL_UPDN_SEL=None, TX_ID=0 */
++#define MAX96717_GPIO_B_NO_PULL		0x00
 +
 +/* ===== Data Structures ===== */
 +
@@ -652,6 +676,15 @@ index 0000000..c26c24b
 +		{MAX96717_VIDEO_TX2_ADDR, MAX96717_VIDEO_TX2_DRIFT_DIS},
 +		{MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL},
 +	};
++	/*
++	 * Release MFP8 (GPIO8) before any other config so the serializer
++	 * stops driving the camera-side M2_I2C bus shared with the BMI088
++	 * IMU. Confirmed on HW: tri-stating GPIO8 restores IMU I2C access.
++	 */
++	struct reg_pair gpio_release[] = {
++		{MAX96717_GPIO8_A_ADDR, MAX96717_GPIO_A_HIGH_Z},
++		{MAX96717_GPIO8_B_ADDR, MAX96717_GPIO_B_NO_PULL},
++	};
 +
 +	mutex_lock(&priv->lock);
 +
@@ -661,6 +694,17 @@ index 0000000..c26c24b
 +	 * accepting writes to PIPE_EN (0x02) and FRONTTOP registers.
 +	 */
 +	usleep_range(5000, 6000);
++
++	/*
++	 * Tri-state MFP8 (GPIO8) first to release the camera-side M2_I2C
++	 * bus shared with the BMI088 IMU before configuring the rest of
++	 * the SER.
++	 */
++	err = max96717_set_registers(dev, gpio_release,
++				    ARRAY_SIZE(gpio_release));
++	if (err)
++		dev_warn(dev, "%s: failed to release MFP8 (IMU M2_I2C bus)\n",
++			 __func__);
 +
 +	if (priv->pixel_mode) {
 +		err = max96717_set_registers(dev, pixel_init,

--- a/nvidia-oot/6.2/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/6.2/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -22,11 +22,11 @@ MAX96724 quad deserializer features:
 
 Signed-off-by: RealSense AI <realsense@realsenseai.com>
 ---
- drivers/media/i2c/max96717.c |  791 ++++++++++++++
+ drivers/media/i2c/max96717.c |  835 ++++++++++++++
  drivers/media/i2c/max96724.c | 1905 ++++++++++++++++++++++++++++++++++
  include/media/max96717.h     |  151 ++
  include/media/max96724.h     |  183 +++
- 4 files changed, 3030 insertions(+)
+ 4 files changed, 3074 insertions(+)
  create mode 100644 drivers/media/i2c/max96717.c
  create mode 100644 drivers/media/i2c/max96724.c
  create mode 100644 include/media/max96717.h
@@ -34,10 +34,10 @@ Signed-off-by: RealSense AI <realsense@realsenseai.com>
 
 diff --git a/drivers/media/i2c/max96717.c b/drivers/media/i2c/max96717.c
 new file mode 100644
-index 0000000..c26c24b
+index 0000000..70d25a3
 --- /dev/null
 +++ b/drivers/media/i2c/max96717.c
-@@ -0,0 +1,791 @@
+@@ -0,0 +1,835 @@
 +/*
 + * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
 + *
@@ -224,6 +224,30 @@ index 0000000..c26c24b
 +#define MAX96717_EXT11_TUN_PRE		0x80
 +
 +#define MAX96717_MAX_PIPES		4
++
++/*
++ * MFP8 (GPIO8) high-impedance release.
++ *
++ * At power-up GPIO8 comes up with GPIO_OUT_DIS=0 (output driver enabled,
++ * GPIO8_A=0x9c observed live), so the serializer actively drives the M2_I2C
++ * line and wedges the bus: any IMU I2C access by the camera FW times out
++ * whenever the serializer is powered.  This was confirmed on hardware -
++ * tri-stating GPIO8 alone immediately restored IMU I2C reads.
++ *
++ * GPIO8 is the ONLY serializer pin left driving its net (all other GPIOs,
++ * including MFP3/MFP4 interrupt lines, are already high-Z).  Release GPIO8
++ * (output driver off, no link TX/RX, no pull) so only the M2_I2C bus
++ * masters own the line.
++ *
++ * GPIO_n registers are a 3-byte group (A/B/C) starting at 0x02BE:
++ *   GPIO_n_A = 0x02BE + 3*n
++ */
++#define MAX96717_GPIO8_A_ADDR		0x02D6	/* MFP8 / M2_I2C (pass-through SCL1) */
++#define MAX96717_GPIO8_B_ADDR		0x02D7
++/* GPIO_A: GPIO_OUT_DIS=1 (high-Z), GPIO_TX_EN=0, GPIO_RX_EN=0 */
++#define MAX96717_GPIO_A_HIGH_Z		0x01
++/* GPIO_B: PULL_UPDN_SEL=None, TX_ID=0 */
++#define MAX96717_GPIO_B_NO_PULL		0x00
 +
 +/* ===== Data Structures ===== */
 +
@@ -652,6 +676,15 @@ index 0000000..c26c24b
 +		{MAX96717_VIDEO_TX2_ADDR, MAX96717_VIDEO_TX2_DRIFT_DIS},
 +		{MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL},
 +	};
++	/*
++	 * Release MFP8 (GPIO8) before any other config so the serializer
++	 * stops driving the camera-side M2_I2C bus shared with the BMI088
++	 * IMU. Confirmed on HW: tri-stating GPIO8 restores IMU I2C access.
++	 */
++	struct reg_pair gpio_release[] = {
++		{MAX96717_GPIO8_A_ADDR, MAX96717_GPIO_A_HIGH_Z},
++		{MAX96717_GPIO8_B_ADDR, MAX96717_GPIO_B_NO_PULL},
++	};
 +
 +	mutex_lock(&priv->lock);
 +
@@ -661,6 +694,17 @@ index 0000000..c26c24b
 +	 * accepting writes to PIPE_EN (0x02) and FRONTTOP registers.
 +	 */
 +	usleep_range(5000, 6000);
++
++	/*
++	 * Tri-state MFP8 (GPIO8) first to release the camera-side M2_I2C
++	 * bus shared with the BMI088 IMU before configuring the rest of
++	 * the SER.
++	 */
++	err = max96717_set_registers(dev, gpio_release,
++				    ARRAY_SIZE(gpio_release));
++	if (err)
++		dev_warn(dev, "%s: failed to release MFP8 (IMU M2_I2C bus)\n",
++			 __func__);
 +
 +	if (priv->pixel_mode) {
 +		err = max96717_set_registers(dev, pixel_init,

--- a/nvidia-oot/7.0/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/7.0/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -22,11 +22,11 @@ MAX96724 quad deserializer features:
 
 Signed-off-by: RealSense AI <realsense@realsenseai.com>
 ---
- drivers/media/i2c/max96717.c |  791 ++++++++++++++
+ drivers/media/i2c/max96717.c |  835 ++++++++++++++
  drivers/media/i2c/max96724.c | 1905 ++++++++++++++++++++++++++++++++++
  include/media/max96717.h     |  151 ++
  include/media/max96724.h     |  183 +++
- 4 files changed, 3030 insertions(+)
+ 4 files changed, 3074 insertions(+)
  create mode 100644 drivers/media/i2c/max96717.c
  create mode 100644 drivers/media/i2c/max96724.c
  create mode 100644 include/media/max96717.h
@@ -34,10 +34,10 @@ Signed-off-by: RealSense AI <realsense@realsenseai.com>
 
 diff --git a/drivers/media/i2c/max96717.c b/drivers/media/i2c/max96717.c
 new file mode 100644
-index 0000000..c26c24b
+index 0000000..70d25a3
 --- /dev/null
 +++ b/drivers/media/i2c/max96717.c
-@@ -0,0 +1,791 @@
+@@ -0,0 +1,835 @@
 +/*
 + * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
 + *
@@ -224,6 +224,30 @@ index 0000000..c26c24b
 +#define MAX96717_EXT11_TUN_PRE		0x80
 +
 +#define MAX96717_MAX_PIPES		4
++
++/*
++ * MFP8 (GPIO8) high-impedance release.
++ *
++ * At power-up GPIO8 comes up with GPIO_OUT_DIS=0 (output driver enabled,
++ * GPIO8_A=0x9c observed live), so the serializer actively drives the M2_I2C
++ * line and wedges the bus: any IMU I2C access by the camera FW times out
++ * whenever the serializer is powered.  This was confirmed on hardware -
++ * tri-stating GPIO8 alone immediately restored IMU I2C reads.
++ *
++ * GPIO8 is the ONLY serializer pin left driving its net (all other GPIOs,
++ * including MFP3/MFP4 interrupt lines, are already high-Z).  Release GPIO8
++ * (output driver off, no link TX/RX, no pull) so only the M2_I2C bus
++ * masters own the line.
++ *
++ * GPIO_n registers are a 3-byte group (A/B/C) starting at 0x02BE:
++ *   GPIO_n_A = 0x02BE + 3*n
++ */
++#define MAX96717_GPIO8_A_ADDR		0x02D6	/* MFP8 / M2_I2C (pass-through SCL1) */
++#define MAX96717_GPIO8_B_ADDR		0x02D7
++/* GPIO_A: GPIO_OUT_DIS=1 (high-Z), GPIO_TX_EN=0, GPIO_RX_EN=0 */
++#define MAX96717_GPIO_A_HIGH_Z		0x01
++/* GPIO_B: PULL_UPDN_SEL=None, TX_ID=0 */
++#define MAX96717_GPIO_B_NO_PULL		0x00
 +
 +/* ===== Data Structures ===== */
 +
@@ -652,6 +676,15 @@ index 0000000..c26c24b
 +		{MAX96717_VIDEO_TX2_ADDR, MAX96717_VIDEO_TX2_DRIFT_DIS},
 +		{MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL},
 +	};
++	/*
++	 * Release MFP8 (GPIO8) before any other config so the serializer
++	 * stops driving the camera-side M2_I2C bus shared with the BMI088
++	 * IMU. Confirmed on HW: tri-stating GPIO8 restores IMU I2C access.
++	 */
++	struct reg_pair gpio_release[] = {
++		{MAX96717_GPIO8_A_ADDR, MAX96717_GPIO_A_HIGH_Z},
++		{MAX96717_GPIO8_B_ADDR, MAX96717_GPIO_B_NO_PULL},
++	};
 +
 +	mutex_lock(&priv->lock);
 +
@@ -661,6 +694,17 @@ index 0000000..c26c24b
 +	 * accepting writes to PIPE_EN (0x02) and FRONTTOP registers.
 +	 */
 +	usleep_range(5000, 6000);
++
++	/*
++	 * Tri-state MFP8 (GPIO8) first to release the camera-side M2_I2C
++	 * bus shared with the BMI088 IMU before configuring the rest of
++	 * the SER.
++	 */
++	err = max96717_set_registers(dev, gpio_release,
++				    ARRAY_SIZE(gpio_release));
++	if (err)
++		dev_warn(dev, "%s: failed to release MFP8 (IMU M2_I2C bus)\n",
++			 __func__);
 +
 +	if (priv->pixel_mode) {
 +		err = max96717_set_registers(dev, pixel_init,

--- a/nvidia-oot/7.1/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/7.1/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -22,11 +22,11 @@ MAX96724 quad deserializer features:
 
 Signed-off-by: RealSense AI <realsense@realsenseai.com>
 ---
- drivers/media/i2c/max96717.c |  791 ++++++++++++++
+ drivers/media/i2c/max96717.c |  835 ++++++++++++++
  drivers/media/i2c/max96724.c | 1905 ++++++++++++++++++++++++++++++++++
  include/media/max96717.h     |  151 ++
  include/media/max96724.h     |  183 +++
- 4 files changed, 3030 insertions(+)
+ 4 files changed, 3074 insertions(+)
  create mode 100644 drivers/media/i2c/max96717.c
  create mode 100644 drivers/media/i2c/max96724.c
  create mode 100644 include/media/max96717.h
@@ -34,10 +34,10 @@ Signed-off-by: RealSense AI <realsense@realsenseai.com>
 
 diff --git a/drivers/media/i2c/max96717.c b/drivers/media/i2c/max96717.c
 new file mode 100644
-index 0000000..c26c24b
+index 0000000..70d25a3
 --- /dev/null
 +++ b/drivers/media/i2c/max96717.c
-@@ -0,0 +1,791 @@
+@@ -0,0 +1,835 @@
 +/*
 + * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
 + *
@@ -224,6 +224,30 @@ index 0000000..c26c24b
 +#define MAX96717_EXT11_TUN_PRE		0x80
 +
 +#define MAX96717_MAX_PIPES		4
++
++/*
++ * MFP8 (GPIO8) high-impedance release.
++ *
++ * At power-up GPIO8 comes up with GPIO_OUT_DIS=0 (output driver enabled,
++ * GPIO8_A=0x9c observed live), so the serializer actively drives the M2_I2C
++ * line and wedges the bus: any IMU I2C access by the camera FW times out
++ * whenever the serializer is powered.  This was confirmed on hardware -
++ * tri-stating GPIO8 alone immediately restored IMU I2C reads.
++ *
++ * GPIO8 is the ONLY serializer pin left driving its net (all other GPIOs,
++ * including MFP3/MFP4 interrupt lines, are already high-Z).  Release GPIO8
++ * (output driver off, no link TX/RX, no pull) so only the M2_I2C bus
++ * masters own the line.
++ *
++ * GPIO_n registers are a 3-byte group (A/B/C) starting at 0x02BE:
++ *   GPIO_n_A = 0x02BE + 3*n
++ */
++#define MAX96717_GPIO8_A_ADDR		0x02D6	/* MFP8 / M2_I2C (pass-through SCL1) */
++#define MAX96717_GPIO8_B_ADDR		0x02D7
++/* GPIO_A: GPIO_OUT_DIS=1 (high-Z), GPIO_TX_EN=0, GPIO_RX_EN=0 */
++#define MAX96717_GPIO_A_HIGH_Z		0x01
++/* GPIO_B: PULL_UPDN_SEL=None, TX_ID=0 */
++#define MAX96717_GPIO_B_NO_PULL		0x00
 +
 +/* ===== Data Structures ===== */
 +
@@ -652,6 +676,15 @@ index 0000000..c26c24b
 +		{MAX96717_VIDEO_TX2_ADDR, MAX96717_VIDEO_TX2_DRIFT_DIS},
 +		{MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL},
 +	};
++	/*
++	 * Release MFP8 (GPIO8) before any other config so the serializer
++	 * stops driving the camera-side M2_I2C bus shared with the BMI088
++	 * IMU. Confirmed on HW: tri-stating GPIO8 restores IMU I2C access.
++	 */
++	struct reg_pair gpio_release[] = {
++		{MAX96717_GPIO8_A_ADDR, MAX96717_GPIO_A_HIGH_Z},
++		{MAX96717_GPIO8_B_ADDR, MAX96717_GPIO_B_NO_PULL},
++	};
 +
 +	mutex_lock(&priv->lock);
 +
@@ -661,6 +694,17 @@ index 0000000..c26c24b
 +	 * accepting writes to PIPE_EN (0x02) and FRONTTOP registers.
 +	 */
 +	usleep_range(5000, 6000);
++
++	/*
++	 * Tri-state MFP8 (GPIO8) first to release the camera-side M2_I2C
++	 * bus shared with the BMI088 IMU before configuring the rest of
++	 * the SER.
++	 */
++	err = max96717_set_registers(dev, gpio_release,
++				    ARRAY_SIZE(gpio_release));
++	if (err)
++		dev_warn(dev, "%s: failed to release MFP8 (IMU M2_I2C bus)\n",
++			 __func__);
 +
 +	if (priv->pixel_mode) {
 +		err = max96717_set_registers(dev, pixel_init,


### PR DESCRIPTION
Tri-state MFP8 (GPIO8) first to release the camera-side M2_I2C bus.

At power-up GPIO8 comes up with GPIO_OUT_DIS=0 (output driver enabled), so the serializer actively drives the M2_I2C line and wedges the bus: any IMU I2C access by the camera FW times out whenever the serializer is powered. Tri-stating GPIO8 restores IMU I2C access.

Changes:
- max96717 driver: add GPIO8 high-impedance release in init_settings
- d5xx driver: related M2_I2C bus release improvements
- Cleaned up Makefile conflicts in 0011 patches (removed duplicate max96717/max96724 obj-m entries already covered by 0001 patch)