### PR TITLE
Add FG12-4CH D457 support

### DIFF
--- a/hardware/nvidia/t23x/nv-public/6.x/0001-overlay-enable-d4xx-camera-for-Orin-jp6.patch
+++ b/hardware/nvidia/t23x/nv-public/6.x/0001-overlay-enable-d4xx-camera-for-Orin-jp6.patch
@@ -5,14 +5,14 @@ Subject: [PATCH] overlay: enable d4xx camera for Orin jp6
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- overlay/Makefile | 21 ++++++++++++++++++++++
- 1 file changed, 22 insertions(+)
+ overlay/Makefile | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
 
 diff --git a/overlay/Makefile b/overlay/Makefile
 index c88bbe2..cdd125f 100644
 --- a/overlay/Makefile
 +++ b/overlay/Makefile
-@@ -60,6 +60,28 @@ dtbo-y += tegra234-p3767-camera-p3768-imx219-A.dtbo
+@@ -60,6 +60,29 @@ dtbo-y += tegra234-p3767-camera-p3768-imx219-A.dtbo
  dtbo-y += tegra234-p3767-camera-p3768-imx219-imx477.dtbo
  dtbo-y += tegra234-p3767-camera-p3768-imx477-C.dtbo
  dtbo-y += tegra234-p3767-camera-p3768-imx477-A.dtbo
@@ -20,6 +20,7 @@ index c88bbe2..cdd125f 100644
 +dtbo-y += tegra234-camera-d4xx-overlay-dual.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay-max96712-EVB.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay-max96712-EVB-cams-0-1.dtbo
++dtbo-y += tegra234-camera-d4xx-overlay-fg12-4ch.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay-fg12-16ch.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay-fg12-16ch-d5xx.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay-fg12-16ch-PWR-only.dtbo
@@ -43,4 +44,3 @@ index c88bbe2..cdd125f 100644
  dtb-y := $(addprefix $(makefile-path)/,$(dtb-y))
 -- 
 2.43.0
-

--- a/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-4ch.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-4ch.dts
@@ -1,0 +1,493 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: Copyright (c) 2018-2023, INTEL CORPORATION.  All rights reserved.
+
+/*
+ * RealSense D457 (d4xx) overlay for the FangZhu FG12-4CH carrier board on
+ * NVIDIA Jetson Orin Nano (p3768-0000 + p3767-xxxx).
+ *
+ * Board topology (single D457 on deserializer link A):
+ *   D457 --GMSL2--> MAX9295 serializer (0x40) --> MAX96712 deserializer (0x29)
+ *        --CSI-2--> Orin Nano CSI port C (port-index = 2 / serial_c), 2-lane.
+ *
+ * This overlay keeps the full D457 -> MAX9295 -> MAX96712 -> Orin path at
+ * 2-lane. The FangZhu-specific MAX96712 hook below only enables board POC
+ * power; MIPI output setup stays on the generic 2-lane MAX96712 path.
+ *
+ * Derived from the verified Seeed Orin Nano max96712 overlay, retargeted to the
+ * Orin Nano p3768/p3767 compatible (so the overlay matches via JetsonIO /
+ * extlinux OVERLAYS) and to the FG12-4CH deserializer I2C address (0x29, the
+ * MAX96712 power-on default, confirmed on hardware via DEV_ID=0xA0 read).
+ * The CSI port-index (2) follows the FangZhu FG12/FG24-4CH board routing.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/clock/tegra234-clock.h>
+#include <dt-bindings/gpio/tegra234-gpio.h>
+#include <dt-bindings/tegra234-p3767-0000-common.h>
+
+/* camera control gpio definitions (from official FangZhu FG12-4CH device tree) */
+#define CAM0_SYNC	TEGRA234_MAIN_GPIO(H, 6)
+#define CAM1_SYNC	TEGRA234_MAIN_GPIO(AC, 0)
+#define CAM_I2C_MUX	TEGRA234_AON_GPIO(CC, 3)
+
+/ {
+	overlay-name = "Jetson RealSense Camera D4xx with max96712 for FangZhu FG12-4CH on Orin Nano (link A)";
+	jetson-header-name = "Jetson 22pin CSI Connector";
+	compatible = JETSON_COMPATIBLE_P3768;
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			tegra-capture-vi {
+				num-channels = <4>;
+				ports {
+					status = "okay";
+					port@0 {
+						status = "okay";
+						reg = <0>;
+						d4xx_vi_in0: endpoint {
+							status = "okay";
+							vc-id = <0>;
+							port-index = <2>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out0>;
+						};
+					};
+					port@1 {
+						status = "okay";
+						reg = <1>;
+						d4xx_vi_in1: endpoint {
+							status = "okay";
+							vc-id = <1>;
+							port-index = <2>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out1>;
+						};
+					};
+					port@2 {
+						status = "okay";
+						reg = <2>;
+						d4xx_vi_in2: endpoint {
+							status = "okay";
+							vc-id = <2>;
+							port-index = <2>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out2>;
+						};
+					};
+					port@3 {
+						status = "okay";
+						reg = <3>;
+						d4xx_vi_in3: endpoint {
+							status = "okay";
+							vc-id = <3>;
+							port-index = <2>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out3>;
+						};
+					};
+				};
+			};
+			tegra-camera-platform {
+				compatible = "nvidia, tegra-camera-platform";
+				status = "okay";
+				num_csi_lanes = <2>;
+				max_lane_speed = <1500000>;
+				min_bits_per_pixel = <8>;
+				vi_peak_byte_per_pixel = <2>;
+				vi_bw_margin_pct = <25>;
+				max_pixel_rate = <160000>;
+				isp_peak_byte_per_pixel = <5>;
+				isp_bw_margin_pct = <25>;
+				modules {
+					status = "okay";
+					module0 {
+						status = "okay";
+						badge = "d4xx_depth";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-001a";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ds5@1a";
+						};
+					};
+					module1 {
+						status = "okay";
+						badge = "d4xx_rgb";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-001b";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ds5@1b";
+						};
+					};
+					module2 {
+						status = "okay";
+						badge = "d4xx_Y8";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-001c";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ds5@1c";
+						};
+					};
+					module3 {
+						status = "okay";
+						badge = "d4xx_imu";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-001d";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ds5@1d";
+						};
+					};
+				};
+			};
+			bus@0 {
+				host1x@13e00000 {
+					nvcsi@15a00000 {
+						num-channels = <4>;
+						channel@0 {
+							status = "okay";
+							reg = <0>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in0: endpoint@0 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <2>;
+										remote-endpoint = <&ds5_0_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out0: endpoint@1 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in0>;
+									};
+								};
+							};
+						};
+						channel@1 {
+							status = "okay";
+							reg = <1>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in1: endpoint@2 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <2>;
+										remote-endpoint = <&ds5_1_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out1: endpoint@3 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in1>;
+									};
+								};
+							};
+						};
+						channel@2 {
+							status = "okay";
+							reg = <2>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in2: endpoint@4 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <2>;
+										remote-endpoint = <&ds5_2_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out2: endpoint@5 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in2>;
+									};
+								};
+							};
+						};
+						channel@3 {
+							status = "okay";
+							reg = <3>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in3: endpoint@6 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <2>;
+										remote-endpoint = <&ds5_3_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out3: endpoint@7 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in3>;
+									};
+								};
+							};
+						};
+					};
+				};
+
+				/*
+				 * FG12-4CH routes the camera I2C through a GPIO-selected mux
+				 * (CAM_I2C_MUX = AON_GPIO(CC,3)).  The deserializer I2C is on the
+				 * i2c@1 branch (gpio HIGH), matching the official FangZhu
+					 * tegra234-p3767-camera-p3768-fzcam-fg12-4ch device tree. The
+					 * CSI video output is configured separately above as
+					 * port-index 2 / serial_c.
+				 */
+				cam_i2cmux {
+					compatible = "i2c-mux-gpio";
+					#address-cells = <1>;
+					#size-cells = <0>;
+					i2c-parent = <&cam_i2c>;
+					mux-gpios = <&gpio_aon CAM_I2C_MUX GPIO_ACTIVE_HIGH>;
+
+					i2c@1 {
+						reg = <1>;
+						#address-cells = <1>;
+						#size-cells = <0>;
+
+					dser: max96712@29 {
+						status = "okay";
+						reg = <0x29>;
+						compatible = "maxim,max96712";
+						csi-mode = "2x4";
+						link-mask = <0x1>;
+						channel = "a";
+						fangzhu,fg12-reverse-lane-polarity;
+						fangzhu,fg12-poc-enable;
+					};
+
+					ser_a: max9295_a@40 {
+						status = "okay";
+						compatible = "maxim,max9295";
+						reg = <0x40>;
+						maxim,gmsl-dser-device = <&dser>;
+					};
+
+					ds5_3: ds5@1d {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x1d>;
+						override_reg = <0x1a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						cam-type = "IMU";
+						nvidia,gmsl-ser-device = <&ser_a>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_3_out: endpoint {
+									vc-id = <3>;
+									port-index = <2>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in3>;
+								};
+							};
+						};
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "2";
+							csi_pixel_bit_depth = "16";
+							active_w = "640";
+							active_h = "480";
+							tegra_sinterface = "serial_c";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "0";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <3>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_2: ds5@1c {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x1c>;
+						override_reg = <0x1a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						cam-type = "Y8";
+						nvidia,gmsl-ser-device = <&ser_a>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_2_out: endpoint {
+									vc-id = <2>;
+									port-index = <2>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in2>;
+								};
+							};
+						};
+						/* mode0: Y8, mode1: depth D16 */
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "2";
+							csi_pixel_bit_depth = "16";
+							active_w = "1280";
+							active_h = "720";
+							tegra_sinterface = "serial_c";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "1";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <2>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_1: ds5@1b {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x1b>;
+						override_reg = <0x1a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						cam-type = "RGB";
+						nvidia,gmsl-ser-device = <&ser_a>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_1_out: endpoint {
+									vc-id = <1>;
+									port-index = <2>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in1>;
+								};
+							};
+						};
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "2";
+							csi_pixel_bit_depth = "16";
+							active_w = "1920";
+							active_h = "1080";
+							tegra_sinterface = "serial_c";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "1";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <1>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_0: ds5@1a {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x1a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						cam-type = "Depth";
+						nvidia,gmsl-ser-device = <&ser_a>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_0_out: endpoint {
+									vc-id = <0>;
+									port-index = <2>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in0>;
+								};
+							};
+						};
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "2";
+							csi_pixel_bit_depth = "16";
+							active_w = "1280";
+							active_h = "720";
+							tegra_sinterface = "serial_c";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "1";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <0>;
+							num-lanes = <2>;
+						};
+					};
+					};
+				};
+			};
+		};
+	};
+};

--- a/nvidia-oot/6.0/0003-Adding-max96712-support-for-D4xx.patch
+++ b/nvidia-oot/6.0/0003-Adding-max96712-support-for-D4xx.patch
@@ -7,14 +7,14 @@ Add MAX96712 deserializer driver support for D4XX/D5XX cameras.
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- drivers/media/i2c/max96712.c | 607 ++++++++++++++++++++++++++++++++---
- 1 file changed, 570 insertions(+), 37 deletions(-)
+ drivers/media/i2c/max96712.c | 672 ++++++++++++++++++++++++++++++++++++++++---
+ 1 file changed, 635 insertions(+), 37 deletions(-)
 
 diff --git a/drivers/media/i2c/max96712.c b/drivers/media/i2c/max96712.c
-index 8e237eef..3b4376fe 100644
+index 8e237eef..42df25b3 100644
 --- a/drivers/media/i2c/max96712.c
 +++ b/drivers/media/i2c/max96712.c
-@@ -16,32 +16,104 @@
+@@ -16,32 +16,111 @@
  #include <linux/gpio.h>
  #include <linux/of.h>
  #include <linux/of_gpio.h>
@@ -59,6 +59,8 @@ index 8e237eef..3b4376fe 100644
 +#define MAX96712_MIPI_PHY0_ADDR 0x8A0
 +#define MAX96712_MIPI_PHY2_ADDR 0x8A2
 +#define MAX96712_MIPI_PHY3_ADDR 0x8A3
++#define MAX96712_MIPI_PHY5_ADDR 0x8A5
++#define MAX96712_MIPI_PHY6_ADDR 0x8A6
 +#define MAX96712_VIDEO_PIPE_SEL_0_ADDR 0xF0
 +#define MAX96712_VIDEO_PIPE_SEL_1_ADDR 0xF1
 +#define MAX96712_VIDEO_PIPE_SEL_2_ADDR 0xF2
@@ -83,6 +85,9 @@ index 8e237eef..3b4376fe 100644
 +
 +#define MAX96712_VIDEO_RX0_ADDR 0x100
 +
++#define MAX96712_FANGZHU_POC_IO_ADDR 0x1
++#define MAX96712_FANGZHU_FG12_POC_ADDR 0x326
++
 +#define MAX96712_DPLL_0_ADDR 0x1D00
 +
 +#define MAX9295_DEFAULT_ADDR 0x40
@@ -102,6 +107,8 @@ index 8e237eef..3b4376fe 100644
 +	bool video_pipe_alloc[MAX96712_MAX_PIPES];
 +	bool force_clk0;
 +	int lane_cnt;
++	bool fangzhu_fg12_reverse_lane_polarity;
++	bool fangzhu_fg12_poc_enable;
  };
  static struct max96712 *global_priv[4];
  
@@ -125,7 +132,7 @@ index 8e237eef..3b4376fe 100644
  	i2c_client = global_priv[channel]->i2c_client;
  	bak = i2c_client->addr;
  
-@@ -53,7 +125,6 @@ int max96712_write_reg_Dser(int slaveAddr, int channel,
+@@ -53,7 +132,6 @@ int max96712_write_reg_Dser(int slaveAddr, int channel,
  		dev_err(&i2c_client->dev, "%s: addr = 0x%x, val = 0x%x\n",
  				__func__, addr, val);
  	}
@@ -133,7 +140,7 @@ index 8e237eef..3b4376fe 100644
  	return err;
  }
  EXPORT_SYMBOL(max96712_write_reg_Dser);
-@@ -68,8 +139,6 @@ int max96712_read_reg_Dser(int slaveAddr, int channel,
+@@ -68,8 +146,6 @@ int max96712_read_reg_Dser(int slaveAddr, int channel,
  
  	if (channel > 3 || channel < 0 || global_priv[channel] == NULL)
  		return -1;
@@ -142,7 +149,7 @@ index 8e237eef..3b4376fe 100644
  	i2c_client = global_priv[channel]->i2c_client;
  	bak = i2c_client->addr;
  	i2c_client->addr = slaveAddr / 2;
-@@ -80,11 +149,56 @@ int max96712_read_reg_Dser(int slaveAddr, int channel,
+@@ -80,11 +156,56 @@ int max96712_read_reg_Dser(int slaveAddr, int channel,
  		dev_err(&i2c_client->dev, "%s: addr = 0x%x, val = 0x%x\n",
  				__func__, addr, *val);
  	}
@@ -200,7 +207,7 @@ index 8e237eef..3b4376fe 100644
  static int max96712_read_reg(struct max96712 *priv,
  			u16 addr, unsigned int *val)
  {
-@@ -99,6 +213,20 @@ static int max96712_read_reg(struct max96712 *priv,
+@@ -99,6 +220,20 @@ static int max96712_read_reg(struct max96712 *priv,
  	return err;
  }
  
@@ -221,7 +228,7 @@ index 8e237eef..3b4376fe 100644
  
  static int max96712_stats_show(struct seq_file *s, void *data)
  {
-@@ -153,24 +281,6 @@ static const struct file_operations max96712_debugfs_fops = {
+@@ -153,24 +288,6 @@ static const struct file_operations max96712_debugfs_fops = {
  	.release = single_release,
  };
  
@@ -246,7 +253,7 @@ index 8e237eef..3b4376fe 100644
  static int max96712_debugfs_init(const char *dir_name,
  				struct dentry **d_entry,
  				struct dentry **f_entry,
-@@ -225,7 +335,8 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -225,7 +342,8 @@ static int max96712_debugfs_init(const char *dir_name,
  static  struct regmap_config max96712_regmap_config = {
  	.reg_bits = 16,
  	.val_bits = 8,
@@ -256,7 +263,7 @@ index 8e237eef..3b4376fe 100644
  };
  
  #if defined(NV_I2C_DRIVER_STRUCT_PROBE_WITHOUT_I2C_DEVICE_ID_ARG) /* Linux 6.3 */
-@@ -237,6 +348,8 @@ static int max96712_probe(struct i2c_client *client,
+@@ -237,6 +355,8 @@ static int max96712_probe(struct i2c_client *client,
  {
  	struct max96712 *priv;
  	int err = 0;
@@ -265,7 +272,7 @@ index 8e237eef..3b4376fe 100644
  
  	dev_info(&client->dev, "%s: enter\n", __func__);
  
-@@ -249,15 +362,50 @@ static int max96712_probe(struct i2c_client *client,
+@@ -249,15 +369,55 @@ static int max96712_probe(struct i2c_client *client,
  			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
  		return -ENODEV;
  	}
@@ -315,6 +322,11 @@ index 8e237eef..3b4376fe 100644
 +		} else {
 +			priv->lane_cnt = value;
 +		}
++
++		priv->fangzhu_fg12_reverse_lane_polarity =
++			of_property_read_bool(np, "fangzhu,fg12-reverse-lane-polarity");
++		priv->fangzhu_fg12_poc_enable =
++			of_property_read_bool(np, "fangzhu,fg12-poc-enable");
  	}
  
 +	dev_set_drvdata(&client->dev, priv);
@@ -322,7 +334,7 @@ index 8e237eef..3b4376fe 100644
  	err = max96712_debugfs_init(NULL, NULL, NULL, priv);
  	if (err)
  		return err;
-@@ -274,8 +422,11 @@ static int max96712_remove(struct i2c_client *client)
+@@ -274,8 +434,11 @@ static int max96712_remove(struct i2c_client *client)
  static void max96712_remove(struct i2c_client *client)
  #endif
  {
@@ -335,7 +347,7 @@ index 8e237eef..3b4376fe 100644
  		i2c_unregister_device(client);
  		client = NULL;
  	}
-@@ -284,13 +435,394 @@ static void max96712_remove(struct i2c_client *client)
+@@ -284,13 +447,447 @@ static void max96712_remove(struct i2c_client *client)
  #endif
  }
  
@@ -356,6 +368,43 @@ index 8e237eef..3b4376fe 100644
 +	}
 +
 +	return err;
++}
++
++static int max96712_set_reverse_lane_polarity(struct max96712 *priv)
++{
++	struct reg_pair lane_polarity[] = {
++		/*
++		 * FG12-4CH routes the MAX96712 CSI-2 lanes with reversed polarity.
++		 */
++		{MAX96712_MIPI_PHY5_ADDR, 0x3f},
++		{MAX96712_MIPI_PHY6_ADDR, 0x3f},
++	};
++
++	return max96712_set_registers(priv, lane_polarity,
++				      ARRAY_SIZE(lane_polarity));
++}
++
++static int max96712_enable_poc(struct max96712 *priv)
++{
++	struct reg_pair poc_enable[] = {
++		{MAX96712_FANGZHU_POC_IO_ADDR, 0xe0},
++		{MAX96712_FANGZHU_FG12_POC_ADDR, 0x80},
++	};
++	int err;
++
++	err = max96712_set_registers(priv, poc_enable,
++				     ARRAY_SIZE(poc_enable));
++	if (err)
++		return err;
++
++	msleep(100);
++	err = max96712_write_reg(priv, MAX96712_FANGZHU_FG12_POC_ADDR, 0x90);
++	if (err)
++		return err;
++
++	msleep(500);
++
++	return 0;
 +}
 +
 +int max96712_get_available_pipe_id(struct device *dev, int vc_id)
@@ -694,13 +743,29 @@ index 8e237eef..3b4376fe 100644
 +
 +int max96712_power_on(struct device *dev)
 +{
-+    struct max96712 *priv = dev_get_drvdata(dev);
-+    if (priv->pwdn_gpio > 0) {
-+        gpio_direction_output(priv->pwdn_gpio, 1);
-+        gpio_set_value(priv->pwdn_gpio, 1);
-+        msleep(100);
-+    }
-+    return 0;
++	struct max96712 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	if (priv->pwdn_gpio > 0) {
++		gpio_direction_output(priv->pwdn_gpio, 1);
++		gpio_set_value(priv->pwdn_gpio, 1);
++		msleep(100);
++	}
++
++	if (priv->fangzhu_fg12_reverse_lane_polarity ||
++	    priv->fangzhu_fg12_poc_enable) {
++		mutex_lock(&priv->lock);
++
++		if (priv->fangzhu_fg12_reverse_lane_polarity)
++			err = max96712_set_reverse_lane_polarity(priv);
++
++		if (!err && priv->fangzhu_fg12_poc_enable)
++			err = max96712_enable_poc(priv);
++
++		mutex_unlock(&priv->lock);
++	}
++
++	return err;
 +}
 +EXPORT_SYMBOL(max96712_power_on);
 +
@@ -731,7 +796,7 @@ index 8e237eef..3b4376fe 100644
  	{ },
  };
  
-@@ -300,6 +832,7 @@ static struct i2c_driver max96712_i2c_driver = {
+@@ -300,6 +897,7 @@ static struct i2c_driver max96712_i2c_driver = {
  	.driver = {
  		.name = "max96712",
  		.owner = THIS_MODULE,
@@ -739,6 +804,6 @@ index 8e237eef..3b4376fe 100644
  	},
  	.probe = max96712_probe,
  	.remove = max96712_remove,
+
 -- 
 2.43.0
-


### PR DESCRIPTION
## Summary

Add support for running a RealSense D457 on Jetson Orin Nano with the FangZhu FG12-4CH carrier board using the validated full 2-lane path.

- Add `tegra234-camera-d4xx-overlay-fg12-4ch.dts`.
- Add the FG12-4CH overlay dtbo to the JP6 Orin overlay build patch.
- Add independently gated FangZhu FG12 reverse-lane-polarity and POC sequences in the shared MAX96712 nvidia-oot patch.
- Keep the D4XX driver unchanged; lane count stays on the existing 2-lane path through the DTS endpoints and modes.

## Version Coverage

The MAX96712 driver patch is shared by the supported nvidia-oot patch sets:

- `nvidia-oot/6.1/0003...` -> `../6.0/0003...`
- `nvidia-oot/6.2/0003...` -> `../6.0/0003...`
- `nvidia-oot/7.0/0006...` -> `../6.0/0003...`
- `nvidia-oot/7.1/0006...` -> `../7.0/0006...`
- `nvidia-oot/7.2/0006...` -> `../7.0/0006...`

So the single `nvidia-oot/6.0/0003-Adding-max96712-support-for-D4xx.patch` update covers JP6 and JP7 variants that consume those symlinks.

## Why This Is Needed

The FG12-4CH board routes the D457 through MAX9295 to MAX96712 at the FG12-4CH deserializer address (`0x29`) and uses CSI port C (`port-index = <2>` / `serial_c`). The overlay configures that board topology and keeps all CSI endpoints and D457 modes at 2 lanes.

The MAX96712 behavior added for this board is split behind two independent DT flags:

- `fangzhu,fg12-reverse-lane-polarity` applies the FG12-4CH lane polarity configuration.
- `fangzhu,fg12-poc-enable` enables the FangZhu board POC power sequence before the serializer/camera path is accessed.

The polarity writes and POC writes are kept separate because lane polarity and power-over-coax are board characteristics that are not inherently tied together. Boards that do not set these DT flags keep the existing generic MAX96712 path.

## Validation

- Hardware validated on Orin Nano + MAX96712 FG12-4CH + MAX9295 / RealSense D457 using `./build_all.sh 6.2`.
- Verified the final PR diff does not modify `kernel/realsense/d4xx.c`.
- Verified the final PR diff only includes the FG12-4CH overlay, Orin overlay dtbo build entry, and shared MAX96712 reverse-lane-polarity / POC hooks.
- Ran `git diff --check origin/dev...HEAD`.
