### PR TITLE
[GMSL] Fix stream recovery and driver removal deadlock

### DIFF
--- a/kernel/realsense/d5xx.c
+++ b/kernel/realsense/d5xx.c
@@ -216,16 +216,11 @@ enum ds5_mux_pad {
 #define DFU_WAIT_RET_LEN 			6
 
 #define DS5_START_POLL_TIME			10
+#define DS5_START_POLL_MAX_TIME			40
 #define DS5_START_MAX_TIME			2000
 #define DS5_STOP_MAX_TIME			7000
 #define DS5_START_MAX_COUNT	(DS5_START_MAX_TIME / DS5_START_POLL_TIME)
-#define DS5_RGB_START_DEBOUNCE_MS		300
-#define DS5_RGB_START_WAIT_MS			3000
-#define DS5_IR_START_DEBOUNCE_MS		300
-#define DS5_IR_START_WAIT_MS			3000
 #define DS5_DSER_REARM_COOLDOWN_MS		1800
-#define DS5_DSER_REARM_FALLBACK_MS		700
-#define DS5_DSER_REARM_WAIT_MS			3500
 #define MAX_DS5_CONFIG_RETRIES		5
 
 /* I2C retry configuration */
@@ -579,10 +574,6 @@ struct ds5_dev {
 	bool ir_streaming;
 	bool rgb_streaming;
 	bool imu_streaming;
-	bool rgb_start_pending;
-	int rgb_start_error;
-	bool ir_start_pending;
-	int ir_start_error;
 };
 
 #ifdef CONFIG_VIDEO_D5XX_SERDES
@@ -605,10 +596,6 @@ struct dser_control {
 	bool datapath_armed;
 	u8 datapath_pipe_mask;
 	bool post_start_kick_pending;
-	bool rearm_pending;
-	bool rearm_started;
-	int rearm_owner_pipe;
-	unsigned int rearm_waiters;
 	unsigned int rearm_gen;
 	unsigned long last_idle_jiffies;
 };
@@ -714,70 +701,23 @@ static void ds5_set_dser_post_start_kick_pending(struct ds5 *state,
 	mutex_unlock(&ctrl->lock);
 }
 
-static void ds5_cancel_dser_rearm(struct ds5 *state)
+static void ds5_clear_dser_start_state(struct ds5 *state)
 {
 	struct dser_control *ctrl = state->ds5_dev->dser_control;
 
 	mutex_lock(&ctrl->lock);
-	ctrl->rearm_pending = false;
-	ctrl->rearm_started = false;
 	ctrl->post_start_kick_pending = false;
-	ctrl->rearm_owner_pipe = PIPE_NOT_CONFIGURED;
-	ctrl->rearm_waiters = 0;
 	mutex_unlock(&ctrl->lock);
 }
 
-static void ds5_schedule_dser_rearm(struct ds5 *state, int pipe_id)
+static void ds5_finish_dser_prestart(struct ds5 *state, bool reset_performed)
 {
 	struct dser_control *ctrl = state->ds5_dev->dser_control;
 
 	mutex_lock(&ctrl->lock);
-	if (!ctrl->rearm_pending) {
-		ctrl->datapath_armed = false;
-		ctrl->rearm_pending = true;
-		ctrl->rearm_started = false;
-		ctrl->rearm_owner_pipe = pipe_id;
-		ctrl->rearm_waiters = 0;
-	}
-	mutex_unlock(&ctrl->lock);
-}
-
-static bool ds5_begin_dser_rearm(struct ds5 *state, int pipe_id,
-				 int *owner_pipe)
-{
-	struct dser_control *ctrl = state->ds5_dev->dser_control;
-	bool can_begin = true;
-
-	mutex_lock(&ctrl->lock);
-	if (ctrl->rearm_pending && ctrl->rearm_started &&
-	    ctrl->rearm_owner_pipe != pipe_id) {
-		can_begin = false;
-		if (owner_pipe)
-			*owner_pipe = ctrl->rearm_owner_pipe;
-	} else {
-		ctrl->datapath_armed = false;
-		ctrl->rearm_pending = true;
-		ctrl->rearm_started = true;
-		ctrl->rearm_owner_pipe = pipe_id;
-		if (owner_pipe)
-			*owner_pipe = pipe_id;
-	}
-	mutex_unlock(&ctrl->lock);
-
-	return can_begin;
-}
-
-static void ds5_mark_dser_rearm_done(struct ds5 *state, bool datapath_armed)
-{
-	struct dser_control *ctrl = state->ds5_dev->dser_control;
-
-	mutex_lock(&ctrl->lock);
-	ctrl->datapath_armed = datapath_armed;
-	ctrl->rearm_pending = false;
-	ctrl->rearm_started = false;
-	ctrl->rearm_owner_pipe = PIPE_NOT_CONFIGURED;
-	ctrl->rearm_waiters = 0;
-	ctrl->rearm_gen++;
+	ctrl->datapath_armed = reset_performed;
+	if (reset_performed)
+		ctrl->rearm_gen++;
 	mutex_unlock(&ctrl->lock);
 }
 
@@ -869,7 +809,7 @@ static void ds5_post_start_dser_datapath_kick(struct ds5 *state, u16 stream_id)
 	 * frames, while leaving the datapath untouched does not resynchronize
 	 * tunnel detection after the camera starts transmitting. */
 	state->dser_ops->retrigger_datapath(state->dser_dev);
-	ds5_cancel_dser_rearm(state);
+	ds5_clear_dser_start_state(state);
 	ds5_set_dser_datapath_pipe_mask(state, active_pipe_mask);
 	ds5_set_dser_post_start_kick_pending(state, false);
 
@@ -930,81 +870,11 @@ static bool ds5_rearm_dser_datapath_before_start(struct ds5 *state, int pipe_id,
 	return true;
 }
 
-static int ds5_wait_for_dser_rearm(struct ds5 *state, int pipe_id)
-{
-	struct dser_control *ctrl = state->ds5_dev->dser_control;
-	unsigned long timeout;
-	unsigned long fallback_timeout;
-	bool started;
-	bool pending;
-	int owner_pipe;
-
-	if (!state->dser_ops->get_active_pipe_count)
-		return 0;
-
-	mutex_lock(&ctrl->lock);
-	pending = ctrl->rearm_pending;
-	owner_pipe = ctrl->rearm_owner_pipe;
-	if (!pending) {
-		mutex_unlock(&ctrl->lock);
-		return 0;
-	}
-	mutex_unlock(&ctrl->lock);
-
-	dev_info(&state->client->dev,
-		 "pipe %d waiting for DES datapath re-arm owner pipe %d before camera I2C config\n",
-		 pipe_id, owner_pipe);
-	fallback_timeout = jiffies + msecs_to_jiffies(DS5_DSER_REARM_FALLBACK_MS);
-	timeout = jiffies + msecs_to_jiffies(DS5_DSER_REARM_WAIT_MS);
-	do {
-		mutex_lock(&ctrl->lock);
-		pending = ctrl->rearm_pending;
-		started = ctrl->rearm_started;
-		owner_pipe = ctrl->rearm_owner_pipe;
-		mutex_unlock(&ctrl->lock);
-		if (!pending)
-			return 0;
-
-		if (!started && owner_pipe == pipe_id &&
-		    time_after_eq(jiffies, fallback_timeout)) {
-			int active_pipes;
-			int link_locked;
-
-			if (!ds5_begin_dser_rearm(state, pipe_id, &owner_pipe))
-				continue;
-
-			active_pipes = state->dser_ops->get_active_pipe_count ?
-				state->dser_ops->get_active_pipe_count(state->dser_dev) : 1;
-			link_locked = state->dser_ops->get_link_locked ?
-				state->dser_ops->get_link_locked(state->dser_dev) : -1;
-
-			dev_info(&state->client->dev,
-				 "pipe %d fallback re-arming DES datapath after waiting for pipe 0\n",
-				 pipe_id);
-			mutex_lock(&serdes_lock__);
-			ds5_mark_dser_rearm_done(state,
-				ds5_rearm_dser_datapath_before_start(state, pipe_id,
-								      active_pipes,
-								      link_locked,
-								      "fallback owner"));
-			mutex_unlock(&serdes_lock__);
-			return 0;
-		}
-		msleep(20);
-	} while (time_before(jiffies, timeout));
-
-	dev_warn(&state->client->dev,
-		 "pipe %d timed out waiting for DES datapath re-arm owner pipe %d\n",
-		 pipe_id, owner_pipe);
-	return -ETIMEDOUT;
-}
-
 static void ds5_disarm_dser_datapath_if_idle(struct ds5 *state)
 {
 	int active_pipes;
 	int link_locked;
 	bool armed;
-	bool pending;
 	struct dser_control *ctrl = state->ds5_dev->dser_control;
 
 	if (!state->dser_ops->get_active_pipe_count)
@@ -1018,25 +888,20 @@ static void ds5_disarm_dser_datapath_if_idle(struct ds5 *state)
 		state->dser_ops->get_link_locked(state->dser_dev) : -1;
 	mutex_lock(&ctrl->lock);
 	armed = ctrl->datapath_armed;
-	pending = ctrl->rearm_pending;
 	ctrl->datapath_armed = false;
 	ctrl->datapath_pipe_mask = 0;
 	ctrl->post_start_kick_pending = false;
-	ctrl->rearm_pending = false;
-	ctrl->rearm_started = false;
-	ctrl->rearm_owner_pipe = PIPE_NOT_CONFIGURED;
-	ctrl->rearm_waiters = 0;
 	ctrl->last_idle_jiffies = jiffies;
 	mutex_unlock(&ctrl->lock);
 
 	if (link_locked > 0) {
-		if (armed || pending)
+		if (armed)
 			dev_info(&state->client->dev,
 				 "all DES pipes released; preserving locked Link A for next start\n");
 		return;
 	}
 
-	if (armed || pending)
+	if (armed)
 		dev_info(&state->client->dev,
 			 "all DES pipes released; datapath marked unarmed for cooldown\n");
 }
@@ -1123,6 +988,15 @@ static inline void msleep_range(unsigned int delay_base)
 }
 #endif
 #endif
+
+static unsigned int ds5_stream_poll_delay(bool starting, unsigned int retry)
+{
+	unsigned int delay = retry * DS5_START_POLL_TIME;
+
+	if (starting)
+		return min(delay, (unsigned int)DS5_START_POLL_MAX_TIME);
+	return delay;
+}
 
 static int ds5_write(struct ds5 *state, u16 reg, u16 val)
 {
@@ -1853,39 +1727,24 @@ static int ds5_setup_pipeline(struct ds5 *state, u8 data_type1, u8 data_type2,
 			 "pipe %d mapping updated while DES datapath armed (%u streams active); keeping datapath armed\n",
 			 pipe_id, started_streams);
 	}
-	/*
-	 * Prefer pipe 0 as the deterministic re-arm owner.  If RGB/IR arrives
-	 * first, it maps its pipe and waits before camera-side I2C config until
-	 * depth/pipe 0 performs the early re-arm.  On an already-locked link,
-	 * avoid ONESHOT and only retrigger the DES CSI datapath before START.
-	 */
-	if (pipe_id == 0 && (link_locked <= 0 || !datapath_armed)) {
-		int owner_pipe = PIPE_NOT_CONFIGURED;
+	/* Pipe setup is serialized by serdes_lock__, so the first active pipe can
+	 * perform the pre-start recovery decision directly.  Waiting for a fixed
+	 * pipe owner delays the first frame and can exceed the VI startup timeout
+	 * when RGB intentionally starts before the stereo streams. */
+	if (active_pipes <= 1 && !datapath_armed) {
+		bool reset_performed;
 
 		dev_info(&state->client->dev,
-			 "pipe 0 re-arming DES datapath before camera I2C config (link %s, armed=%d, active_pipes=%d)\n",
+			 "pipe %d evaluating DES datapath before camera I2C config (link %s, active_pipes=%d)\n",
+			 pipe_id,
 			 link_locked > 0 ? "locked" :
 			 (link_locked == 0 ? "unlocked" : "unknown"),
-			 datapath_armed, active_pipes);
-		if (ds5_begin_dser_rearm(state, pipe_id, &owner_pipe)) {
-			datapath_armed =
-				ds5_rearm_dser_datapath_before_start(state, pipe_id,
-								      active_pipes,
-								      link_locked,
-								      "pipe 0");
-			ds5_mark_dser_rearm_done(state, datapath_armed);
-		} else {
-			dev_info(&state->client->dev,
-				 "pipe 0 waiting for active DES datapath re-arm owner pipe %d\n",
-				 owner_pipe);
-		}
-	} else if (active_pipes <= 1 && !datapath_armed) {
-		dev_info(&state->client->dev,
-			 "first non-depth pipe %d scheduling DES datapath re-arm for pipe 0 (link %s, armed=%d)\n",
-			 pipe_id, link_locked > 0 ? "locked" :
-			 (link_locked == 0 ? "unlocked" : "unknown"),
-			 datapath_armed);
-		ds5_schedule_dser_rearm(state, pipe_id);
+			 active_pipes);
+		reset_performed = ds5_rearm_dser_datapath_before_start(state,
+									 pipe_id, active_pipes,
+									 link_locked,
+									 "first active pipe");
+		ds5_finish_dser_prestart(state, reset_performed);
 	} else {
 		dev_info(&state->client->dev,
 			 "pipe %d mapping updated w/o link reset (%d pipes active, link %s)\n",
@@ -2056,10 +1915,6 @@ static int ds5_configure(struct ds5 *state)
 				"pipe %d already configured (dt1=0x%x dt2=0x%x vc=%u)\n",
 				sensor->pipe_id, data_type1, data_type2, vc_id);
 	}
-
-	ret = ds5_wait_for_dser_rearm(state, sensor->pipe_id);
-	if (ret < 0)
-		return ret;
 
 	pipe_reapply_gen = ds5_dser_rearm_gen(state);
 	if (sensor->pipe_reapply_gen != pipe_reapply_gen) {
@@ -2607,188 +2462,7 @@ static void ds5_reset_streaming_flags(struct ds5_dev *ds5_dev)
 	ds5_dev->ir_streaming = false;
 	ds5_dev->rgb_streaming = false;
 	ds5_dev->imu_streaming = false;
-	ds5_dev->rgb_start_pending = false;
-	ds5_dev->rgb_start_error = 0;
-	ds5_dev->ir_start_pending = false;
-	ds5_dev->ir_start_error = 0;
 	mutex_unlock(&ds5_dev->lock);
-}
-
-static void ds5_set_rgb_start_pending(struct ds5 *state, u16 stream_id, bool pending)
-{
-	if (stream_id != DS5_STREAM_RGB)
-		return;
-
-	mutex_lock(&state->ds5_dev->lock);
-	state->ds5_dev->rgb_start_pending = pending;
-	if (pending)
-		state->ds5_dev->rgb_start_error = 0;
-	mutex_unlock(&state->ds5_dev->lock);
-}
-
-static void ds5_finish_rgb_start(struct ds5 *state, u16 stream_id, int ret)
-{
-	if (stream_id != DS5_STREAM_RGB)
-		return;
-
-	mutex_lock(&state->ds5_dev->lock);
-	state->ds5_dev->rgb_start_error = ret < 0 ? ret : 0;
-	state->ds5_dev->rgb_start_pending = false;
-	mutex_unlock(&state->ds5_dev->lock);
-}
-
-static bool ds5_rgb_start_state(struct ds5 *state, int *error)
-{
-	bool pending;
-
-	mutex_lock(&state->ds5_dev->lock);
-	pending = state->ds5_dev->rgb_start_pending;
-	if (error)
-		*error = state->ds5_dev->rgb_start_error;
-	mutex_unlock(&state->ds5_dev->lock);
-
-	return pending;
-}
-
-static int ds5_wait_for_rgb_start_before_stereo(struct ds5 *state, u16 stream_id)
-{
-#ifdef CONFIG_VIDEO_D5XX_SERDES
-	unsigned long discover_timeout;
-	unsigned long timeout;
-	int rgb_error = 0;
-
-	if (stream_id == DS5_STREAM_RGB || stream_id == DS5_STREAM_IMU)
-		return 0;
-
-	/*
-	 * RGB joining an already-streaming stereo pipe can stall the shared HIF
-	 * CSI TX task (FW reports frame counter N, ack N-2).  Give a concurrent
-	 * RGB START a short window to announce itself, then let it complete first.
-	 */
-	discover_timeout = jiffies + msecs_to_jiffies(DS5_RGB_START_DEBOUNCE_MS);
-	while (!ds5_rgb_start_state(state, &rgb_error)) {
-		if (!time_before(jiffies, discover_timeout))
-			return 0;
-		msleep(20);
-	}
-
-	dev_info(&state->client->dev,
-		 "stream %d waiting for RGB START to complete before stereo START\n",
-		 stream_id);
-	timeout = jiffies + msecs_to_jiffies(DS5_RGB_START_WAIT_MS);
-	while (ds5_rgb_start_state(state, &rgb_error)) {
-		if (!time_before(jiffies, timeout)) {
-			dev_warn(&state->client->dev,
-				 "stream %d timed out waiting for RGB START; aborting stereo START\n",
-				 stream_id);
-			return -ETIMEDOUT;
-		}
-		msleep(20);
-	}
-
-	if (rgb_error < 0) {
-		dev_warn(&state->client->dev,
-			 "stream %d observed RGB START failure (%d); aborting stereo START\n",
-			 stream_id, rgb_error);
-		return rgb_error;
-	}
-
-	dev_info(&state->client->dev,
-		 "stream %d observed RGB START complete; continuing stereo START\n",
-		 stream_id);
-	return 0;
-#else
-	(void)state;
-	(void)stream_id;
-	return 0;
-#endif
-}
-
-static void ds5_set_ir_start_pending(struct ds5 *state, u16 stream_id, bool pending)
-{
-	if (stream_id != DS5_STREAM_IR)
-		return;
-
-	mutex_lock(&state->ds5_dev->lock);
-	state->ds5_dev->ir_start_pending = pending;
-	if (pending)
-		state->ds5_dev->ir_start_error = 0;
-	mutex_unlock(&state->ds5_dev->lock);
-}
-
-static void ds5_finish_ir_start(struct ds5 *state, u16 stream_id, int ret)
-{
-	if (stream_id != DS5_STREAM_IR)
-		return;
-
-	mutex_lock(&state->ds5_dev->lock);
-	state->ds5_dev->ir_start_error = ret < 0 ? ret : 0;
-	state->ds5_dev->ir_start_pending = false;
-	mutex_unlock(&state->ds5_dev->lock);
-}
-
-static bool ds5_ir_start_state(struct ds5 *state, int *error)
-{
-	bool pending;
-
-	mutex_lock(&state->ds5_dev->lock);
-	pending = state->ds5_dev->ir_start_pending;
-	if (error)
-		*error = state->ds5_dev->ir_start_error;
-	mutex_unlock(&state->ds5_dev->lock);
-
-	return pending;
-}
-
-static int ds5_wait_for_ir_start_before_depth(struct ds5 *state, u16 stream_id)
-{
-#ifdef CONFIG_VIDEO_D5XX_SERDES
-	unsigned long discover_timeout;
-	unsigned long timeout;
-	int ir_error = 0;
-
-	if (stream_id != DS5_STREAM_DEPTH)
-		return 0;
-
-	/* The PR #282 FW keeps one gated stereo pipeline alive, so IR can build
-	 * it first and Depth can enable its pre-built branch without a rebuild. */
-	discover_timeout = jiffies + msecs_to_jiffies(DS5_IR_START_DEBOUNCE_MS);
-	while (!ds5_ir_start_state(state, &ir_error)) {
-		if (!time_before(jiffies, discover_timeout))
-			return 0;
-		msleep(20);
-	}
-
-	dev_info(&state->client->dev,
-		 "stream %d waiting for IR START to complete before depth gate\n",
-		 stream_id);
-	timeout = jiffies + msecs_to_jiffies(DS5_IR_START_WAIT_MS);
-	while (ds5_ir_start_state(state, &ir_error)) {
-		if (!time_before(jiffies, timeout)) {
-			dev_warn(&state->client->dev,
-				 "stream %d timed out waiting for IR START; aborting depth START\n",
-				 stream_id);
-			return -ETIMEDOUT;
-		}
-		msleep(20);
-	}
-
-	if (ir_error < 0) {
-		dev_warn(&state->client->dev,
-			 "stream %d observed IR START failure (%d); aborting depth START\n",
-			 stream_id, ir_error);
-		return ir_error;
-	}
-
-	dev_info(&state->client->dev,
-		 "stream %d observed IR START complete; enabling depth gate\n",
-		 stream_id);
-	return 0;
-#else
-	(void)state;
-	(void)stream_id;
-	return 0;
-#endif
 }
 
 #ifdef CONFIG_VIDEO_D5XX_SERDES
@@ -3017,7 +2691,7 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	ds5_reset_streaming_flags(state->ds5_dev);
 #ifdef CONFIG_VIDEO_D5XX_SERDES
 	ds5_set_dser_datapath_armed(state, false);
-	ds5_cancel_dser_rearm(state);
+	ds5_clear_dser_start_state(state);
 #endif
 
 	/* 3. Scratch one control-status register before reset.
@@ -4156,10 +3830,6 @@ static int ds5_setup_and_link(struct ds5 *state)
 						if (NULL == dser_inited[j].dser_dev) {
 							dser_inited[j].dser_dev = state->dser_dev;
 							dser_inited[j].datapath_armed = false;
-							dser_inited[j].rearm_pending = false;
-							dser_inited[j].rearm_started = false;
-							dser_inited[j].rearm_owner_pipe = PIPE_NOT_CONFIGURED;
-							dser_inited[j].rearm_waiters = 0;
 							state->ds5_dev->dser_control = &dser_inited[j];
 						}
 						mutex_unlock(&dser_inited[j].lock);
@@ -5520,14 +5190,9 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		state->reset_ref_dser = cur_dser;
 	}
 
-	/* spare duplicate calls */
+	/* Ignore requests that already match the cached stream state. */
 	if (sensor->streaming == on)
 		return 0;
-
-	if (on) {
-		ds5_set_rgb_start_pending(state, stream_id, true);
-		ds5_set_ir_start_pending(state, stream_id, true);
-	}
 
 	if (on) {
 		stream_cmd = (DS5_STREAM_START | stream_id);
@@ -5537,27 +5202,6 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		stream_cmd = (DS5_STREAM_STOP | stream_id);
 		expected_streaming_state = DS5_STREAM_IDLE;
 		status = DS5_STATUS_STREAMING;
-	}
-
-	if (on) {
-		ret = ds5_wait_for_rgb_start_before_stereo(state, stream_id);
-		if (ret < 0) {
-#ifdef CONFIG_VIDEO_D5XX_SERDES
-			ds5_release_serdes_pipe(state, sensor, "RGB START dependency failure");
-#endif
-			ds5_finish_rgb_start(state, stream_id, ret);
-			ds5_finish_ir_start(state, stream_id, ret);
-			return ret;
-		}
-		ret = ds5_wait_for_ir_start_before_depth(state, stream_id);
-		if (ret < 0) {
-#ifdef CONFIG_VIDEO_D5XX_SERDES
-			ds5_release_serdes_pipe(state, sensor, "IR START dependency failure");
-#endif
-			ds5_finish_rgb_start(state, stream_id, ret);
-			ds5_finish_ir_start(state, stream_id, ret);
-			return ret;
-		}
 	}
 
 	/* START changes pipeline topology and remains fully serialized. STOP only
@@ -5577,26 +5221,17 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 #endif
 			mutex_unlock(&state->ds5_dev->stream_ctrl_lock);
 			stream_ctrl_locked = false;
-			ds5_finish_rgb_start(state, stream_id, ret);
-			ds5_finish_ir_start(state, stream_id, ret);
 			return ret;
 		}
 		ds5_config_done = true;
-#ifdef CONFIG_VIDEO_D5XX_SERDES
-		if (state->dser_ops->get_active_pipe_count &&
-		    state->dser_ops->get_active_pipe_count(state->dser_dev) == 1) {
-			dev_info(&state->client->dev,
-				 "first active pipe configured; yielding briefly before START\n");
-			msleep(80);
-		}
-#endif
 	}
 
 	/* Verify stream is in the expected state before issuing command */
 	ts = jiffies;
 	for (timeout = ts + msecs_to_jiffies(on ? DS5_START_MAX_TIME :
 							 DS5_STOP_MAX_TIME), i = 0;
-			time_before(jiffies, timeout); i++, msleep_range(i*DS5_START_POLL_TIME))
+			time_before(jiffies, timeout);
+			i++, msleep_range(ds5_stream_poll_delay(on, i)))
 	{
 		ret = ds5_read(state, config_status_base, &status);
 		if (ret < 0 || status == DS5_STATUS_UNAVAILABLE ||
@@ -5627,57 +5262,37 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 			"stream %d in expected state, toggling to %d (status: 0x%04x) %dms\n",
 			stream_id, on, status, jiffies_to_msecs(jiffies - ts));
 	} else {
+		if (on && reset_invalidated && (status & DS5_STATUS_STREAMING))
+			dev_warn(&state->client->dev,
+				"stream %d state mismatch after reset invalidation: host=off HKR=streaming (status: 0x%04x)\n",
+				stream_id, status);
+
 		/*
-		 * If state was invalidated by a reset-generation bump and FW
-		 * still reports this stream as active, force a stop to guarantee
-		 * the next start goes through full reconfiguration.  During a
-		 * normal batched stereo/RGB start, another stream may legitimately
-		 * bring the shared datapath up first; treat that as an already-on
-		 * no-op below.
+		 * The device status is authoritative. Do not inject a compensating
+		 * STOP/START sequence here: it reorders the caller's stream commands
+		 * and hides the lifecycle bug that produced a stale host cache.
+		 *
+		 * After HW reset the FW reboots and all streams return to idle. If VI
+		 * error recovery asks to stop an already-idle stream, or start an
+		 * already-streaming one, synchronize the local cache and let the upper
+		 * layer continue instead of entering an EBUSY retry loop.
 		 */
-		if (on && reset_invalidated && (status & DS5_STATUS_STREAMING)) {
-			dev_warn(&state->client->dev,
-				"stream %d reports streaming while host state is off (status: 0x%04x, reset_invalidated=%d), forcing stop and reconfigure\n",
-				stream_id, status, reset_invalidated);
-
-			ret = ds5_write(state, DS5_START_STOP_STREAM,
-					DS5_STREAM_STOP | stream_id);
-			if (ret < 0)
-				dev_warn(&state->client->dev,
-					"stream %d forced stop write failed (%d), continuing with reconfigure\n",
-					stream_id, ret);
-
-			mutex_lock(&state->ds5_dev->lock);
-			*streaming_flag = false;
-			mutex_unlock(&state->ds5_dev->lock);
-			sensor->streaming = false;
-		} else {
-			/*
-			 * After HW reset the FW reboots and all streams return to
-			 * idle.  If VI error recovery tries to stop a stream that
-			 * is already stopped (or start one already started), treat
-			 * it as a no-op so the upper layer can proceed with
-			 * restart instead of getting stuck in an EBUSY loop.
-			 */
-			dev_warn(&state->client->dev,
-				"stream %d in %d state already (status: 0x%04x) %dms, treating as no-op\n",
-				stream_id, on, status, jiffies_to_msecs(jiffies - ts));
-			mutex_lock(&state->ds5_dev->lock);
-			*streaming_flag = on;
-			mutex_unlock(&state->ds5_dev->lock);
-			sensor->streaming = on;
+		dev_warn(&state->client->dev,
+			"stream %d in %d state already (status: 0x%04x) %dms, treating as no-op\n",
+			stream_id, on, status, jiffies_to_msecs(jiffies - ts));
+		mutex_lock(&state->ds5_dev->lock);
+		*streaming_flag = on;
+		mutex_unlock(&state->ds5_dev->lock);
+		sensor->streaming = on;
 #ifdef CONFIG_VIDEO_D5XX_SERDES
-			if (on)
-				ds5_post_start_dser_datapath_kick(state, stream_id);
+		if (on)
+			ds5_post_start_dser_datapath_kick(state, stream_id);
 #endif
-			if (stream_ctrl_locked) {
-				mutex_unlock(&state->ds5_dev->stream_ctrl_lock);
-				stream_ctrl_locked = false;
-			}
-			ds5_finish_rgb_start(state, stream_id, 0);
-			ds5_finish_ir_start(state, stream_id, 0);
-			return 0;
+		if (stream_ctrl_locked) {
+			mutex_unlock(&state->ds5_dev->stream_ctrl_lock);
+			stream_ctrl_locked = false;
 		}
+		return 0;
 	}
 
 	restore_val = sensor->streaming;
@@ -5694,7 +5309,8 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 	streaming = ~expected_streaming_state; /* force initial toggle */
 		for (timeout = ts + msecs_to_jiffies(on ? DS5_START_MAX_TIME :
 								 DS5_STOP_MAX_TIME), i = 0;
-				time_before(jiffies, timeout); i++, msleep_range(i*DS5_START_POLL_TIME))
+				time_before(jiffies, timeout);
+				i++, msleep_range(ds5_stream_poll_delay(on, i)))
 		{
 			command_read_status = false;
 			if (!ds5_config_done) {
@@ -5706,8 +5322,6 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 						mutex_unlock(&state->ds5_dev->stream_ctrl_lock);
 						stream_ctrl_locked = false;
 					}
-					ds5_finish_rgb_start(state, stream_id, ret);
-					ds5_finish_ir_start(state, stream_id, ret);
 					return ret;
 				}
 				dev_warn(&state->client->dev, "stream %d config failed, retry %d, %dms\n",
@@ -5875,8 +5489,6 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 #endif
 	if (stream_ctrl_locked)
 		mutex_unlock(&state->ds5_dev->stream_ctrl_lock);
-	ds5_finish_rgb_start(state, stream_id, ret);
-	ds5_finish_ir_start(state, stream_id, ret);
 	return ret;
 #endif /* !DS5_BYPASS_CAMERA_I2C */
 }

--- a/kernel/realsense/d5xx.c
+++ b/kernel/realsense/d5xx.c
@@ -51,7 +51,7 @@ struct dser_interface {
 	int (*set_pipe)(struct device *dev, int pipe_id, u8 data_type1, u8 data_type2, u32 vc_id);
 	int (*release_pipe)(struct device *dev, int pipe_id);
 	void (*reset_oneshot)(struct device *dev);
-	int (*retrigger_datapath)(struct device *dev);
+	void (*retrigger_datapath)(struct device *dev);
 	int (*get_active_pipe_count)(struct device *dev);
 	int (*get_link_locked)(struct device *dev);
 	
@@ -196,7 +196,7 @@ struct dser_interface {
 #define MAX_DEPTH_EXP				200000
 #define MAX_RGB_EXP					10000
 #define DEF_DEPTH_EXP				33000
-#define DEF_RGB_EXP					166
+#define DEF_RGB_EXP					1660
 
 enum ds5_mux_pad {
 	DS5_MUX_PAD_EXTERNAL,
@@ -219,8 +219,13 @@ enum ds5_mux_pad {
 #define DS5_START_MAX_TIME			2000
 #define DS5_STOP_MAX_TIME			7000
 #define DS5_START_MAX_COUNT	(DS5_START_MAX_TIME / DS5_START_POLL_TIME)
-#define DS5_DEPENDENCY_DEBOUNCE_MS		300
-#define DS5_DEPENDENCY_WAIT_MS			3000
+#define DS5_RGB_START_DEBOUNCE_MS		300
+#define DS5_RGB_START_WAIT_MS			3000
+#define DS5_IR_START_DEBOUNCE_MS		300
+#define DS5_IR_START_WAIT_MS			3000
+#define DS5_DSER_REARM_COOLDOWN_MS		1800
+#define DS5_DSER_REARM_FALLBACK_MS		700
+#define DS5_DSER_REARM_WAIT_MS			3500
 #define MAX_DS5_CONFIG_RETRIES		5
 
 /* I2C retry configuration */
@@ -451,6 +456,7 @@ struct ds5_sensor {
 	u16 pipe_data_type1;
 	u16 pipe_data_type2;
 	u32 pipe_vc_id;
+	unsigned int pipe_reapply_gen;
 	u16 cached_dt_value;
 	u16 cached_md_value;
 	u16 cached_override_value;
@@ -529,13 +535,6 @@ struct ds5 {
 	struct ds5_dev *ds5_dev; /* pointer to DS5 device struct */
 };
 
-#ifdef CONFIG_VIDEO_D5XX_SERDES
-struct ds5_start_state {
-	bool pending;
-	int error;
-};
-#endif
-
 struct ds5_dev {
 	struct mutex lock;
 	struct mutex stream_ctrl_lock;
@@ -580,10 +579,10 @@ struct ds5_dev {
 	bool ir_streaming;
 	bool rgb_streaming;
 	bool imu_streaming;
-#ifdef CONFIG_VIDEO_D5XX_SERDES
-	struct ds5_start_state rgb_start;
-	struct ds5_start_state ir_start;
-#endif
+	bool rgb_start_pending;
+	int rgb_start_error;
+	bool ir_start_pending;
+	int ir_start_error;
 };
 
 #ifdef CONFIG_VIDEO_D5XX_SERDES
@@ -603,6 +602,15 @@ struct dser_control {
 	*/
 	atomic_t reset_gen;
 	struct device *dser_dev;
+	bool datapath_armed;
+	u8 datapath_pipe_mask;
+	bool post_start_kick_pending;
+	bool rearm_pending;
+	bool rearm_started;
+	int rearm_owner_pipe;
+	unsigned int rearm_waiters;
+	unsigned int rearm_gen;
+	unsigned long last_idle_jiffies;
 };
 static struct dser_control dser_inited[MAX_DSER_NUM];
 
@@ -638,6 +646,153 @@ static inline atomic_t *dser_get_reset_gen(struct ds5 *state)
 	return &state->ds5_dev->dser_control->reset_gen;
 }
 
+static bool ds5_dser_datapath_armed(struct ds5 *state)
+{
+	bool armed;
+	struct dser_control *ctrl = state->ds5_dev->dser_control;
+
+	mutex_lock(&ctrl->lock);
+	armed = ctrl->datapath_armed;
+	mutex_unlock(&ctrl->lock);
+
+	return armed;
+}
+
+static void ds5_set_dser_datapath_armed(struct ds5 *state, bool armed)
+{
+	struct dser_control *ctrl = state->ds5_dev->dser_control;
+
+	mutex_lock(&ctrl->lock);
+	ctrl->datapath_armed = armed;
+	if (!armed)
+		ctrl->datapath_pipe_mask = 0;
+	mutex_unlock(&ctrl->lock);
+}
+
+static bool ds5_dser_datapath_matches(struct ds5 *state, u8 pipe_mask)
+{
+	bool matches;
+	struct dser_control *ctrl = state->ds5_dev->dser_control;
+
+	mutex_lock(&ctrl->lock);
+	matches = ctrl->datapath_armed &&
+		  ctrl->datapath_pipe_mask == pipe_mask;
+	mutex_unlock(&ctrl->lock);
+
+	return matches;
+}
+
+static void ds5_set_dser_datapath_pipe_mask(struct ds5 *state, u8 pipe_mask)
+{
+	struct dser_control *ctrl = state->ds5_dev->dser_control;
+
+	mutex_lock(&ctrl->lock);
+	ctrl->datapath_armed = true;
+	ctrl->datapath_pipe_mask = pipe_mask;
+	mutex_unlock(&ctrl->lock);
+}
+
+static bool ds5_dser_post_start_kick_pending(struct ds5 *state)
+{
+	bool pending;
+	struct dser_control *ctrl = state->ds5_dev->dser_control;
+
+	mutex_lock(&ctrl->lock);
+	pending = ctrl->post_start_kick_pending;
+	mutex_unlock(&ctrl->lock);
+
+	return pending;
+}
+
+static void ds5_set_dser_post_start_kick_pending(struct ds5 *state,
+						 bool pending)
+{
+	struct dser_control *ctrl = state->ds5_dev->dser_control;
+
+	mutex_lock(&ctrl->lock);
+	ctrl->post_start_kick_pending = pending;
+	mutex_unlock(&ctrl->lock);
+}
+
+static void ds5_cancel_dser_rearm(struct ds5 *state)
+{
+	struct dser_control *ctrl = state->ds5_dev->dser_control;
+
+	mutex_lock(&ctrl->lock);
+	ctrl->rearm_pending = false;
+	ctrl->rearm_started = false;
+	ctrl->post_start_kick_pending = false;
+	ctrl->rearm_owner_pipe = PIPE_NOT_CONFIGURED;
+	ctrl->rearm_waiters = 0;
+	mutex_unlock(&ctrl->lock);
+}
+
+static void ds5_schedule_dser_rearm(struct ds5 *state, int pipe_id)
+{
+	struct dser_control *ctrl = state->ds5_dev->dser_control;
+
+	mutex_lock(&ctrl->lock);
+	if (!ctrl->rearm_pending) {
+		ctrl->datapath_armed = false;
+		ctrl->rearm_pending = true;
+		ctrl->rearm_started = false;
+		ctrl->rearm_owner_pipe = pipe_id;
+		ctrl->rearm_waiters = 0;
+	}
+	mutex_unlock(&ctrl->lock);
+}
+
+static bool ds5_begin_dser_rearm(struct ds5 *state, int pipe_id,
+				 int *owner_pipe)
+{
+	struct dser_control *ctrl = state->ds5_dev->dser_control;
+	bool can_begin = true;
+
+	mutex_lock(&ctrl->lock);
+	if (ctrl->rearm_pending && ctrl->rearm_started &&
+	    ctrl->rearm_owner_pipe != pipe_id) {
+		can_begin = false;
+		if (owner_pipe)
+			*owner_pipe = ctrl->rearm_owner_pipe;
+	} else {
+		ctrl->datapath_armed = false;
+		ctrl->rearm_pending = true;
+		ctrl->rearm_started = true;
+		ctrl->rearm_owner_pipe = pipe_id;
+		if (owner_pipe)
+			*owner_pipe = pipe_id;
+	}
+	mutex_unlock(&ctrl->lock);
+
+	return can_begin;
+}
+
+static void ds5_mark_dser_rearm_done(struct ds5 *state, bool datapath_armed)
+{
+	struct dser_control *ctrl = state->ds5_dev->dser_control;
+
+	mutex_lock(&ctrl->lock);
+	ctrl->datapath_armed = datapath_armed;
+	ctrl->rearm_pending = false;
+	ctrl->rearm_started = false;
+	ctrl->rearm_owner_pipe = PIPE_NOT_CONFIGURED;
+	ctrl->rearm_waiters = 0;
+	ctrl->rearm_gen++;
+	mutex_unlock(&ctrl->lock);
+}
+
+static unsigned int ds5_dser_rearm_gen(struct ds5 *state)
+{
+	unsigned int gen;
+	struct dser_control *ctrl = state->ds5_dev->dser_control;
+
+	mutex_lock(&ctrl->lock);
+	gen = ctrl->rearm_gen;
+	mutex_unlock(&ctrl->lock);
+
+	return gen;
+}
+
 static unsigned int ds5_started_mipi_streams(struct ds5 *state)
 {
 	unsigned int count = 0;
@@ -656,9 +811,201 @@ static unsigned int ds5_started_mipi_streams(struct ds5 *state)
 	return count;
 }
 
+static u8 ds5_started_mipi_pipe_mask(struct ds5 *state)
+{
+	u8 mask = 0;
+
+	mutex_lock(&state->ds5_dev->lock);
+	if (state->ds5_dev->depth_streaming)
+		mask |= BIT(0);
+	if (state->ds5_dev->rgb_streaming)
+		mask |= BIT(1);
+	if (state->ds5_dev->ir_streaming)
+		mask |= BIT(2);
+	if (state->ds5_dev->imu_streaming)
+		mask |= BIT(3);
+	mutex_unlock(&state->ds5_dev->lock);
+
+	return mask;
+}
+
+static void ds5_post_start_dser_datapath_kick(struct ds5 *state, u16 stream_id)
+{
+	unsigned int started_streams;
+	u8 active_pipe_mask;
+	int active_pipes;
+	int link_locked;
+
+	mutex_lock(&serdes_lock__);
+	link_locked = state->dser_ops->get_link_locked ?
+		state->dser_ops->get_link_locked(state->dser_dev) : -1;
+	if (link_locked <= 0)
+		goto out;
+
+	active_pipes = state->dser_ops->get_active_pipe_count ?
+		state->dser_ops->get_active_pipe_count(state->dser_dev) : 1;
+	started_streams = ds5_started_mipi_streams(state);
+	active_pipe_mask = ds5_started_mipi_pipe_mask(state);
+	if (started_streams < active_pipes) {
+		dev_info(&state->client->dev,
+			 "stream %u START ok; locked DES datapath unchanged until remaining streams start (%u/%d)\n",
+			 stream_id, started_streams, active_pipes);
+		goto out;
+	}
+
+	if (ds5_dser_datapath_matches(state, active_pipe_mask) &&
+	    !ds5_dser_post_start_kick_pending(state)) {
+		dev_info(&state->client->dev,
+			 "stream %u START ok; keeping locked GMSL Link A unchanged for pipe mask 0x%02x (%u/%d streams started)\n",
+			 stream_id, active_pipe_mask, started_streams, active_pipes);
+		goto out;
+	}
+
+	dev_info(&state->client->dev,
+		 "stream %u START ok; retriggering DES CSI datapath without resetting locked GMSL Link A for pipe mask 0x%02x (%u/%d streams started)\n",
+		 stream_id, active_pipe_mask, started_streams, active_pipes);
+	/* PIPE_EN/mapping retrigger is local to the DES CSI datapath.  ONESHOT
+	 * would reset the whole Link A PHY/data path and invalidate queued VI
+	 * frames, while leaving the datapath untouched does not resynchronize
+	 * tunnel detection after the camera starts transmitting. */
+	state->dser_ops->retrigger_datapath(state->dser_dev);
+	ds5_cancel_dser_rearm(state);
+	ds5_set_dser_datapath_pipe_mask(state, active_pipe_mask);
+	ds5_set_dser_post_start_kick_pending(state, false);
+
+out:
+	mutex_unlock(&serdes_lock__);
+}
+
+static void ds5_wait_for_dser_rearm_cooldown(struct ds5 *state, const char *reason)
+{
+	struct dser_control *ctrl = state->ds5_dev->dser_control;
+	unsigned long last_idle;
+	unsigned long ready;
+	unsigned int wait_ms;
+
+	mutex_lock(&ctrl->lock);
+	last_idle = ctrl->last_idle_jiffies;
+	mutex_unlock(&ctrl->lock);
+
+	if (!last_idle)
+		return;
+
+	ready = last_idle + msecs_to_jiffies(DS5_DSER_REARM_COOLDOWN_MS);
+	if (!time_before(jiffies, ready))
+		return;
+
+	wait_ms = jiffies_to_msecs(ready - jiffies);
+	dev_info(&state->client->dev,
+		 "waiting %u ms before DES datapath re-arm (%s)\n",
+		 wait_ms, reason);
+	msleep(wait_ms);
+}
+
+static bool ds5_rearm_dser_datapath_before_start(struct ds5 *state, int pipe_id,
+						 int active_pipes,
+						 int link_locked,
+						 const char *reason)
+{
+	/* ONESHOT resets the complete Link A PHY and data path, including the
+	 * tunnel carrying remote I2C.  A locked link does not need recovery;
+	 * the post-START path will retrigger only the DES CSI data path. */
+	if (link_locked > 0) {
+		dev_info(&state->client->dev,
+			 "pipe %d pre-start preserving locked Link A (%s, %d pipes active)\n",
+			 pipe_id, reason, active_pipes);
+		return false;
+	}
+
+	ds5_wait_for_dser_rearm_cooldown(state, reason);
+	dev_info(&state->client->dev,
+		 "pipe %d pre-start resetting GMSL Link A PHY and datapath with ONESHOT (%s, %d pipes active, link %s)\n",
+		 pipe_id, reason, active_pipes,
+		 link_locked > 0 ? "locked" :
+		 (link_locked == 0 ? "unlocked" : "unknown"));
+	state->dser_ops->reset_oneshot(state->dser_dev);
+	max96717_retrigger_tx(state->ser_dev);
+	msleep(200);
+	ds5_set_dser_post_start_kick_pending(state, true);
+	return true;
+}
+
+static int ds5_wait_for_dser_rearm(struct ds5 *state, int pipe_id)
+{
+	struct dser_control *ctrl = state->ds5_dev->dser_control;
+	unsigned long timeout;
+	unsigned long fallback_timeout;
+	bool started;
+	bool pending;
+	int owner_pipe;
+
+	if (!state->dser_ops->get_active_pipe_count)
+		return 0;
+
+	mutex_lock(&ctrl->lock);
+	pending = ctrl->rearm_pending;
+	owner_pipe = ctrl->rearm_owner_pipe;
+	if (!pending) {
+		mutex_unlock(&ctrl->lock);
+		return 0;
+	}
+	mutex_unlock(&ctrl->lock);
+
+	dev_info(&state->client->dev,
+		 "pipe %d waiting for DES datapath re-arm owner pipe %d before camera I2C config\n",
+		 pipe_id, owner_pipe);
+	fallback_timeout = jiffies + msecs_to_jiffies(DS5_DSER_REARM_FALLBACK_MS);
+	timeout = jiffies + msecs_to_jiffies(DS5_DSER_REARM_WAIT_MS);
+	do {
+		mutex_lock(&ctrl->lock);
+		pending = ctrl->rearm_pending;
+		started = ctrl->rearm_started;
+		owner_pipe = ctrl->rearm_owner_pipe;
+		mutex_unlock(&ctrl->lock);
+		if (!pending)
+			return 0;
+
+		if (!started && owner_pipe == pipe_id &&
+		    time_after_eq(jiffies, fallback_timeout)) {
+			int active_pipes;
+			int link_locked;
+
+			if (!ds5_begin_dser_rearm(state, pipe_id, &owner_pipe))
+				continue;
+
+			active_pipes = state->dser_ops->get_active_pipe_count ?
+				state->dser_ops->get_active_pipe_count(state->dser_dev) : 1;
+			link_locked = state->dser_ops->get_link_locked ?
+				state->dser_ops->get_link_locked(state->dser_dev) : -1;
+
+			dev_info(&state->client->dev,
+				 "pipe %d fallback re-arming DES datapath after waiting for pipe 0\n",
+				 pipe_id);
+			mutex_lock(&serdes_lock__);
+			ds5_mark_dser_rearm_done(state,
+				ds5_rearm_dser_datapath_before_start(state, pipe_id,
+								      active_pipes,
+								      link_locked,
+								      "fallback owner"));
+			mutex_unlock(&serdes_lock__);
+			return 0;
+		}
+		msleep(20);
+	} while (time_before(jiffies, timeout));
+
+	dev_warn(&state->client->dev,
+		 "pipe %d timed out waiting for DES datapath re-arm owner pipe %d\n",
+		 pipe_id, owner_pipe);
+	return -ETIMEDOUT;
+}
+
 static void ds5_disarm_dser_datapath_if_idle(struct ds5 *state)
 {
 	int active_pipes;
+	int link_locked;
+	bool armed;
+	bool pending;
+	struct dser_control *ctrl = state->ds5_dev->dser_control;
 
 	if (!state->dser_ops->get_active_pipe_count)
 		return;
@@ -667,8 +1014,31 @@ static void ds5_disarm_dser_datapath_if_idle(struct ds5 *state)
 	if (active_pipes != 0)
 		return;
 
-	dev_info(&state->client->dev,
-		 "all DES pipes released; preserving Link A for next start\n");
+	link_locked = state->dser_ops->get_link_locked ?
+		state->dser_ops->get_link_locked(state->dser_dev) : -1;
+	mutex_lock(&ctrl->lock);
+	armed = ctrl->datapath_armed;
+	pending = ctrl->rearm_pending;
+	ctrl->datapath_armed = false;
+	ctrl->datapath_pipe_mask = 0;
+	ctrl->post_start_kick_pending = false;
+	ctrl->rearm_pending = false;
+	ctrl->rearm_started = false;
+	ctrl->rearm_owner_pipe = PIPE_NOT_CONFIGURED;
+	ctrl->rearm_waiters = 0;
+	ctrl->last_idle_jiffies = jiffies;
+	mutex_unlock(&ctrl->lock);
+
+	if (link_locked > 0) {
+		if (armed || pending)
+			dev_info(&state->client->dev,
+				 "all DES pipes released; preserving locked Link A for next start\n");
+		return;
+	}
+
+	if (armed || pending)
+		dev_info(&state->client->dev,
+			 "all DES pipes released; datapath marked unarmed for cooldown\n");
 }
 
 /* MAX96724 deserializer interface implementation */
@@ -1462,55 +1832,60 @@ static int ds5_setup_pipeline(struct ds5 *state, u8 data_type1, u8 data_type2,
 		state->dser_ops->get_active_pipe_count(state->dser_dev) : 1;
 	int link_locked = (state->dser_ops->get_link_locked != NULL) ?
 		state->dser_ops->get_link_locked(state->dser_dev) : -1;
+	bool datapath_armed = ds5_dser_datapath_armed(state);
 
-	if (ser_pipe_id < 0)
-		return ser_pipe_id;
-	if (state->dser_ops->get_link_locked && link_locked < 0)
-		return link_locked;
+	if (link_locked > 0 && !datapath_armed && active_pipes <= 1)
+		dev_info(&state->client->dev,
+			 "link locked; DES datapath retrigger will run after camera START\n");
 
-	ret = state->dser_ops->bind_ser_to_dser_pipe(state->dser_dev, pipe_id,
-						     ser_pipe_id, vc_id);
-	if (ret < 0)
-		goto error;
+	ret |= state->dser_ops->bind_ser_to_dser_pipe(state->dser_dev, pipe_id, ser_pipe_id, vc_id);
 	dev_dbg(&state->client->dev,
 			"set ser pipe %d, dser pipe %d, data_type1: 0x%x, data_type2: 0x%x, ser_vc_id: %u, vc_id: %u\n",
 			ser_pipe_id, pipe_id, data_type1, data_type2, ser_vc_id, vc_id);
-	ret = max96717_set_pipe(state->ser_dev, ser_pipe_id, data_type1,
-				data_type2, ser_vc_id);
-	if (ret < 0)
-		goto error;
-	ret = state->dser_ops->set_pipe(state->dser_dev, pipe_id, data_type1,
-					data_type2, vc_id);
-	if (ret < 0)
-		goto error;
-
-	if (link_locked > 0 && active_pipes > 1) {
+	ret |= max96717_set_pipe(state->ser_dev, ser_pipe_id,
+				data_type1, data_type2, ser_vc_id);
+	ret |= state->dser_ops->set_pipe(state->dser_dev, pipe_id,
+				data_type1, data_type2, vc_id);
+	if (ret >= 0 && link_locked > 0 && datapath_armed) {
 		unsigned int started_streams = ds5_started_mipi_streams(state);
 
 		dev_info(&state->client->dev,
 			 "pipe %d mapping updated while DES datapath armed (%u streams active); keeping datapath armed\n",
 			 pipe_id, started_streams);
 	}
-	if (active_pipes <= 1) {
-		if (link_locked > 0) {
-			dev_info(&state->client->dev,
-				 "pipe %d preserving locked Link A before DES pre-start re-arm\n",
-				 pipe_id);
+	/*
+	 * Prefer pipe 0 as the deterministic re-arm owner.  If RGB/IR arrives
+	 * first, it maps its pipe and waits before camera-side I2C config until
+	 * depth/pipe 0 performs the early re-arm.  On an already-locked link,
+	 * avoid ONESHOT and only retrigger the DES CSI datapath before START.
+	 */
+	if (pipe_id == 0 && (link_locked <= 0 || !datapath_armed)) {
+		int owner_pipe = PIPE_NOT_CONFIGURED;
+
+		dev_info(&state->client->dev,
+			 "pipe 0 re-arming DES datapath before camera I2C config (link %s, armed=%d, active_pipes=%d)\n",
+			 link_locked > 0 ? "locked" :
+			 (link_locked == 0 ? "unlocked" : "unknown"),
+			 datapath_armed, active_pipes);
+		if (ds5_begin_dser_rearm(state, pipe_id, &owner_pipe)) {
+			datapath_armed =
+				ds5_rearm_dser_datapath_before_start(state, pipe_id,
+								      active_pipes,
+								      link_locked,
+								      "pipe 0");
+			ds5_mark_dser_rearm_done(state, datapath_armed);
 		} else {
 			dev_info(&state->client->dev,
-				 "pipe %d resetting unlocked GMSL Link A before cold start\n",
-				 pipe_id);
-			state->dser_ops->reset_oneshot(state->dser_dev);
-			max96717_retrigger_tx(state->ser_dev);
-			msleep(200);
+				 "pipe 0 waiting for active DES datapath re-arm owner pipe %d\n",
+				 owner_pipe);
 		}
-		ret = state->dser_ops->retrigger_datapath(state->dser_dev);
-		if (ret < 0) {
-			dev_warn(&state->client->dev,
-				 "pipe %d DES pre-start re-arm failed (%d)\n",
-				 pipe_id, ret);
-			goto error;
-		}
+	} else if (active_pipes <= 1 && !datapath_armed) {
+		dev_info(&state->client->dev,
+			 "first non-depth pipe %d scheduling DES datapath re-arm for pipe 0 (link %s, armed=%d)\n",
+			 pipe_id, link_locked > 0 ? "locked" :
+			 (link_locked == 0 ? "unlocked" : "unknown"),
+			 datapath_armed);
+		ds5_schedule_dser_rearm(state, pipe_id);
 	} else {
 		dev_info(&state->client->dev,
 			 "pipe %d mapping updated w/o link reset (%d pipes active, link %s)\n",
@@ -1518,12 +1893,11 @@ static int ds5_setup_pipeline(struct ds5 *state, u8 data_type1, u8 data_type2,
 			 link_locked > 0 ? "locked" :
 			 (link_locked == 0 ? "unlocked" : "unknown"));
 	}
-	return 0;
+	if (ret)
+		dev_warn(&state->client->dev,
+			 "failed to set pipe %d, data_type1: 0x%x, data_type2: 0x%x, vc_id: %u\n",
+			 pipe_id, data_type1, data_type2, vc_id);
 
-error:
-	dev_warn(&state->client->dev,
-		 "failed to set pipe %d, data_type1: 0x%x, data_type2: 0x%x, vc_id: %u (%d)\n",
-		 pipe_id, data_type1, data_type2, vc_id, ret);
 	return ret;
 }
 #endif
@@ -1551,6 +1925,7 @@ static void ds5_invalidate_sensor(struct ds5 *state, struct ds5_sensor *sensor)
 	sensor->pipe_data_type1 = 0;
 	sensor->pipe_data_type2 = 0;
 	sensor->pipe_vc_id = 0xFFFF;
+	sensor->pipe_reapply_gen = 0;
 }
 
 static int ds5_configure(struct ds5 *state)
@@ -1559,6 +1934,8 @@ static int ds5_configure(struct ds5 *state)
 	u16 md_fmt, vc_id;
 #ifdef CONFIG_VIDEO_D5XX_SERDES
 	u16 data_type1, data_type2;
+	bool is_calib = 0;
+	unsigned int pipe_reapply_gen;
 #endif
 #if !DS5_BYPASS_CAMERA_I2C
 	u16 dt_addr, md_addr, override_addr, fps_addr, width_addr, height_addr;
@@ -1619,6 +1996,7 @@ static int ds5_configure(struct ds5 *state)
 #ifdef CONFIG_VIDEO_D5XX_SERDES
 	data_type1 = sensor->config.format->data_type;
 	data_type2 = md_fmt;
+	is_calib = (state->is_y8 && (data_type1 == GMSL_CSI_DT_RGB_888));
 
 	vc_id = state->g_ctx.dst_vc;
 	dev_info(&state->client->dev,
@@ -1635,6 +2013,7 @@ static int ds5_configure(struct ds5 *state)
 				ds5_disarm_dser_datapath_if_idle(state);
 			mutex_unlock(&serdes_lock__);
 			dev_warn(&state->client->dev, "release pipe %d (%d)\n", sensor->pipe_id, ret);
+			sensor->pipe_reapply_gen = 0;
 		}
 		/*
 		* Serialize SERDES pipe allocation and configuration
@@ -1651,9 +2030,14 @@ static int ds5_configure(struct ds5 *state)
 			dev_err(&state->client->dev, "No free pipe in %s\n",state->dser_ops->name);
 			return -ENOSR;
 		}
+		pipe_reapply_gen = ds5_dser_rearm_gen(state);
+		sensor->pipe_reapply_gen = pipe_reapply_gen;
 		mutex_lock(&serdes_lock__);
 		ret = ds5_setup_pipeline(state, data_type1, data_type2,
 					 sensor->pipe_id, vc_id);
+		/* reset data path when switching to Y12I */
+		if (is_calib)
+			state->dser_ops->reset_oneshot(state->dser_dev);
 		mutex_unlock(&serdes_lock__);
 		if (ret < 0) {
 			dev_err(&state->client->dev,
@@ -1671,6 +2055,34 @@ static int ds5_configure(struct ds5 *state)
 		dev_info(&state->client->dev,
 				"pipe %d already configured (dt1=0x%x dt2=0x%x vc=%u)\n",
 				sensor->pipe_id, data_type1, data_type2, vc_id);
+	}
+
+	ret = ds5_wait_for_dser_rearm(state, sensor->pipe_id);
+	if (ret < 0)
+		return ret;
+
+	pipe_reapply_gen = ds5_dser_rearm_gen(state);
+	if (sensor->pipe_reapply_gen != pipe_reapply_gen) {
+		mutex_lock(&serdes_lock__);
+		ret = ds5_setup_pipeline(state, data_type1, data_type2,
+					 sensor->pipe_id, vc_id);
+		mutex_unlock(&serdes_lock__);
+		if (ret < 0) {
+			dev_err(&state->client->dev,
+				"pipe %d re-apply after DES re-arm FAILED (dt1=0x%x dt2=0x%x vc=%u gen=%u->%u) ret=%d\n",
+				sensor->pipe_id, data_type1, data_type2, vc_id,
+				sensor->pipe_reapply_gen, pipe_reapply_gen, ret);
+			return ret;
+		}
+		dev_info(&state->client->dev,
+			 "pipe %d re-applied after DES re-arm (dt1=0x%x dt2=0x%x vc=%u gen=%u)\n",
+			 sensor->pipe_id, data_type1, data_type2, vc_id,
+			 pipe_reapply_gen);
+		sensor->pipe_reapply_gen = pipe_reapply_gen;
+	} else {
+		dev_dbg(&state->client->dev,
+			"pipe %d already applied for DES re-arm gen %u (dt1=0x%x dt2=0x%x vc=%u)\n",
+			sensor->pipe_id, pipe_reapply_gen, data_type1, data_type2, vc_id);
 	}
 #else /* Non-SERDES configuration */
 	vc_id = (state->is_depth) ? 0 : (state->is_rgb) ? 1 : (state->is_y8) ? 2 : 3;
@@ -2195,150 +2607,189 @@ static void ds5_reset_streaming_flags(struct ds5_dev *ds5_dev)
 	ds5_dev->ir_streaming = false;
 	ds5_dev->rgb_streaming = false;
 	ds5_dev->imu_streaming = false;
-#ifdef CONFIG_VIDEO_D5XX_SERDES
-	ds5_dev->rgb_start.pending = false;
-	ds5_dev->rgb_start.error = 0;
-	ds5_dev->ir_start.pending = false;
-	ds5_dev->ir_start.error = 0;
-#endif
+	ds5_dev->rgb_start_pending = false;
+	ds5_dev->rgb_start_error = 0;
+	ds5_dev->ir_start_pending = false;
+	ds5_dev->ir_start_error = 0;
 	mutex_unlock(&ds5_dev->lock);
 }
 
-#ifdef CONFIG_VIDEO_D5XX_SERDES
-static bool ds5_streams_idle(struct ds5 *state)
+static void ds5_set_rgb_start_pending(struct ds5 *state, u16 stream_id, bool pending)
 {
-	struct ds5_dev *ds5_dev = state->ds5_dev;
-	bool idle;
-
-	mutex_lock(&ds5_dev->lock);
-	idle = !ds5_dev->depth_streaming && !ds5_dev->rgb_streaming &&
-	       !ds5_dev->ir_streaming && !ds5_dev->imu_streaming;
-	mutex_unlock(&ds5_dev->lock);
-
-	return idle;
-}
-
-static struct ds5_start_state *ds5_get_start_state(struct ds5_dev *ds5_dev,
-						    u16 stream_id)
-{
-	if (stream_id == DS5_STREAM_RGB)
-		return &ds5_dev->rgb_start;
-	if (stream_id == DS5_STREAM_IR)
-		return &ds5_dev->ir_start;
-	return NULL;
-}
-
-static void ds5_set_start_pending(struct ds5 *state, u16 stream_id)
-{
-	struct ds5_start_state *start =
-		ds5_get_start_state(state->ds5_dev, stream_id);
-
-	if (!start)
+	if (stream_id != DS5_STREAM_RGB)
 		return;
 
 	mutex_lock(&state->ds5_dev->lock);
-	start->pending = true;
-	start->error = 0;
+	state->ds5_dev->rgb_start_pending = pending;
+	if (pending)
+		state->ds5_dev->rgb_start_error = 0;
 	mutex_unlock(&state->ds5_dev->lock);
 }
 
-static void ds5_finish_start(struct ds5 *state, u16 stream_id, int ret)
+static void ds5_finish_rgb_start(struct ds5 *state, u16 stream_id, int ret)
 {
-	struct ds5_start_state *start =
-		ds5_get_start_state(state->ds5_dev, stream_id);
-
-	if (!start)
+	if (stream_id != DS5_STREAM_RGB)
 		return;
 
 	mutex_lock(&state->ds5_dev->lock);
-	start->error = ret < 0 ? ret : 0;
-	start->pending = false;
+	state->ds5_dev->rgb_start_error = ret < 0 ? ret : 0;
+	state->ds5_dev->rgb_start_pending = false;
 	mutex_unlock(&state->ds5_dev->lock);
 }
 
-static bool ds5_start_pending(struct ds5 *state, u16 stream_id, int *error)
+static bool ds5_rgb_start_state(struct ds5 *state, int *error)
 {
-	struct ds5_start_state *start =
-		ds5_get_start_state(state->ds5_dev, stream_id);
 	bool pending;
 
-	if (!start)
-		return false;
-
 	mutex_lock(&state->ds5_dev->lock);
-	pending = start->pending;
+	pending = state->ds5_dev->rgb_start_pending;
 	if (error)
-		*error = start->error;
+		*error = state->ds5_dev->rgb_start_error;
 	mutex_unlock(&state->ds5_dev->lock);
 
 	return pending;
 }
 
-static int ds5_wait_for_start(struct ds5 *state, u16 stream_id,
-			      u16 dependency_id, unsigned int debounce_ms,
-			      unsigned int wait_ms, const char *dependency_name)
+static int ds5_wait_for_rgb_start_before_stereo(struct ds5 *state, u16 stream_id)
 {
+#ifdef CONFIG_VIDEO_D5XX_SERDES
 	unsigned long discover_timeout;
 	unsigned long timeout;
-	int start_error = 0;
+	int rgb_error = 0;
 
-	discover_timeout = jiffies + msecs_to_jiffies(debounce_ms);
-	while (!ds5_start_pending(state, dependency_id, &start_error)) {
+	if (stream_id == DS5_STREAM_RGB || stream_id == DS5_STREAM_IMU)
+		return 0;
+
+	/*
+	 * RGB joining an already-streaming stereo pipe can stall the shared HIF
+	 * CSI TX task (FW reports frame counter N, ack N-2).  Give a concurrent
+	 * RGB START a short window to announce itself, then let it complete first.
+	 */
+	discover_timeout = jiffies + msecs_to_jiffies(DS5_RGB_START_DEBOUNCE_MS);
+	while (!ds5_rgb_start_state(state, &rgb_error)) {
 		if (!time_before(jiffies, discover_timeout))
 			return 0;
 		msleep(20);
 	}
 
 	dev_info(&state->client->dev,
-		 "stream %u waiting for %s START to complete\n",
-		 stream_id, dependency_name);
-	timeout = jiffies + msecs_to_jiffies(wait_ms);
-	while (ds5_start_pending(state, dependency_id, &start_error)) {
+		 "stream %d waiting for RGB START to complete before stereo START\n",
+		 stream_id);
+	timeout = jiffies + msecs_to_jiffies(DS5_RGB_START_WAIT_MS);
+	while (ds5_rgb_start_state(state, &rgb_error)) {
 		if (!time_before(jiffies, timeout)) {
 			dev_warn(&state->client->dev,
-				 "stream %u timed out waiting for %s START\n",
-				 stream_id, dependency_name);
+				 "stream %d timed out waiting for RGB START; aborting stereo START\n",
+				 stream_id);
 			return -ETIMEDOUT;
 		}
 		msleep(20);
 	}
 
-	if (start_error < 0) {
+	if (rgb_error < 0) {
 		dev_warn(&state->client->dev,
-			 "stream %u observed %s START failure (%d)\n",
-			 stream_id, dependency_name, start_error);
-		return start_error;
+			 "stream %d observed RGB START failure (%d); aborting stereo START\n",
+			 stream_id, rgb_error);
+		return rgb_error;
 	}
 
+	dev_info(&state->client->dev,
+		 "stream %d observed RGB START complete; continuing stereo START\n",
+		 stream_id);
 	return 0;
-}
 #else
-static void ds5_set_start_pending(struct ds5 *state, u16 stream_id)
-{
 	(void)state;
 	(void)stream_id;
-}
-
-static void ds5_finish_start(struct ds5 *state, u16 stream_id, int ret)
-{
-	(void)state;
-	(void)stream_id;
-	(void)ret;
-}
-
-static int ds5_wait_for_start(struct ds5 *state, u16 stream_id,
-			      u16 dependency_id, unsigned int debounce_ms,
-			      unsigned int wait_ms, const char *dependency_name)
-{
-	(void)state;
-	(void)stream_id;
-	(void)dependency_id;
-	(void)debounce_ms;
-	(void)wait_ms;
-	(void)dependency_name;
 	return 0;
-}
 #endif
+}
+
+static void ds5_set_ir_start_pending(struct ds5 *state, u16 stream_id, bool pending)
+{
+	if (stream_id != DS5_STREAM_IR)
+		return;
+
+	mutex_lock(&state->ds5_dev->lock);
+	state->ds5_dev->ir_start_pending = pending;
+	if (pending)
+		state->ds5_dev->ir_start_error = 0;
+	mutex_unlock(&state->ds5_dev->lock);
+}
+
+static void ds5_finish_ir_start(struct ds5 *state, u16 stream_id, int ret)
+{
+	if (stream_id != DS5_STREAM_IR)
+		return;
+
+	mutex_lock(&state->ds5_dev->lock);
+	state->ds5_dev->ir_start_error = ret < 0 ? ret : 0;
+	state->ds5_dev->ir_start_pending = false;
+	mutex_unlock(&state->ds5_dev->lock);
+}
+
+static bool ds5_ir_start_state(struct ds5 *state, int *error)
+{
+	bool pending;
+
+	mutex_lock(&state->ds5_dev->lock);
+	pending = state->ds5_dev->ir_start_pending;
+	if (error)
+		*error = state->ds5_dev->ir_start_error;
+	mutex_unlock(&state->ds5_dev->lock);
+
+	return pending;
+}
+
+static int ds5_wait_for_ir_start_before_depth(struct ds5 *state, u16 stream_id)
+{
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+	unsigned long discover_timeout;
+	unsigned long timeout;
+	int ir_error = 0;
+
+	if (stream_id != DS5_STREAM_DEPTH)
+		return 0;
+
+	/* The PR #282 FW keeps one gated stereo pipeline alive, so IR can build
+	 * it first and Depth can enable its pre-built branch without a rebuild. */
+	discover_timeout = jiffies + msecs_to_jiffies(DS5_IR_START_DEBOUNCE_MS);
+	while (!ds5_ir_start_state(state, &ir_error)) {
+		if (!time_before(jiffies, discover_timeout))
+			return 0;
+		msleep(20);
+	}
+
+	dev_info(&state->client->dev,
+		 "stream %d waiting for IR START to complete before depth gate\n",
+		 stream_id);
+	timeout = jiffies + msecs_to_jiffies(DS5_IR_START_WAIT_MS);
+	while (ds5_ir_start_state(state, &ir_error)) {
+		if (!time_before(jiffies, timeout)) {
+			dev_warn(&state->client->dev,
+				 "stream %d timed out waiting for IR START; aborting depth START\n",
+				 stream_id);
+			return -ETIMEDOUT;
+		}
+		msleep(20);
+	}
+
+	if (ir_error < 0) {
+		dev_warn(&state->client->dev,
+			 "stream %d observed IR START failure (%d); aborting depth START\n",
+			 stream_id, ir_error);
+		return ir_error;
+	}
+
+	dev_info(&state->client->dev,
+		 "stream %d observed IR START complete; enabling depth gate\n",
+		 stream_id);
+	return 0;
+#else
+	(void)state;
+	(void)stream_id;
+	return 0;
+#endif
+}
 
 #ifdef CONFIG_VIDEO_D5XX_SERDES
 static void ds5_release_serdes_pipe(struct ds5 *state,
@@ -2359,6 +2810,7 @@ static void ds5_release_serdes_pipe(struct ds5 *state,
 	} else {
 		ds5_disarm_dser_datapath_if_idle(state);
 		sensor->pipe_id = PIPE_NOT_CONFIGURED;
+		sensor->pipe_reapply_gen = 0;
 	}
 	mutex_unlock(&serdes_lock__);
 }
@@ -2563,6 +3015,11 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	atomic_inc(ds5_get_reset_gen(state));
 	WRITE_ONCE(state->ds5_dev->cached_device_type, DS5_DEVICE_TYPE_UNKNOWN);
 	ds5_reset_streaming_flags(state->ds5_dev);
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+	ds5_set_dser_datapath_armed(state, false);
+	ds5_cancel_dser_rearm(state);
+#endif
+
 	/* 3. Scratch one control-status register before reset.
 	 *    FW restores them to default 0x0000 only after reset completes.
 	 */
@@ -3185,7 +3642,7 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 		data = ((u32)reg << 16) & 0xffff0000;
 		ds5_read(state, base | DS5_MANUAL_EXPOSURE_LSB, &reg);
 		data |= reg;
-		ctrl->val = (s32)data;
+		*ctrl->p_new.p_u32 = data;
 		break;
 
 	case DS5_CAMERA_CID_LASER_POWER:
@@ -3335,32 +3792,6 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 static const struct v4l2_ctrl_ops ds5_ctrl_ops = {
 	.s_ctrl	= ds5_s_ctrl,
 	.g_volatile_ctrl = ds5_g_volatile_ctrl,
-};
-
-static const struct v4l2_ctrl_config ds5_ctrl_depth_exposure = {
-	.ops = &ds5_ctrl_ops,
-	.id = V4L2_CID_EXPOSURE_ABSOLUTE,
-	.name = "Exposure Time, Absolute",
-	.type = V4L2_CTRL_TYPE_INTEGER,
-	.min = 1,
-	.max = MAX_DEPTH_EXP,
-	.step = 1,
-	.def = DEF_DEPTH_EXP,
-	.flags = V4L2_CTRL_FLAG_VOLATILE |
-		 V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
-};
-
-static const struct v4l2_ctrl_config ds5_ctrl_rgb_exposure = {
-	.ops = &ds5_ctrl_ops,
-	.id = V4L2_CID_EXPOSURE_ABSOLUTE,
-	.name = "Exposure Time, Absolute",
-	.type = V4L2_CTRL_TYPE_INTEGER,
-	.min = 1,
-	.max = MAX_RGB_EXP,
-	.step = 1,
-	.def = DEF_RGB_EXP,
-	.flags = V4L2_CTRL_FLAG_VOLATILE |
-		 V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
 };
 
 static const struct v4l2_ctrl_config ds5_ctrl_log = {
@@ -3724,6 +4155,11 @@ static int ds5_setup_and_link(struct ds5 *state)
 						mutex_lock(&dser_inited[j].lock);
 						if (NULL == dser_inited[j].dser_dev) {
 							dser_inited[j].dser_dev = state->dser_dev;
+							dser_inited[j].datapath_armed = false;
+							dser_inited[j].rearm_pending = false;
+							dser_inited[j].rearm_started = false;
+							dser_inited[j].rearm_owner_pipe = PIPE_NOT_CONFIGURED;
+							dser_inited[j].rearm_waiters = 0;
 							state->ds5_dev->dser_control = &dser_inited[j];
 						}
 						mutex_unlock(&dser_inited[j].lock);
@@ -4318,13 +4754,23 @@ static int ds5_ctrl_init(struct ds5 *state, int sid)
 		}
 	}
 
-	/* Exposure time is a one-element U32 payload in microseconds. */
+	/* Exposure time: V4L2_CID_EXPOSURE_ABSOLUTE default unit: 100 us. */
 	if (sid == DEPTH_SID || sid == IR_SID) {
-		ctrls->exposure = v4l2_ctrl_new_custom(
-				hdl, &ds5_ctrl_depth_exposure, sensor);
+		ctrls->exposure = v4l2_ctrl_new_std(hdl, ops,
+					V4L2_CID_EXPOSURE_ABSOLUTE,
+					1, MAX_DEPTH_EXP, 1, DEF_DEPTH_EXP);
 	} else if (sid == RGB_SID) {
-		ctrls->exposure = v4l2_ctrl_new_custom(
-				hdl, &ds5_ctrl_rgb_exposure, sensor);
+		ctrls->exposure = v4l2_ctrl_new_std(hdl, ops,
+					V4L2_CID_EXPOSURE_ABSOLUTE,
+					1, MAX_RGB_EXP, 1, DEF_RGB_EXP);
+	}
+
+	if ((ctrls->exposure) && (sid >= DEPTH_SID && sid < IMU_SID)) {
+		ctrls->exposure->priv = sensor;
+		ctrls->exposure->flags |=
+				V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_EXECUTE_ON_WRITE;
+		/* override default int type to u32 to match SKU & UVC */
+		ctrls->exposure->type = V4L2_CTRL_TYPE_U32;
 	}
 	if (hdl->error) {
 		v4l2_err(sd, "error creating controls (%d)\n", hdl->error);
@@ -4428,6 +4874,7 @@ static int ds5_sensor_init(struct i2c_client *c, struct ds5 *state,
 	char suffix = dpdata->suffix;
 #endif
 	sensor->pipe_id = PIPE_NOT_CONFIGURED;
+	sensor->pipe_reapply_gen = 0;
 	v4l2_i2c_subdev_init(sd, c, ops);
 	/* See tegracam_v4l2.c tegracam_v4l2subdev_register() */
 	/* Set owner to NULL so we can unload the driver module */
@@ -4976,13 +5423,27 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 	} else {
 		/* On stream off, release SERDES pipe */
 #ifdef CONFIG_VIDEO_D5XX_SERDES
-		ds5_release_serdes_pipe(state, sensor, "stream stop");
+		if (sensor->pipe_id >= 0) {
+			mutex_lock(&serdes_lock__);
+			if (state->dser_ops->release_pipe(state->dser_dev, sensor->pipe_id) < 0)
+				dev_warn(&state->client->dev, "release pipe failed\n");
+			else {
+				ds5_disarm_dser_datapath_if_idle(state);
+				sensor->pipe_id = PIPE_NOT_CONFIGURED;
+				sensor->pipe_reapply_gen = 0;
+			}
+			mutex_unlock(&serdes_lock__);
+		}
 		/*
 		 * Tear down the DES FSYNC generator when the last stream
 		 * stops.  Serializer GPIO tunneling remains tied to
 		 * camera_sync_mode and is disabled by the control callback.
 		 */
-		if (ds5_sync_mode_uses_esync(state) && ds5_streams_idle(state))
+		if (ds5_sync_mode_uses_esync(state) &&
+		    !state->ds5_dev->depth_streaming &&
+		    !state->ds5_dev->rgb_streaming &&
+		    !state->ds5_dev->ir_streaming &&
+		    !state->ds5_dev->imu_streaming)
 			ds5_set_des_fsync(state, false);
 #endif
 	}
@@ -5059,30 +5520,13 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		state->reset_ref_dser = cur_dser;
 	}
 
-	/*
-	 * A duplicate STREAMOFF can arrive after HKR has already stopped the
-	 * stream.  The camera state may be idle while the DES pipe allocated by
-	 * the previous STREAMON is still owned by this sensor, so STREAMOFF must
-	 * still perform the host-side cleanup.
-	 */
-	if (sensor->streaming == on) {
-		if (!on) {
-			mutex_lock(&state->ds5_dev->lock);
-			*streaming_flag = false;
-			mutex_unlock(&state->ds5_dev->lock);
-#ifdef CONFIG_VIDEO_D5XX_SERDES
-			ds5_release_serdes_pipe(state, sensor,
-						"duplicate stream stop");
-			if (ds5_sync_mode_uses_esync(state) &&
-			    ds5_streams_idle(state))
-				ds5_set_des_fsync(state, false);
-#endif
-		}
+	/* spare duplicate calls */
+	if (sensor->streaming == on)
 		return 0;
-	}
 
 	if (on) {
-		ds5_set_start_pending(state, stream_id);
+		ds5_set_rgb_start_pending(state, stream_id, true);
+		ds5_set_ir_start_pending(state, stream_id, true);
 	}
 
 	if (on) {
@@ -5096,27 +5540,22 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 	}
 
 	if (on) {
-		ret = 0;
-		if (stream_id != DS5_STREAM_RGB && stream_id != DS5_STREAM_IMU)
-			ret = ds5_wait_for_start(state, stream_id, DS5_STREAM_RGB,
-						 DS5_DEPENDENCY_DEBOUNCE_MS,
-						 DS5_DEPENDENCY_WAIT_MS, "RGB");
+		ret = ds5_wait_for_rgb_start_before_stereo(state, stream_id);
 		if (ret < 0) {
 #ifdef CONFIG_VIDEO_D5XX_SERDES
 			ds5_release_serdes_pipe(state, sensor, "RGB START dependency failure");
 #endif
-			ds5_finish_start(state, stream_id, ret);
+			ds5_finish_rgb_start(state, stream_id, ret);
+			ds5_finish_ir_start(state, stream_id, ret);
 			return ret;
 		}
-		if (stream_id == DS5_STREAM_DEPTH)
-			ret = ds5_wait_for_start(state, stream_id, DS5_STREAM_IR,
-						 DS5_DEPENDENCY_DEBOUNCE_MS,
-						 DS5_DEPENDENCY_WAIT_MS, "IR");
+		ret = ds5_wait_for_ir_start_before_depth(state, stream_id);
 		if (ret < 0) {
 #ifdef CONFIG_VIDEO_D5XX_SERDES
 			ds5_release_serdes_pipe(state, sensor, "IR START dependency failure");
 #endif
-			ds5_finish_start(state, stream_id, ret);
+			ds5_finish_rgb_start(state, stream_id, ret);
+			ds5_finish_ir_start(state, stream_id, ret);
 			return ret;
 		}
 	}
@@ -5138,7 +5577,8 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 #endif
 			mutex_unlock(&state->ds5_dev->stream_ctrl_lock);
 			stream_ctrl_locked = false;
-			ds5_finish_start(state, stream_id, ret);
+			ds5_finish_rgb_start(state, stream_id, ret);
+			ds5_finish_ir_start(state, stream_id, ret);
 			return ret;
 		}
 		ds5_config_done = true;
@@ -5162,12 +5602,6 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		if (ret < 0 || status == DS5_STATUS_UNAVAILABLE ||
 		    (status & ~DS5_STATUS_VALID_MASK))
 			continue;
-		/* A recovery STOP may race with an HKR-side teardown that already
-		 * made the stream idle.  Let the common no-op cleanup run now rather
-		 * than waiting the full STOP timeout for a state transition that has
-		 * already happened. */
-		if (!on && !(status & DS5_STATUS_STREAMING))
-			break;
 		if (on == !(status & DS5_STATUS_STREAMING)) {
 			break;
 		}
@@ -5190,7 +5624,10 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		/*
 		 * If state was invalidated by a reset-generation bump and FW
 		 * still reports this stream as active, force a stop to guarantee
-		 * the next start goes through full reconfiguration.
+		 * the next start goes through full reconfiguration.  During a
+		 * normal batched stereo/RGB start, another stream may legitimately
+		 * bring the shared datapath up first; treat that as an already-on
+		 * no-op below.
 		 */
 		if (on && reset_invalidated && (status & DS5_STATUS_STREAMING)) {
 			dev_warn(&state->client->dev,
@@ -5208,21 +5645,13 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 			*streaming_flag = false;
 			mutex_unlock(&state->ds5_dev->lock);
 			sensor->streaming = false;
-		} else if (on && (status & DS5_STATUS_STREAMING)) {
-			/*
-			 * CONFIG_STATUS reflects the shared HKR pipeline.  With gated
-			 * Depth/IR outputs it can be active before this stream's cadence
-			 * is enabled, so a stream-specific START must still be sent.
-			 */
-			dev_info(&state->client->dev,
-				 "stream %d reports shared pipeline active; issuing stream-specific START\n",
-				 stream_id);
 		} else {
 			/*
 			 * After HW reset the FW reboots and all streams return to
-			 * idle.  If VI error recovery tries to stop a stream that is
-			 * already stopped, clean up host resources and let the upper
-			 * layer proceed instead of getting stuck in an EBUSY loop.
+			 * idle.  If VI error recovery tries to stop a stream that
+			 * is already stopped (or start one already started), treat
+			 * it as a no-op so the upper layer can proceed with
+			 * restart instead of getting stuck in an EBUSY loop.
 			 */
 			dev_warn(&state->client->dev,
 				"stream %d in %d state already (status: 0x%04x) %dms, treating as no-op\n",
@@ -5232,17 +5661,15 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 			mutex_unlock(&state->ds5_dev->lock);
 			sensor->streaming = on;
 #ifdef CONFIG_VIDEO_D5XX_SERDES
-			ds5_release_serdes_pipe(state, sensor,
-						"stream already stopped");
-			if (ds5_sync_mode_uses_esync(state) &&
-			    ds5_streams_idle(state))
-				ds5_set_des_fsync(state, false);
+			if (on)
+				ds5_post_start_dser_datapath_kick(state, stream_id);
 #endif
 			if (stream_ctrl_locked) {
 				mutex_unlock(&state->ds5_dev->stream_ctrl_lock);
 				stream_ctrl_locked = false;
 			}
-			ds5_finish_start(state, stream_id, 0);
+			ds5_finish_rgb_start(state, stream_id, 0);
+			ds5_finish_ir_start(state, stream_id, 0);
 			return 0;
 		}
 	}
@@ -5273,7 +5700,8 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 						mutex_unlock(&state->ds5_dev->stream_ctrl_lock);
 						stream_ctrl_locked = false;
 					}
-					ds5_finish_start(state, stream_id, ret);
+					ds5_finish_rgb_start(state, stream_id, ret);
+					ds5_finish_ir_start(state, stream_id, ret);
 					return ret;
 				}
 				dev_warn(&state->client->dev, "stream %d config failed, retry %d, %dms\n",
@@ -5372,8 +5800,19 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 				mutex_unlock(&state->ds5_dev->stream_ctrl_lock);
 		}
 #ifdef CONFIG_VIDEO_D5XX_SERDES
-		if (on)
-			ds5_release_serdes_pipe(state, sensor, "stream start timeout");
+		if (on && sensor->pipe_id >= 0) {
+			mutex_lock(&serdes_lock__);
+			ret = state->dser_ops->release_pipe(state->dser_dev, sensor->pipe_id);
+			if (ret >= 0)
+				ds5_disarm_dser_datapath_if_idle(state);
+			mutex_unlock(&serdes_lock__);
+			if (ret < 0) {
+				dev_warn(&state->client->dev, "release pipe failed\n");
+			} else {
+				sensor->pipe_id = PIPE_NOT_CONFIGURED;
+				sensor->pipe_reapply_gen = 0;
+			}
+		}
 #endif
 		mutex_lock(&state->ds5_dev->lock);
 		*streaming_flag = restore_val;
@@ -5384,7 +5823,20 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 	else if (!on)
 	{
 #ifdef CONFIG_VIDEO_D5XX_SERDES
-		ds5_release_serdes_pipe(state, sensor, "stream stop");
+		mutex_lock(&serdes_lock__);
+		if (state->dser_ops->release_pipe(state->dser_dev, sensor->pipe_id) < 0)
+			dev_warn(&state->client->dev, "release pipe failed\n");
+		else {
+			ds5_disarm_dser_datapath_if_idle(state);
+			sensor->pipe_id = PIPE_NOT_CONFIGURED;
+			sensor->pipe_reapply_gen = 0;
+		}
+		if (state->is_y8
+			&& (state->ir.sensor.config.format->data_type == GMSL_CSI_DT_RGB_888))
+		{
+			state->dser_ops->reset_oneshot(state->dser_dev);
+		}
+		mutex_unlock(&serdes_lock__);
 		msleep_range(100);
 
 		/*
@@ -5393,11 +5845,23 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		 * cleared for *this* sensor before we entered the polling
 		 * loop) to decide whether any stream is still active.
 		 */
-		if (ds5_sync_mode_uses_esync(state) && ds5_streams_idle(state))
+		if (ds5_sync_mode_uses_esync(state) &&
+		    !state->ds5_dev->depth_streaming &&
+		    !state->ds5_dev->rgb_streaming &&
+		    !state->ds5_dev->ir_streaming &&
+		    !state->ds5_dev->imu_streaming)
 			ds5_set_des_fsync(state, false);
 #endif
 	}
 #ifdef CONFIG_VIDEO_D5XX_SERDES
+	/*
+	 * Stream-on success path (neither timeout nor stream-off).
+	 * Re-assert serializer GPIO tunneling after reset/recovery and
+	 * start the DES internal FSYNC source at the negotiated FPS.
+	 */
+	if (on && ret >= 0)
+		ds5_post_start_dser_datapath_kick(state, stream_id);
+
 	if (on && ds5_sync_mode_uses_esync(state)) {
 		ds5_set_ser_esync_tunneling(state, true);
 		ds5_set_des_fsync(state, true);
@@ -5405,7 +5869,8 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 #endif
 	if (stream_ctrl_locked)
 		mutex_unlock(&state->ds5_dev->stream_ctrl_lock);
-	ds5_finish_start(state, stream_id, ret);
+	ds5_finish_rgb_start(state, stream_id, ret);
+	ds5_finish_ir_start(state, stream_id, ret);
 	return ret;
 #endif /* !DS5_BYPASS_CAMERA_I2C */
 }

--- a/kernel/realsense/d5xx.c
+++ b/kernel/realsense/d5xx.c
@@ -51,6 +51,9 @@ struct dser_interface {
 	int (*set_pipe)(struct device *dev, int pipe_id, u8 data_type1, u8 data_type2, u32 vc_id);
 	int (*release_pipe)(struct device *dev, int pipe_id);
 	void (*reset_oneshot)(struct device *dev);
+	void (*retrigger_datapath)(struct device *dev);
+	int (*get_active_pipe_count)(struct device *dev);
+	int (*get_link_locked)(struct device *dev);
 	
 	/* Setup and control */
 	int (*setup_link)(struct device *dev, struct device *s_dev);
@@ -185,6 +188,8 @@ struct dser_interface {
 #define DS5_STATUS_INVALID_DT		0x2
 #define DS5_STATUS_INVALID_RES		0x4
 #define DS5_STATUS_INVALID_FPS		0x8
+#define DS5_STATUS_VALID_MASK		0xf
+#define DS5_STATUS_UNAVAILABLE		0xffff
 
 #define MIPI_LANE_RATE				1300
 
@@ -212,7 +217,15 @@ enum ds5_mux_pad {
 
 #define DS5_START_POLL_TIME			10
 #define DS5_START_MAX_TIME			2000
+#define DS5_STOP_MAX_TIME			7000
 #define DS5_START_MAX_COUNT	(DS5_START_MAX_TIME / DS5_START_POLL_TIME)
+#define DS5_RGB_START_DEBOUNCE_MS		300
+#define DS5_RGB_START_WAIT_MS			3000
+#define DS5_IR_START_DEBOUNCE_MS		300
+#define DS5_IR_START_WAIT_MS			3000
+#define DS5_DSER_REARM_COOLDOWN_MS		1800
+#define DS5_DSER_REARM_FALLBACK_MS		700
+#define DS5_DSER_REARM_WAIT_MS			3500
 #define MAX_DS5_CONFIG_RETRIES		5
 
 /* I2C retry configuration */
@@ -443,6 +456,7 @@ struct ds5_sensor {
 	u16 pipe_data_type1;
 	u16 pipe_data_type2;
 	u32 pipe_vc_id;
+	unsigned int pipe_reapply_gen;
 	u16 cached_dt_value;
 	u16 cached_md_value;
 	u16 cached_override_value;
@@ -523,6 +537,7 @@ struct ds5 {
 
 struct ds5_dev {
 	struct mutex lock;
+	struct mutex stream_ctrl_lock;
 
 	/*
 	* Per-camera reset generation counter.
@@ -564,6 +579,10 @@ struct ds5_dev {
 	bool ir_streaming;
 	bool rgb_streaming;
 	bool imu_streaming;
+	bool rgb_start_pending;
+	int rgb_start_error;
+	bool ir_start_pending;
+	int ir_start_error;
 };
 
 #ifdef CONFIG_VIDEO_D5XX_SERDES
@@ -583,6 +602,15 @@ struct dser_control {
 	*/
 	atomic_t reset_gen;
 	struct device *dser_dev;
+	bool datapath_armed;
+	u8 datapath_pipe_mask;
+	bool post_start_kick_pending;
+	bool rearm_pending;
+	bool rearm_started;
+	int rearm_owner_pipe;
+	unsigned int rearm_waiters;
+	unsigned int rearm_gen;
+	unsigned long last_idle_jiffies;
 };
 static struct dser_control dser_inited[MAX_DSER_NUM];
 
@@ -599,6 +627,8 @@ static void ds5_init_global_slots_once(void)
 
 	for (i = 0; i < MAX_DS5_NUM; i++)
 		mutex_init(&ds5_inited[i].lock);
+	for (i = 0; i < MAX_DS5_NUM; i++)
+		mutex_init(&ds5_inited[i].stream_ctrl_lock);
 
 	for (i = 0; i < MAX_DSER_NUM; i++)
 		mutex_init(&dser_inited[i].lock);
@@ -616,6 +646,401 @@ static inline atomic_t *dser_get_reset_gen(struct ds5 *state)
 	return &state->ds5_dev->dser_control->reset_gen;
 }
 
+static bool ds5_dser_datapath_armed(struct ds5 *state)
+{
+	bool armed;
+	struct dser_control *ctrl = state->ds5_dev->dser_control;
+
+	mutex_lock(&ctrl->lock);
+	armed = ctrl->datapath_armed;
+	mutex_unlock(&ctrl->lock);
+
+	return armed;
+}
+
+static void ds5_set_dser_datapath_armed(struct ds5 *state, bool armed)
+{
+	struct dser_control *ctrl = state->ds5_dev->dser_control;
+
+	mutex_lock(&ctrl->lock);
+	ctrl->datapath_armed = armed;
+	if (!armed)
+		ctrl->datapath_pipe_mask = 0;
+	mutex_unlock(&ctrl->lock);
+}
+
+static bool ds5_dser_datapath_matches(struct ds5 *state, u8 pipe_mask)
+{
+	bool matches;
+	struct dser_control *ctrl = state->ds5_dev->dser_control;
+
+	mutex_lock(&ctrl->lock);
+	matches = ctrl->datapath_armed &&
+		  ctrl->datapath_pipe_mask == pipe_mask;
+	mutex_unlock(&ctrl->lock);
+
+	return matches;
+}
+
+static void ds5_set_dser_datapath_pipe_mask(struct ds5 *state, u8 pipe_mask)
+{
+	struct dser_control *ctrl = state->ds5_dev->dser_control;
+
+	mutex_lock(&ctrl->lock);
+	ctrl->datapath_armed = true;
+	ctrl->datapath_pipe_mask = pipe_mask;
+	mutex_unlock(&ctrl->lock);
+}
+
+static bool ds5_dser_post_start_kick_pending(struct ds5 *state)
+{
+	bool pending;
+	struct dser_control *ctrl = state->ds5_dev->dser_control;
+
+	mutex_lock(&ctrl->lock);
+	pending = ctrl->post_start_kick_pending;
+	mutex_unlock(&ctrl->lock);
+
+	return pending;
+}
+
+static void ds5_set_dser_post_start_kick_pending(struct ds5 *state,
+						 bool pending)
+{
+	struct dser_control *ctrl = state->ds5_dev->dser_control;
+
+	mutex_lock(&ctrl->lock);
+	ctrl->post_start_kick_pending = pending;
+	mutex_unlock(&ctrl->lock);
+}
+
+static void ds5_cancel_dser_rearm(struct ds5 *state)
+{
+	struct dser_control *ctrl = state->ds5_dev->dser_control;
+
+	mutex_lock(&ctrl->lock);
+	ctrl->rearm_pending = false;
+	ctrl->rearm_started = false;
+	ctrl->post_start_kick_pending = false;
+	ctrl->rearm_owner_pipe = PIPE_NOT_CONFIGURED;
+	ctrl->rearm_waiters = 0;
+	mutex_unlock(&ctrl->lock);
+}
+
+static void ds5_schedule_dser_rearm(struct ds5 *state, int pipe_id)
+{
+	struct dser_control *ctrl = state->ds5_dev->dser_control;
+
+	mutex_lock(&ctrl->lock);
+	if (!ctrl->rearm_pending) {
+		ctrl->datapath_armed = false;
+		ctrl->rearm_pending = true;
+		ctrl->rearm_started = false;
+		ctrl->rearm_owner_pipe = pipe_id;
+		ctrl->rearm_waiters = 0;
+	}
+	mutex_unlock(&ctrl->lock);
+}
+
+static bool ds5_begin_dser_rearm(struct ds5 *state, int pipe_id,
+				 int *owner_pipe)
+{
+	struct dser_control *ctrl = state->ds5_dev->dser_control;
+	bool can_begin = true;
+
+	mutex_lock(&ctrl->lock);
+	if (ctrl->rearm_pending && ctrl->rearm_started &&
+	    ctrl->rearm_owner_pipe != pipe_id) {
+		can_begin = false;
+		if (owner_pipe)
+			*owner_pipe = ctrl->rearm_owner_pipe;
+	} else {
+		ctrl->datapath_armed = false;
+		ctrl->rearm_pending = true;
+		ctrl->rearm_started = true;
+		ctrl->rearm_owner_pipe = pipe_id;
+		if (owner_pipe)
+			*owner_pipe = pipe_id;
+	}
+	mutex_unlock(&ctrl->lock);
+
+	return can_begin;
+}
+
+static void ds5_mark_dser_rearm_done(struct ds5 *state, bool datapath_armed)
+{
+	struct dser_control *ctrl = state->ds5_dev->dser_control;
+
+	mutex_lock(&ctrl->lock);
+	ctrl->datapath_armed = datapath_armed;
+	ctrl->rearm_pending = false;
+	ctrl->rearm_started = false;
+	ctrl->rearm_owner_pipe = PIPE_NOT_CONFIGURED;
+	ctrl->rearm_waiters = 0;
+	ctrl->rearm_gen++;
+	mutex_unlock(&ctrl->lock);
+}
+
+static unsigned int ds5_dser_rearm_gen(struct ds5 *state)
+{
+	unsigned int gen;
+	struct dser_control *ctrl = state->ds5_dev->dser_control;
+
+	mutex_lock(&ctrl->lock);
+	gen = ctrl->rearm_gen;
+	mutex_unlock(&ctrl->lock);
+
+	return gen;
+}
+
+static unsigned int ds5_started_mipi_streams(struct ds5 *state)
+{
+	unsigned int count = 0;
+
+	mutex_lock(&state->ds5_dev->lock);
+	if (state->ds5_dev->depth_streaming)
+		count++;
+	if (state->ds5_dev->rgb_streaming)
+		count++;
+	if (state->ds5_dev->ir_streaming)
+		count++;
+	if (state->ds5_dev->imu_streaming)
+		count++;
+	mutex_unlock(&state->ds5_dev->lock);
+
+	return count;
+}
+
+static u8 ds5_started_mipi_pipe_mask(struct ds5 *state)
+{
+	u8 mask = 0;
+
+	mutex_lock(&state->ds5_dev->lock);
+	if (state->ds5_dev->depth_streaming)
+		mask |= BIT(0);
+	if (state->ds5_dev->rgb_streaming)
+		mask |= BIT(1);
+	if (state->ds5_dev->ir_streaming)
+		mask |= BIT(2);
+	if (state->ds5_dev->imu_streaming)
+		mask |= BIT(3);
+	mutex_unlock(&state->ds5_dev->lock);
+
+	return mask;
+}
+
+static void ds5_post_start_dser_datapath_kick(struct ds5 *state, u16 stream_id)
+{
+	unsigned int started_streams;
+	u8 active_pipe_mask;
+	int active_pipes;
+	int link_locked;
+
+	mutex_lock(&serdes_lock__);
+	link_locked = state->dser_ops->get_link_locked ?
+		state->dser_ops->get_link_locked(state->dser_dev) : -1;
+	if (link_locked <= 0)
+		goto out;
+
+	active_pipes = state->dser_ops->get_active_pipe_count ?
+		state->dser_ops->get_active_pipe_count(state->dser_dev) : 1;
+	started_streams = ds5_started_mipi_streams(state);
+	active_pipe_mask = ds5_started_mipi_pipe_mask(state);
+	if (started_streams < active_pipes) {
+		dev_info(&state->client->dev,
+			 "stream %u START ok; locked DES datapath unchanged until remaining streams start (%u/%d)\n",
+			 stream_id, started_streams, active_pipes);
+		goto out;
+	}
+
+	if (ds5_dser_datapath_matches(state, active_pipe_mask) &&
+	    !ds5_dser_post_start_kick_pending(state)) {
+		dev_info(&state->client->dev,
+			 "stream %u START ok; keeping locked GMSL Link A unchanged for pipe mask 0x%02x (%u/%d streams started)\n",
+			 stream_id, active_pipe_mask, started_streams, active_pipes);
+		goto out;
+	}
+
+	dev_info(&state->client->dev,
+		 "stream %u START ok; retriggering DES CSI datapath without resetting locked GMSL Link A for pipe mask 0x%02x (%u/%d streams started)\n",
+		 stream_id, active_pipe_mask, started_streams, active_pipes);
+	/* PIPE_EN/mapping retrigger is local to the DES CSI datapath.  ONESHOT
+	 * would reset the whole Link A PHY/data path and invalidate queued VI
+	 * frames, while leaving the datapath untouched does not resynchronize
+	 * tunnel detection after the camera starts transmitting. */
+	state->dser_ops->retrigger_datapath(state->dser_dev);
+	ds5_cancel_dser_rearm(state);
+	ds5_set_dser_datapath_pipe_mask(state, active_pipe_mask);
+	ds5_set_dser_post_start_kick_pending(state, false);
+
+out:
+	mutex_unlock(&serdes_lock__);
+}
+
+static void ds5_wait_for_dser_rearm_cooldown(struct ds5 *state, const char *reason)
+{
+	struct dser_control *ctrl = state->ds5_dev->dser_control;
+	unsigned long last_idle;
+	unsigned long ready;
+	unsigned int wait_ms;
+
+	mutex_lock(&ctrl->lock);
+	last_idle = ctrl->last_idle_jiffies;
+	mutex_unlock(&ctrl->lock);
+
+	if (!last_idle)
+		return;
+
+	ready = last_idle + msecs_to_jiffies(DS5_DSER_REARM_COOLDOWN_MS);
+	if (!time_before(jiffies, ready))
+		return;
+
+	wait_ms = jiffies_to_msecs(ready - jiffies);
+	dev_info(&state->client->dev,
+		 "waiting %u ms before DES datapath re-arm (%s)\n",
+		 wait_ms, reason);
+	msleep(wait_ms);
+}
+
+static bool ds5_rearm_dser_datapath_before_start(struct ds5 *state, int pipe_id,
+						 int active_pipes,
+						 int link_locked,
+						 const char *reason)
+{
+	/* ONESHOT resets the complete Link A PHY and data path, including the
+	 * tunnel carrying remote I2C.  A locked link does not need recovery;
+	 * the post-START path will retrigger only the DES CSI data path. */
+	if (link_locked > 0) {
+		dev_info(&state->client->dev,
+			 "pipe %d pre-start preserving locked Link A (%s, %d pipes active)\n",
+			 pipe_id, reason, active_pipes);
+		return false;
+	}
+
+	ds5_wait_for_dser_rearm_cooldown(state, reason);
+	dev_info(&state->client->dev,
+		 "pipe %d pre-start resetting GMSL Link A PHY and datapath with ONESHOT (%s, %d pipes active, link %s)\n",
+		 pipe_id, reason, active_pipes,
+		 link_locked > 0 ? "locked" :
+		 (link_locked == 0 ? "unlocked" : "unknown"));
+	state->dser_ops->reset_oneshot(state->dser_dev);
+	max96717_retrigger_tx(state->ser_dev);
+	msleep(200);
+	ds5_set_dser_post_start_kick_pending(state, true);
+	return true;
+}
+
+static int ds5_wait_for_dser_rearm(struct ds5 *state, int pipe_id)
+{
+	struct dser_control *ctrl = state->ds5_dev->dser_control;
+	unsigned long timeout;
+	unsigned long fallback_timeout;
+	bool started;
+	bool pending;
+	int owner_pipe;
+
+	if (!state->dser_ops->get_active_pipe_count)
+		return 0;
+
+	mutex_lock(&ctrl->lock);
+	pending = ctrl->rearm_pending;
+	owner_pipe = ctrl->rearm_owner_pipe;
+	if (!pending) {
+		mutex_unlock(&ctrl->lock);
+		return 0;
+	}
+	mutex_unlock(&ctrl->lock);
+
+	dev_info(&state->client->dev,
+		 "pipe %d waiting for DES datapath re-arm owner pipe %d before camera I2C config\n",
+		 pipe_id, owner_pipe);
+	fallback_timeout = jiffies + msecs_to_jiffies(DS5_DSER_REARM_FALLBACK_MS);
+	timeout = jiffies + msecs_to_jiffies(DS5_DSER_REARM_WAIT_MS);
+	do {
+		mutex_lock(&ctrl->lock);
+		pending = ctrl->rearm_pending;
+		started = ctrl->rearm_started;
+		owner_pipe = ctrl->rearm_owner_pipe;
+		mutex_unlock(&ctrl->lock);
+		if (!pending)
+			return 0;
+
+		if (!started && owner_pipe == pipe_id &&
+		    time_after_eq(jiffies, fallback_timeout)) {
+			int active_pipes;
+			int link_locked;
+
+			if (!ds5_begin_dser_rearm(state, pipe_id, &owner_pipe))
+				continue;
+
+			active_pipes = state->dser_ops->get_active_pipe_count ?
+				state->dser_ops->get_active_pipe_count(state->dser_dev) : 1;
+			link_locked = state->dser_ops->get_link_locked ?
+				state->dser_ops->get_link_locked(state->dser_dev) : -1;
+
+			dev_info(&state->client->dev,
+				 "pipe %d fallback re-arming DES datapath after waiting for pipe 0\n",
+				 pipe_id);
+			mutex_lock(&serdes_lock__);
+			ds5_mark_dser_rearm_done(state,
+				ds5_rearm_dser_datapath_before_start(state, pipe_id,
+								      active_pipes,
+								      link_locked,
+								      "fallback owner"));
+			mutex_unlock(&serdes_lock__);
+			return 0;
+		}
+		msleep(20);
+	} while (time_before(jiffies, timeout));
+
+	dev_warn(&state->client->dev,
+		 "pipe %d timed out waiting for DES datapath re-arm owner pipe %d\n",
+		 pipe_id, owner_pipe);
+	return -ETIMEDOUT;
+}
+
+static void ds5_disarm_dser_datapath_if_idle(struct ds5 *state)
+{
+	int active_pipes;
+	int link_locked;
+	bool armed;
+	bool pending;
+	struct dser_control *ctrl = state->ds5_dev->dser_control;
+
+	if (!state->dser_ops->get_active_pipe_count)
+		return;
+
+	active_pipes = state->dser_ops->get_active_pipe_count(state->dser_dev);
+	if (active_pipes != 0)
+		return;
+
+	link_locked = state->dser_ops->get_link_locked ?
+		state->dser_ops->get_link_locked(state->dser_dev) : -1;
+	mutex_lock(&ctrl->lock);
+	armed = ctrl->datapath_armed;
+	pending = ctrl->rearm_pending;
+	ctrl->datapath_armed = false;
+	ctrl->datapath_pipe_mask = 0;
+	ctrl->post_start_kick_pending = false;
+	ctrl->rearm_pending = false;
+	ctrl->rearm_started = false;
+	ctrl->rearm_owner_pipe = PIPE_NOT_CONFIGURED;
+	ctrl->rearm_waiters = 0;
+	ctrl->last_idle_jiffies = jiffies;
+	mutex_unlock(&ctrl->lock);
+
+	if (link_locked > 0) {
+		if (armed || pending)
+			dev_info(&state->client->dev,
+				 "all DES pipes released; preserving locked Link A for next start\n");
+		return;
+	}
+
+	if (armed || pending)
+		dev_info(&state->client->dev,
+			 "all DES pipes released; datapath marked unarmed for cooldown\n");
+}
+
 /* MAX96724 deserializer interface implementation */
 static const struct dser_interface max96724_interface = {
 	.get_available_pipe_id = max96724_get_available_pipe_id,
@@ -624,6 +1049,9 @@ static const struct dser_interface max96724_interface = {
 	.set_pipe = max96724_set_pipe,
 	.release_pipe = max96724_release_pipe,
 	.reset_oneshot = max96724_reset_oneshot,
+	.retrigger_datapath = max96724_retrigger_datapath,
+	.get_active_pipe_count = max96724_active_pipe_count,
+	.get_link_locked = max96724_link_locked,
 	.setup_link = max96724_setup_link,
 	.setup_control = max96724_setup_control,
 	.reset_control = max96724_reset_control,
@@ -655,6 +1083,7 @@ static void ds5_init_global_slots_once(void)
 	mutex_lock(&ds5_slots_lock__);
 	if (!ds5_slots_inited) {
 		mutex_init(&ds5_inited[0].lock);
+		mutex_init(&ds5_inited[0].stream_ctrl_lock);
 		ds5_slots_inited = true;
 	}
 	mutex_unlock(&ds5_slots_lock__);
@@ -731,8 +1160,64 @@ static int ds5_write(struct ds5 *state, u16 reg, u16 val)
 	return ret;
 }
 
+static int ds5_write_then_read(struct ds5 *state, u16 write_reg, u16 write_val,
+			       u16 read_reg, u16 *read_val)
+{
+	struct i2c_client *client = state->client;
+	u8 write_buf[4] = {
+		write_reg & 0xff, write_reg >> 8,
+		write_val & 0xff, write_val >> 8,
+	};
+	u8 read_reg_buf[2] = { read_reg & 0xff, read_reg >> 8 };
+	u8 read_buf[2];
+	u16 flags = client->flags & I2C_M_TEN;
+	struct i2c_msg msgs[] = {
+		{
+			.addr = client->addr,
+			.flags = flags,
+			.len = sizeof(write_buf),
+			.buf = write_buf,
+		},
+		{
+			.addr = client->addr,
+			.flags = flags,
+			.len = sizeof(read_reg_buf),
+			.buf = read_reg_buf,
+		},
+		{
+			.addr = client->addr,
+			.flags = flags | I2C_M_RD,
+			.len = sizeof(read_buf),
+			.buf = read_buf,
+		},
+	};
+	int retry;
+	int ret = -EIO;
+
+	/* Keep the command and its first status read in one adapter transaction.
+	 * Repeated STARTs provide an unambiguous boundary to the remote slave even
+	 * when its polling task is scheduled after all address bytes have arrived. */
+	for (retry = 0; retry < DS5_I2C_RETRY_COUNT; retry++) {
+		ret = i2c_transfer(client->adapter, msgs, ARRAY_SIZE(msgs));
+		if (ret == ARRAY_SIZE(msgs)) {
+			*read_val = read_buf[0] | ((u16)read_buf[1] << 8);
+			return 0;
+		}
+		if (ret >= 0)
+			ret = -EIO;
+		if (retry < DS5_I2C_RETRY_COUNT - 1)
+			usleep_range(DS5_I2C_RETRY_DELAY_US,
+				     DS5_I2C_RETRY_DELAY_US + 500);
+	}
+
+	dev_err(&client->dev,
+		"%s(): i2c write/read failed after %d retries, 0x%04x = 0x%x -> 0x%04x, err %d\n",
+		__func__, DS5_I2C_RETRY_COUNT, write_reg, write_val, read_reg, ret);
+	return ret;
+}
+
 static int ds5_raw_write(struct ds5 *state, u16 reg,
-		const void *val, size_t val_len)
+			const void *val, size_t val_len)
 {
 	int ret;
 	int retry;
@@ -1343,6 +1828,15 @@ static int ds5_setup_pipeline(struct ds5 *state, u8 data_type1, u8 data_type2,
 	 */
 	int ser_vc_id = vc_id % DS5_MAX_STREAMS;
 	int ser_pipe_id = state->dser_ops->get_ser_pipe_id(state->dser_dev, pipe_id, ser_vc_id);
+	int active_pipes = (state->dser_ops->get_active_pipe_count != NULL) ?
+		state->dser_ops->get_active_pipe_count(state->dser_dev) : 1;
+	int link_locked = (state->dser_ops->get_link_locked != NULL) ?
+		state->dser_ops->get_link_locked(state->dser_dev) : -1;
+	bool datapath_armed = ds5_dser_datapath_armed(state);
+
+	if (link_locked > 0 && !datapath_armed && active_pipes <= 1)
+		dev_info(&state->client->dev,
+			 "link locked; DES datapath retrigger will run after camera START\n");
 
 	ret |= state->dser_ops->bind_ser_to_dser_pipe(state->dser_dev, pipe_id, ser_pipe_id, vc_id);
 	dev_dbg(&state->client->dev,
@@ -1352,12 +1846,53 @@ static int ds5_setup_pipeline(struct ds5 *state, u8 data_type1, u8 data_type2,
 				data_type1, data_type2, ser_vc_id);
 	ret |= state->dser_ops->set_pipe(state->dser_dev, pipe_id,
 				data_type1, data_type2, vc_id);
-	state->dser_ops->reset_oneshot(state->dser_dev);
-	/* DES ONESHOT resets the data path; SER must retrigger TX for
-	 * the DES to re-acquire the tunnel stream.
+	if (ret >= 0 && link_locked > 0 && datapath_armed) {
+		unsigned int started_streams = ds5_started_mipi_streams(state);
+
+		dev_info(&state->client->dev,
+			 "pipe %d mapping updated while DES datapath armed (%u streams active); keeping datapath armed\n",
+			 pipe_id, started_streams);
+	}
+	/*
+	 * Prefer pipe 0 as the deterministic re-arm owner.  If RGB/IR arrives
+	 * first, it maps its pipe and waits before camera-side I2C config until
+	 * depth/pipe 0 performs the early re-arm.  On an already-locked link,
+	 * avoid ONESHOT and only retrigger the DES CSI datapath before START.
 	 */
-	max96717_retrigger_tx(state->ser_dev);
-	msleep(200);
+	if (pipe_id == 0 && (link_locked <= 0 || !datapath_armed)) {
+		int owner_pipe = PIPE_NOT_CONFIGURED;
+
+		dev_info(&state->client->dev,
+			 "pipe 0 re-arming DES datapath before camera I2C config (link %s, armed=%d, active_pipes=%d)\n",
+			 link_locked > 0 ? "locked" :
+			 (link_locked == 0 ? "unlocked" : "unknown"),
+			 datapath_armed, active_pipes);
+		if (ds5_begin_dser_rearm(state, pipe_id, &owner_pipe)) {
+			datapath_armed =
+				ds5_rearm_dser_datapath_before_start(state, pipe_id,
+								      active_pipes,
+								      link_locked,
+								      "pipe 0");
+			ds5_mark_dser_rearm_done(state, datapath_armed);
+		} else {
+			dev_info(&state->client->dev,
+				 "pipe 0 waiting for active DES datapath re-arm owner pipe %d\n",
+				 owner_pipe);
+		}
+	} else if (active_pipes <= 1 && !datapath_armed) {
+		dev_info(&state->client->dev,
+			 "first non-depth pipe %d scheduling DES datapath re-arm for pipe 0 (link %s, armed=%d)\n",
+			 pipe_id, link_locked > 0 ? "locked" :
+			 (link_locked == 0 ? "unlocked" : "unknown"),
+			 datapath_armed);
+		ds5_schedule_dser_rearm(state, pipe_id);
+	} else {
+		dev_info(&state->client->dev,
+			 "pipe %d mapping updated w/o link reset (%d pipes active, link %s)\n",
+			 pipe_id, active_pipes,
+			 link_locked > 0 ? "locked" :
+			 (link_locked == 0 ? "unlocked" : "unknown"));
+	}
 	if (ret)
 		dev_warn(&state->client->dev,
 			 "failed to set pipe %d, data_type1: 0x%x, data_type2: 0x%x, vc_id: %u\n",
@@ -1390,6 +1925,7 @@ static void ds5_invalidate_sensor(struct ds5 *state, struct ds5_sensor *sensor)
 	sensor->pipe_data_type1 = 0;
 	sensor->pipe_data_type2 = 0;
 	sensor->pipe_vc_id = 0xFFFF;
+	sensor->pipe_reapply_gen = 0;
 }
 
 static int ds5_configure(struct ds5 *state)
@@ -1399,6 +1935,7 @@ static int ds5_configure(struct ds5 *state)
 #ifdef CONFIG_VIDEO_D5XX_SERDES
 	u16 data_type1, data_type2;
 	bool is_calib = 0;
+	unsigned int pipe_reapply_gen;
 #endif
 #if !DS5_BYPASS_CAMERA_I2C
 	u16 dt_addr, md_addr, override_addr, fps_addr, width_addr, height_addr;
@@ -1472,8 +2009,11 @@ static int ds5_configure(struct ds5 *state)
 		if (sensor->pipe_id >= 0) {
 			mutex_lock(&serdes_lock__);
 			ret = state->dser_ops->release_pipe(state->dser_dev, sensor->pipe_id);
+			if (ret >= 0)
+				ds5_disarm_dser_datapath_if_idle(state);
 			mutex_unlock(&serdes_lock__);
 			dev_warn(&state->client->dev, "release pipe %d (%d)\n", sensor->pipe_id, ret);
+			sensor->pipe_reapply_gen = 0;
 		}
 		/*
 		* Serialize SERDES pipe allocation and configuration
@@ -1490,6 +2030,8 @@ static int ds5_configure(struct ds5 *state)
 			dev_err(&state->client->dev, "No free pipe in %s\n",state->dser_ops->name);
 			return -ENOSR;
 		}
+		pipe_reapply_gen = ds5_dser_rearm_gen(state);
+		sensor->pipe_reapply_gen = pipe_reapply_gen;
 		mutex_lock(&serdes_lock__);
 		ret = ds5_setup_pipeline(state, data_type1, data_type2,
 					 sensor->pipe_id, vc_id);
@@ -1513,6 +2055,34 @@ static int ds5_configure(struct ds5 *state)
 		dev_info(&state->client->dev,
 				"pipe %d already configured (dt1=0x%x dt2=0x%x vc=%u)\n",
 				sensor->pipe_id, data_type1, data_type2, vc_id);
+	}
+
+	ret = ds5_wait_for_dser_rearm(state, sensor->pipe_id);
+	if (ret < 0)
+		return ret;
+
+	pipe_reapply_gen = ds5_dser_rearm_gen(state);
+	if (sensor->pipe_reapply_gen != pipe_reapply_gen) {
+		mutex_lock(&serdes_lock__);
+		ret = ds5_setup_pipeline(state, data_type1, data_type2,
+					 sensor->pipe_id, vc_id);
+		mutex_unlock(&serdes_lock__);
+		if (ret < 0) {
+			dev_err(&state->client->dev,
+				"pipe %d re-apply after DES re-arm FAILED (dt1=0x%x dt2=0x%x vc=%u gen=%u->%u) ret=%d\n",
+				sensor->pipe_id, data_type1, data_type2, vc_id,
+				sensor->pipe_reapply_gen, pipe_reapply_gen, ret);
+			return ret;
+		}
+		dev_info(&state->client->dev,
+			 "pipe %d re-applied after DES re-arm (dt1=0x%x dt2=0x%x vc=%u gen=%u)\n",
+			 sensor->pipe_id, data_type1, data_type2, vc_id,
+			 pipe_reapply_gen);
+		sensor->pipe_reapply_gen = pipe_reapply_gen;
+	} else {
+		dev_dbg(&state->client->dev,
+			"pipe %d already applied for DES re-arm gen %u (dt1=0x%x dt2=0x%x vc=%u)\n",
+			sensor->pipe_id, pipe_reapply_gen, data_type1, data_type2, vc_id);
 	}
 #else /* Non-SERDES configuration */
 	vc_id = (state->is_depth) ? 0 : (state->is_rgb) ? 1 : (state->is_y8) ? 2 : 3;
@@ -2037,8 +2607,214 @@ static void ds5_reset_streaming_flags(struct ds5_dev *ds5_dev)
 	ds5_dev->ir_streaming = false;
 	ds5_dev->rgb_streaming = false;
 	ds5_dev->imu_streaming = false;
+	ds5_dev->rgb_start_pending = false;
+	ds5_dev->rgb_start_error = 0;
+	ds5_dev->ir_start_pending = false;
+	ds5_dev->ir_start_error = 0;
 	mutex_unlock(&ds5_dev->lock);
 }
+
+static void ds5_set_rgb_start_pending(struct ds5 *state, u16 stream_id, bool pending)
+{
+	if (stream_id != DS5_STREAM_RGB)
+		return;
+
+	mutex_lock(&state->ds5_dev->lock);
+	state->ds5_dev->rgb_start_pending = pending;
+	if (pending)
+		state->ds5_dev->rgb_start_error = 0;
+	mutex_unlock(&state->ds5_dev->lock);
+}
+
+static void ds5_finish_rgb_start(struct ds5 *state, u16 stream_id, int ret)
+{
+	if (stream_id != DS5_STREAM_RGB)
+		return;
+
+	mutex_lock(&state->ds5_dev->lock);
+	state->ds5_dev->rgb_start_error = ret < 0 ? ret : 0;
+	state->ds5_dev->rgb_start_pending = false;
+	mutex_unlock(&state->ds5_dev->lock);
+}
+
+static bool ds5_rgb_start_state(struct ds5 *state, int *error)
+{
+	bool pending;
+
+	mutex_lock(&state->ds5_dev->lock);
+	pending = state->ds5_dev->rgb_start_pending;
+	if (error)
+		*error = state->ds5_dev->rgb_start_error;
+	mutex_unlock(&state->ds5_dev->lock);
+
+	return pending;
+}
+
+static int ds5_wait_for_rgb_start_before_stereo(struct ds5 *state, u16 stream_id)
+{
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+	unsigned long discover_timeout;
+	unsigned long timeout;
+	int rgb_error = 0;
+
+	if (stream_id == DS5_STREAM_RGB || stream_id == DS5_STREAM_IMU)
+		return 0;
+
+	/*
+	 * RGB joining an already-streaming stereo pipe can stall the shared HIF
+	 * CSI TX task (FW reports frame counter N, ack N-2).  Give a concurrent
+	 * RGB START a short window to announce itself, then let it complete first.
+	 */
+	discover_timeout = jiffies + msecs_to_jiffies(DS5_RGB_START_DEBOUNCE_MS);
+	while (!ds5_rgb_start_state(state, &rgb_error)) {
+		if (!time_before(jiffies, discover_timeout))
+			return 0;
+		msleep(20);
+	}
+
+	dev_info(&state->client->dev,
+		 "stream %d waiting for RGB START to complete before stereo START\n",
+		 stream_id);
+	timeout = jiffies + msecs_to_jiffies(DS5_RGB_START_WAIT_MS);
+	while (ds5_rgb_start_state(state, &rgb_error)) {
+		if (!time_before(jiffies, timeout)) {
+			dev_warn(&state->client->dev,
+				 "stream %d timed out waiting for RGB START; aborting stereo START\n",
+				 stream_id);
+			return -ETIMEDOUT;
+		}
+		msleep(20);
+	}
+
+	if (rgb_error < 0) {
+		dev_warn(&state->client->dev,
+			 "stream %d observed RGB START failure (%d); aborting stereo START\n",
+			 stream_id, rgb_error);
+		return rgb_error;
+	}
+
+	dev_info(&state->client->dev,
+		 "stream %d observed RGB START complete; continuing stereo START\n",
+		 stream_id);
+	return 0;
+#else
+	(void)state;
+	(void)stream_id;
+	return 0;
+#endif
+}
+
+static void ds5_set_ir_start_pending(struct ds5 *state, u16 stream_id, bool pending)
+{
+	if (stream_id != DS5_STREAM_IR)
+		return;
+
+	mutex_lock(&state->ds5_dev->lock);
+	state->ds5_dev->ir_start_pending = pending;
+	if (pending)
+		state->ds5_dev->ir_start_error = 0;
+	mutex_unlock(&state->ds5_dev->lock);
+}
+
+static void ds5_finish_ir_start(struct ds5 *state, u16 stream_id, int ret)
+{
+	if (stream_id != DS5_STREAM_IR)
+		return;
+
+	mutex_lock(&state->ds5_dev->lock);
+	state->ds5_dev->ir_start_error = ret < 0 ? ret : 0;
+	state->ds5_dev->ir_start_pending = false;
+	mutex_unlock(&state->ds5_dev->lock);
+}
+
+static bool ds5_ir_start_state(struct ds5 *state, int *error)
+{
+	bool pending;
+
+	mutex_lock(&state->ds5_dev->lock);
+	pending = state->ds5_dev->ir_start_pending;
+	if (error)
+		*error = state->ds5_dev->ir_start_error;
+	mutex_unlock(&state->ds5_dev->lock);
+
+	return pending;
+}
+
+static int ds5_wait_for_ir_start_before_depth(struct ds5 *state, u16 stream_id)
+{
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+	unsigned long discover_timeout;
+	unsigned long timeout;
+	int ir_error = 0;
+
+	if (stream_id != DS5_STREAM_DEPTH)
+		return 0;
+
+	/* The PR #282 FW keeps one gated stereo pipeline alive, so IR can build
+	 * it first and Depth can enable its pre-built branch without a rebuild. */
+	discover_timeout = jiffies + msecs_to_jiffies(DS5_IR_START_DEBOUNCE_MS);
+	while (!ds5_ir_start_state(state, &ir_error)) {
+		if (!time_before(jiffies, discover_timeout))
+			return 0;
+		msleep(20);
+	}
+
+	dev_info(&state->client->dev,
+		 "stream %d waiting for IR START to complete before depth gate\n",
+		 stream_id);
+	timeout = jiffies + msecs_to_jiffies(DS5_IR_START_WAIT_MS);
+	while (ds5_ir_start_state(state, &ir_error)) {
+		if (!time_before(jiffies, timeout)) {
+			dev_warn(&state->client->dev,
+				 "stream %d timed out waiting for IR START; aborting depth START\n",
+				 stream_id);
+			return -ETIMEDOUT;
+		}
+		msleep(20);
+	}
+
+	if (ir_error < 0) {
+		dev_warn(&state->client->dev,
+			 "stream %d observed IR START failure (%d); aborting depth START\n",
+			 stream_id, ir_error);
+		return ir_error;
+	}
+
+	dev_info(&state->client->dev,
+		 "stream %d observed IR START complete; enabling depth gate\n",
+		 stream_id);
+	return 0;
+#else
+	(void)state;
+	(void)stream_id;
+	return 0;
+#endif
+}
+
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+static void ds5_release_serdes_pipe(struct ds5 *state,
+				    struct ds5_sensor *sensor,
+				    const char *reason)
+{
+	int ret;
+
+	if (!sensor || sensor->pipe_id < 0)
+		return;
+
+	mutex_lock(&serdes_lock__);
+	ret = state->dser_ops->release_pipe(state->dser_dev, sensor->pipe_id);
+	if (ret < 0) {
+		dev_warn(&state->client->dev,
+			 "release pipe %d failed after %s (%d)\n",
+			 sensor->pipe_id, reason, ret);
+	} else {
+		ds5_disarm_dser_datapath_if_idle(state);
+		sensor->pipe_id = PIPE_NOT_CONFIGURED;
+		sensor->pipe_reapply_gen = 0;
+	}
+	mutex_unlock(&serdes_lock__);
+}
+#endif
 
 static int ds5_set_ser_esync_tunneling(struct ds5 *state, bool enable)
 {
@@ -2239,6 +3015,10 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	atomic_inc(ds5_get_reset_gen(state));
 	WRITE_ONCE(state->ds5_dev->cached_device_type, DS5_DEVICE_TYPE_UNKNOWN);
 	ds5_reset_streaming_flags(state->ds5_dev);
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+	ds5_set_dser_datapath_armed(state, false);
+	ds5_cancel_dser_rearm(state);
+#endif
 
 	/* 3. Scratch one control-status register before reset.
 	 *    FW restores them to default 0x0000 only after reset completes.
@@ -3375,6 +4155,11 @@ static int ds5_setup_and_link(struct ds5 *state)
 						mutex_lock(&dser_inited[j].lock);
 						if (NULL == dser_inited[j].dser_dev) {
 							dser_inited[j].dser_dev = state->dser_dev;
+							dser_inited[j].datapath_armed = false;
+							dser_inited[j].rearm_pending = false;
+							dser_inited[j].rearm_started = false;
+							dser_inited[j].rearm_owner_pipe = PIPE_NOT_CONFIGURED;
+							dser_inited[j].rearm_waiters = 0;
 							state->ds5_dev->dser_control = &dser_inited[j];
 						}
 						mutex_unlock(&dser_inited[j].lock);
@@ -4089,6 +4874,7 @@ static int ds5_sensor_init(struct i2c_client *c, struct ds5 *state,
 	char suffix = dpdata->suffix;
 #endif
 	sensor->pipe_id = PIPE_NOT_CONFIGURED;
+	sensor->pipe_reapply_gen = 0;
 	v4l2_i2c_subdev_init(sd, c, ops);
 	/* See tegracam_v4l2.c tegracam_v4l2subdev_register() */
 	/* Set owner to NULL so we can unload the driver module */
@@ -4641,8 +5427,11 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 			mutex_lock(&serdes_lock__);
 			if (state->dser_ops->release_pipe(state->dser_dev, sensor->pipe_id) < 0)
 				dev_warn(&state->client->dev, "release pipe failed\n");
-			else
+			else {
+				ds5_disarm_dser_datapath_if_idle(state);
 				sensor->pipe_id = PIPE_NOT_CONFIGURED;
+				sensor->pipe_reapply_gen = 0;
+			}
 			mutex_unlock(&serdes_lock__);
 		}
 		/*
@@ -4671,6 +5460,8 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 	u16 expected_streaming_state;
 	bool ds5_config_done = !on; /* for stop, skip config */
 	bool reset_invalidated = false;
+	bool stream_ctrl_locked = false;
+	bool command_read_status;
 	bool *streaming_flag = NULL;
 #ifdef CONFIG_VIDEO_D5XX_SERDES
 	int cur_dser = atomic_read(dser_get_reset_gen(state));
@@ -4679,24 +5470,6 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 #endif
 	int cur_ds5 = atomic_read(ds5_get_reset_gen(state));
 
-	/* 
-	 * Lazy invalidation after HW or deserializer reset.
-	 * Detect gen-counter bumps, clear stale streaming/config/pipe
-	 * state, then update refs.  Must run before the duplicate-call
-	 * guard so a reset-killed stream is not mistaken for "already off".
-	 */
-	if (state->reset_ref_ds5 != cur_ds5
-			|| state->reset_ref_dser != cur_dser) {
-		ds5_invalidate_sensor(state, sensor);
-		sensor->streaming = false;
-		reset_invalidated = true;
-		state->reset_ref_ds5 = cur_ds5;
-		state->reset_ref_dser = cur_dser;
-	}
-
-	/* spare duplicate calls */
-	if (sensor->streaming == on)
-		return 0;
 	if (state->is_depth) {
 		config_status_base = DS5_DEPTH_CONFIG_STATUS;
 		stream_status_base = DS5_DEPTH_STREAM_STATUS;
@@ -4732,6 +5505,30 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 	dev_dbg(&state->client->dev, "s_stream for stream %s, vc:%d, SENSOR=%s on = %d\n",
 			sensor->sd.name, vc_id, ds5_get_sensor_name(state), on);
 
+	/*
+	 * Lazy invalidation after HW or deserializer reset.
+	 * Detect gen-counter bumps, clear stale streaming/config/pipe
+	 * state, then update refs.  Must run before the duplicate-call
+	 * guard so a reset-killed stream is not mistaken for "already off".
+	 */
+	if (state->reset_ref_ds5 != cur_ds5
+			|| state->reset_ref_dser != cur_dser) {
+		ds5_invalidate_sensor(state, sensor);
+		sensor->streaming = false;
+		reset_invalidated = true;
+		state->reset_ref_ds5 = cur_ds5;
+		state->reset_ref_dser = cur_dser;
+	}
+
+	/* spare duplicate calls */
+	if (sensor->streaming == on)
+		return 0;
+
+	if (on) {
+		ds5_set_rgb_start_pending(state, stream_id, true);
+		ds5_set_ir_start_pending(state, stream_id, true);
+	}
+
 	if (on) {
 		stream_cmd = (DS5_STREAM_START | stream_id);
 		expected_streaming_state = DS5_STREAM_STREAMING;
@@ -4742,15 +5539,81 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		status = DS5_STATUS_STREAMING;
 	}
 
+	if (on) {
+		ret = ds5_wait_for_rgb_start_before_stereo(state, stream_id);
+		if (ret < 0) {
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+			ds5_release_serdes_pipe(state, sensor, "RGB START dependency failure");
+#endif
+			ds5_finish_rgb_start(state, stream_id, ret);
+			ds5_finish_ir_start(state, stream_id, ret);
+			return ret;
+		}
+		ret = ds5_wait_for_ir_start_before_depth(state, stream_id);
+		if (ret < 0) {
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+			ds5_release_serdes_pipe(state, sensor, "IR START dependency failure");
+#endif
+			ds5_finish_rgb_start(state, stream_id, ret);
+			ds5_finish_ir_start(state, stream_id, ret);
+			return ret;
+		}
+	}
+
+	/* START changes pipeline topology and remains fully serialized. STOP only
+	 * serializes the shared command-register write; each stream then drains
+	 * and polls independently, so control I2C remains usable while another
+	 * HKR data path is stopping. */
+	if (on) {
+		mutex_lock(&state->ds5_dev->stream_ctrl_lock);
+		stream_ctrl_locked = true;
+	}
+
+	if (on) {
+		ret = ds5_configure(state);
+		if (ret < 0) {
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+			ds5_release_serdes_pipe(state, sensor, "stream configure failure");
+#endif
+			mutex_unlock(&state->ds5_dev->stream_ctrl_lock);
+			stream_ctrl_locked = false;
+			ds5_finish_rgb_start(state, stream_id, ret);
+			ds5_finish_ir_start(state, stream_id, ret);
+			return ret;
+		}
+		ds5_config_done = true;
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+		if (state->dser_ops->get_active_pipe_count &&
+		    state->dser_ops->get_active_pipe_count(state->dser_dev) == 1) {
+			dev_info(&state->client->dev,
+				 "first active pipe configured; yielding briefly before START\n");
+			msleep(80);
+		}
+#endif
+	}
+
 	/* Verify stream is in the expected state before issuing command */
 	ts = jiffies;
-	for (timeout = ts + msecs_to_jiffies(DS5_START_MAX_TIME), i = 0;
+	for (timeout = ts + msecs_to_jiffies(on ? DS5_START_MAX_TIME :
+							 DS5_STOP_MAX_TIME), i = 0;
 			time_before(jiffies, timeout); i++, msleep_range(i*DS5_START_POLL_TIME))
 	{
 		ret = ds5_read(state, config_status_base, &status);
-		if ((ret >= 0) && (on == !(status & DS5_STATUS_STREAMING))) {
+		if (ret < 0 || status == DS5_STATUS_UNAVAILABLE ||
+		    (status & ~DS5_STATUS_VALID_MASK))
+			continue;
+		if (on == !(status & DS5_STATUS_STREAMING)) {
 			break;
 		}
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+		if (on && status != DS5_STATUS_UNAVAILABLE &&
+		    (status & DS5_STATUS_STREAMING)) {
+			dev_info(&state->client->dev,
+				 "stream %d already reports streaming before START; treating as already started\n",
+				 stream_id);
+			break;
+		}
+#endif
 	}
 	if (on == !(status & DS5_STATUS_STREAMING))
 	{
@@ -4758,15 +5621,18 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 			"stream %d in expected state, toggling to %d (status: 0x%04x) %dms\n",
 			stream_id, on, status, jiffies_to_msecs(jiffies - ts));
 	} else {
-		/* 
-		 * If state was invalidated by reset-generation bump and FW still
-		 * reports this stream as active, force a stop to guarantee next
-		 * start goes through full reconfiguration.
+		/*
+		 * If state was invalidated by a reset-generation bump and FW
+		 * still reports this stream as active, force a stop to guarantee
+		 * the next start goes through full reconfiguration.  During a
+		 * normal batched stereo/RGB start, another stream may legitimately
+		 * bring the shared datapath up first; treat that as an already-on
+		 * no-op below.
 		 */
 		if (on && reset_invalidated && (status & DS5_STATUS_STREAMING)) {
 			dev_warn(&state->client->dev,
-				"stream %d reports streaming after reset invalidation (status: 0x%04x), forcing stop and reconfigure\n",
-				stream_id, status);
+				"stream %d reports streaming while host state is off (status: 0x%04x, reset_invalidated=%d), forcing stop and reconfigure\n",
+				stream_id, status, reset_invalidated);
 
 			ret = ds5_write(state, DS5_START_STOP_STREAM,
 					DS5_STREAM_STOP | stream_id);
@@ -4794,6 +5660,16 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 			*streaming_flag = on;
 			mutex_unlock(&state->ds5_dev->lock);
 			sensor->streaming = on;
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+			if (on)
+				ds5_post_start_dser_datapath_kick(state, stream_id);
+#endif
+			if (stream_ctrl_locked) {
+				mutex_unlock(&state->ds5_dev->stream_ctrl_lock);
+				stream_ctrl_locked = false;
+			}
+			ds5_finish_rgb_start(state, stream_id, 0);
+			ds5_finish_ir_start(state, stream_id, 0);
 			return 0;
 		}
 	}
@@ -4810,14 +5686,22 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 	 */
 	ts = jiffies;
 	streaming = ~expected_streaming_state; /* force initial toggle */
-	for (timeout = ts + msecs_to_jiffies(DS5_START_MAX_TIME), i = 0;
-			time_before(jiffies, timeout); i++, msleep_range(i*DS5_START_POLL_TIME))
-	{
-		if (!ds5_config_done) {
+		for (timeout = ts + msecs_to_jiffies(on ? DS5_START_MAX_TIME :
+								 DS5_STOP_MAX_TIME), i = 0;
+				time_before(jiffies, timeout); i++, msleep_range(i*DS5_START_POLL_TIME))
+		{
+			command_read_status = false;
+			if (!ds5_config_done) {
 			ret = ds5_configure(state);
 			if (ret < 0) {
 				if (ret == -ENOSR) {
 					/* No recovery can help if no resources are available */
+					if (stream_ctrl_locked) {
+						mutex_unlock(&state->ds5_dev->stream_ctrl_lock);
+						stream_ctrl_locked = false;
+					}
+					ds5_finish_rgb_start(state, stream_id, ret);
+					ds5_finish_ir_start(state, stream_id, ret);
 					return ret;
 				}
 				dev_warn(&state->client->dev, "stream %d config failed, retry %d, %dms\n",
@@ -4827,16 +5711,24 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 			ds5_config_done = true;
 		}
 
-		if (streaming != expected_streaming_state) {
-			ret = ds5_write(state, DS5_START_STOP_STREAM, stream_cmd);
-			if (ret < 0) {
-				dev_warn(&state->client->dev, "stream %d cmd 0x%x write failed, retry %d, %dms\n",
-					stream_id, stream_cmd, i, jiffies_to_msecs(jiffies - ts));
+			if (streaming != expected_streaming_state) {
+				if (!on)
+					mutex_lock(&state->ds5_dev->stream_ctrl_lock);
+				ret = ds5_write_then_read(state, DS5_START_STOP_STREAM,
+							  stream_cmd, stream_status_base,
+							  &streaming);
+				if (!on)
+					mutex_unlock(&state->ds5_dev->stream_ctrl_lock);
+				if (ret < 0) {
+					dev_warn(&state->client->dev, "stream %d cmd 0x%x write failed, retry %d, %dms\n",
+						stream_id, stream_cmd, i, jiffies_to_msecs(jiffies - ts));
+				} else
+					command_read_status = true;
 			}
-		}
 
-		ret = ds5_read(state, stream_status_base, &streaming);
-		if (ret < 0) {
+			if (!command_read_status)
+				ret = ds5_read(state, stream_status_base, &streaming);
+			if (ret < 0) {
 			dev_warn(&state->client->dev,
 				"stream %d status i2c read failed (%d), retry %u, %dms\n",
 				stream_id, ret, i, jiffies_to_msecs(jiffies - ts));
@@ -4853,6 +5745,14 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 			dev_warn(&state->client->dev,
 				"stream %d config status i2c read failed (%d), retry %u, %dms\n",
 				stream_id, ret, i, jiffies_to_msecs(jiffies - ts));
+			continue;
+		}
+
+		if (status == DS5_STATUS_UNAVAILABLE ||
+		    (status & ~DS5_STATUS_VALID_MASK)) {
+			dev_warn(&state->client->dev,
+				"stream %d config status invalid/unavailable (0x%04x), retry %u, %dms\n",
+				stream_id, status, i, jiffies_to_msecs(jiffies - ts));
 			continue;
 		}
 
@@ -4892,18 +5792,25 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 			stream_id, on, jiffies_to_msecs(jiffies - ts), i);
 
 		if (streaming == expected_streaming_state) { /* try to toggle stream back on timeout  */
+			if (!on)
+				mutex_lock(&state->ds5_dev->stream_ctrl_lock);
 			ds5_write(state, DS5_START_STOP_STREAM,
 				(on ? DS5_STREAM_STOP : DS5_STREAM_START) | stream_id);
+			if (!on)
+				mutex_unlock(&state->ds5_dev->stream_ctrl_lock);
 		}
 #ifdef CONFIG_VIDEO_D5XX_SERDES
 		if (on && sensor->pipe_id >= 0) {
 			mutex_lock(&serdes_lock__);
 			ret = state->dser_ops->release_pipe(state->dser_dev, sensor->pipe_id);
+			if (ret >= 0)
+				ds5_disarm_dser_datapath_if_idle(state);
 			mutex_unlock(&serdes_lock__);
 			if (ret < 0) {
 				dev_warn(&state->client->dev, "release pipe failed\n");
 			} else {
 				sensor->pipe_id = PIPE_NOT_CONFIGURED;
+				sensor->pipe_reapply_gen = 0;
 			}
 		}
 #endif
@@ -4919,8 +5826,11 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		mutex_lock(&serdes_lock__);
 		if (state->dser_ops->release_pipe(state->dser_dev, sensor->pipe_id) < 0)
 			dev_warn(&state->client->dev, "release pipe failed\n");
-		else
+		else {
+			ds5_disarm_dser_datapath_if_idle(state);
 			sensor->pipe_id = PIPE_NOT_CONFIGURED;
+			sensor->pipe_reapply_gen = 0;
+		}
 		if (state->is_y8
 			&& (state->ir.sensor.config.format->data_type == GMSL_CSI_DT_RGB_888))
 		{
@@ -4949,11 +5859,18 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 	 * Re-assert serializer GPIO tunneling after reset/recovery and
 	 * start the DES internal FSYNC source at the negotiated FPS.
 	 */
+	if (on && ret >= 0)
+		ds5_post_start_dser_datapath_kick(state, stream_id);
+
 	if (on && ds5_sync_mode_uses_esync(state)) {
 		ds5_set_ser_esync_tunneling(state, true);
 		ds5_set_des_fsync(state, true);
 	}
 #endif
+	if (stream_ctrl_locked)
+		mutex_unlock(&state->ds5_dev->stream_ctrl_lock);
+	ds5_finish_rgb_start(state, stream_id, ret);
+	ds5_finish_ir_start(state, stream_id, ret);
 	return ret;
 #endif /* !DS5_BYPASS_CAMERA_I2C */
 }

--- a/kernel/realsense/d5xx.c
+++ b/kernel/realsense/d5xx.c
@@ -196,7 +196,7 @@ struct dser_interface {
 #define MAX_DEPTH_EXP				200000
 #define MAX_RGB_EXP					10000
 #define DEF_DEPTH_EXP				33000
-#define DEF_RGB_EXP					1660
+#define DEF_RGB_EXP					166
 
 enum ds5_mux_pad {
 	DS5_MUX_PAD_EXTERNAL,
@@ -221,7 +221,6 @@ enum ds5_mux_pad {
 #define DS5_START_MAX_COUNT	(DS5_START_MAX_TIME / DS5_START_POLL_TIME)
 #define DS5_DEPENDENCY_DEBOUNCE_MS		300
 #define DS5_DEPENDENCY_WAIT_MS			3000
-#define DS5_DSER_REARM_COOLDOWN_MS		1800
 #define MAX_DS5_CONFIG_RETRIES		5
 
 /* I2C retry configuration */
@@ -604,7 +603,6 @@ struct dser_control {
 	*/
 	atomic_t reset_gen;
 	struct device *dser_dev;
-	unsigned long last_idle_jiffies;
 };
 static struct dser_control dser_inited[MAX_DSER_NUM];
 
@@ -658,107 +656,9 @@ static unsigned int ds5_started_mipi_streams(struct ds5 *state)
 	return count;
 }
 
-static u8 ds5_started_mipi_pipe_mask(struct ds5 *state)
-{
-	u8 mask = 0;
-
-	mutex_lock(&state->ds5_dev->lock);
-	if (state->ds5_dev->depth_streaming)
-		mask |= BIT(0);
-	if (state->ds5_dev->rgb_streaming)
-		mask |= BIT(1);
-	if (state->ds5_dev->ir_streaming)
-		mask |= BIT(2);
-	if (state->ds5_dev->imu_streaming)
-		mask |= BIT(3);
-	mutex_unlock(&state->ds5_dev->lock);
-
-	return mask;
-}
-
-static void ds5_post_start_dser_datapath_kick(struct ds5 *state, u16 stream_id)
-{
-	unsigned int started_streams;
-	u8 active_pipe_mask;
-	int active_pipes;
-	int link_locked;
-
-	mutex_lock(&serdes_lock__);
-	link_locked = state->dser_ops->get_link_locked ?
-		state->dser_ops->get_link_locked(state->dser_dev) : -1;
-	if (link_locked <= 0)
-		goto out;
-
-	active_pipes = state->dser_ops->get_active_pipe_count ?
-		state->dser_ops->get_active_pipe_count(state->dser_dev) : 1;
-	started_streams = ds5_started_mipi_streams(state);
-	active_pipe_mask = ds5_started_mipi_pipe_mask(state);
-	if (started_streams < active_pipes) {
-		dev_info(&state->client->dev,
-			 "stream %u START ok; locked DES datapath unchanged until remaining streams start (%u/%d)\n",
-			 stream_id, started_streams, active_pipes);
-		goto out;
-	}
-
-	dev_info(&state->client->dev,
-		 "stream %u START ok; updating DES CSI datapath without resetting locked GMSL Link A for pipe mask 0x%02x (%u/%d streams started)\n",
-		 stream_id, active_pipe_mask, started_streams, active_pipes);
-	/* PIPE_EN/mapping retrigger is local to the DES CSI datapath.  ONESHOT
-	 * would reset the whole Link A PHY/data path and invalidate queued VI
-	 * frames, while leaving the datapath untouched does not resynchronize
-	 * tunnel detection after the camera starts transmitting. */
-	if (state->dser_ops->retrigger_datapath(state->dser_dev) < 0) {
-		dev_warn(&state->client->dev,
-			 "stream %u START ok; DES CSI datapath retrigger failed\n",
-			 stream_id);
-		goto out;
-	}
-
-out:
-	mutex_unlock(&serdes_lock__);
-}
-
-static void ds5_wait_for_dser_rearm_cooldown(struct ds5 *state, const char *reason)
-{
-	struct dser_control *ctrl = state->ds5_dev->dser_control;
-	unsigned long last_idle;
-	unsigned long ready;
-	unsigned int wait_ms;
-
-	mutex_lock(&ctrl->lock);
-	last_idle = ctrl->last_idle_jiffies;
-	mutex_unlock(&ctrl->lock);
-
-	if (!last_idle)
-		return;
-
-	ready = last_idle + msecs_to_jiffies(DS5_DSER_REARM_COOLDOWN_MS);
-	if (!time_before(jiffies, ready))
-		return;
-
-	wait_ms = jiffies_to_msecs(ready - jiffies);
-	dev_info(&state->client->dev,
-		 "waiting %u ms before DES datapath re-arm (%s)\n",
-		 wait_ms, reason);
-	msleep(wait_ms);
-}
-
-static void ds5_reset_dser_datapath_before_start(struct ds5 *state, int pipe_id)
-{
-	ds5_wait_for_dser_rearm_cooldown(state, "unlocked link");
-	dev_info(&state->client->dev,
-		 "pipe %d pre-start resetting unlocked GMSL Link A PHY and datapath\n",
-		 pipe_id);
-	state->dser_ops->reset_oneshot(state->dser_dev);
-	max96717_retrigger_tx(state->ser_dev);
-	msleep(200);
-}
-
 static void ds5_disarm_dser_datapath_if_idle(struct ds5 *state)
 {
 	int active_pipes;
-	int link_locked;
-	struct dser_control *ctrl = state->ds5_dev->dser_control;
 
 	if (!state->dser_ops->get_active_pipe_count)
 		return;
@@ -767,20 +667,8 @@ static void ds5_disarm_dser_datapath_if_idle(struct ds5 *state)
 	if (active_pipes != 0)
 		return;
 
-	link_locked = state->dser_ops->get_link_locked ?
-		state->dser_ops->get_link_locked(state->dser_dev) : -1;
-	mutex_lock(&ctrl->lock);
-	ctrl->last_idle_jiffies = jiffies;
-	mutex_unlock(&ctrl->lock);
-
-	if (link_locked > 0) {
-		dev_info(&state->client->dev,
-			 "all DES pipes released; preserving locked Link A for next start\n");
-		return;
-	}
-
 	dev_info(&state->client->dev,
-		 "all DES pipes released; starting re-arm cooldown\n");
+		 "all DES pipes released; preserving Link A for next start\n");
 }
 
 /* MAX96724 deserializer interface implementation */
@@ -1606,10 +1494,22 @@ static int ds5_setup_pipeline(struct ds5 *state, u8 data_type1, u8 data_type2,
 	if (active_pipes <= 1) {
 		if (link_locked > 0) {
 			dev_info(&state->client->dev,
-				 "pipe %d preserving locked Link A; DES datapath retrigger will run after START\n",
+				 "pipe %d preserving locked Link A before DES pre-start re-arm\n",
 				 pipe_id);
 		} else {
-			ds5_reset_dser_datapath_before_start(state, pipe_id);
+			dev_info(&state->client->dev,
+				 "pipe %d resetting unlocked GMSL Link A before cold start\n",
+				 pipe_id);
+			state->dser_ops->reset_oneshot(state->dser_dev);
+			max96717_retrigger_tx(state->ser_dev);
+			msleep(200);
+		}
+		ret = state->dser_ops->retrigger_datapath(state->dser_dev);
+		if (ret < 0) {
+			dev_warn(&state->client->dev,
+				 "pipe %d DES pre-start re-arm failed (%d)\n",
+				 pipe_id, ret);
+			goto error;
 		}
 	} else {
 		dev_info(&state->client->dev,
@@ -2833,11 +2733,7 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 		break;
 
 	case V4L2_CID_EXPOSURE_ABSOLUTE:
-		if (!ctrl->p_new.p_u32)
-			ret = -EINVAL;
-		else
-			ret = ds5_hw_set_exposure(state, base,
-						 *ctrl->p_new.p_u32);
+		ret = ds5_hw_set_exposure(state, base, ctrl->val);
 		break;
 	case DS5_CAMERA_CID_LASER_POWER:
 		if (!state->is_rgb)
@@ -3289,7 +3185,7 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 		data = ((u32)reg << 16) & 0xffff0000;
 		ds5_read(state, base | DS5_MANUAL_EXPOSURE_LSB, &reg);
 		data |= reg;
-		*ctrl->p_new.p_u32 = data;
+		ctrl->val = (s32)data;
 		break;
 
 	case DS5_CAMERA_CID_LASER_POWER:
@@ -3445,13 +3341,11 @@ static const struct v4l2_ctrl_config ds5_ctrl_depth_exposure = {
 	.ops = &ds5_ctrl_ops,
 	.id = V4L2_CID_EXPOSURE_ABSOLUTE,
 	.name = "Exposure Time, Absolute",
-	.type = V4L2_CTRL_TYPE_U32,
+	.type = V4L2_CTRL_TYPE_INTEGER,
 	.min = 1,
 	.max = MAX_DEPTH_EXP,
 	.step = 1,
 	.def = DEF_DEPTH_EXP,
-	.dims = {1},
-	.elem_size = sizeof(u32),
 	.flags = V4L2_CTRL_FLAG_VOLATILE |
 		 V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
 };
@@ -3460,13 +3354,11 @@ static const struct v4l2_ctrl_config ds5_ctrl_rgb_exposure = {
 	.ops = &ds5_ctrl_ops,
 	.id = V4L2_CID_EXPOSURE_ABSOLUTE,
 	.name = "Exposure Time, Absolute",
-	.type = V4L2_CTRL_TYPE_U32,
+	.type = V4L2_CTRL_TYPE_INTEGER,
 	.min = 1,
 	.max = MAX_RGB_EXP,
 	.step = 1,
 	.def = DEF_RGB_EXP,
-	.dims = {1},
-	.elem_size = sizeof(u32),
 	.flags = V4L2_CTRL_FLAG_VOLATILE |
 		 V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
 };
@@ -5270,6 +5162,12 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		if (ret < 0 || status == DS5_STATUS_UNAVAILABLE ||
 		    (status & ~DS5_STATUS_VALID_MASK))
 			continue;
+		/* A recovery STOP may race with an HKR-side teardown that already
+		 * made the stream idle.  Let the common no-op cleanup run now rather
+		 * than waiting the full STOP timeout for a state transition that has
+		 * already happened. */
+		if (!on && !(status & DS5_STATUS_STREAMING))
+			break;
 		if (on == !(status & DS5_STATUS_STREAMING)) {
 			break;
 		}
@@ -5500,14 +5398,6 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 #endif
 	}
 #ifdef CONFIG_VIDEO_D5XX_SERDES
-	/*
-	 * Stream-on success path (neither timeout nor stream-off).
-	 * Re-assert serializer GPIO tunneling after reset/recovery and
-	 * start the DES internal FSYNC source at the negotiated FPS.
-	 */
-	if (on && ret >= 0)
-		ds5_post_start_dser_datapath_kick(state, stream_id);
-
 	if (on && ds5_sync_mode_uses_esync(state)) {
 		ds5_set_ser_esync_tunneling(state, true);
 		ds5_set_des_fsync(state, true);

--- a/kernel/realsense/d5xx.c
+++ b/kernel/realsense/d5xx.c
@@ -5602,6 +5602,12 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		if (ret < 0 || status == DS5_STATUS_UNAVAILABLE ||
 		    (status & ~DS5_STATUS_VALID_MASK))
 			continue;
+		/* A recovery STOP may race with an HKR-side teardown that already
+		 * made the stream idle.  Let the common no-op cleanup run now rather
+		 * than waiting the full STOP timeout for a state transition that has
+		 * already happened. */
+		if (!on && !(status & DS5_STATUS_STREAMING))
+			break;
 		if (on == !(status & DS5_STATUS_STREAMING)) {
 			break;
 		}

--- a/kernel/realsense/d5xx.c
+++ b/kernel/realsense/d5xx.c
@@ -51,7 +51,7 @@ struct dser_interface {
 	int (*set_pipe)(struct device *dev, int pipe_id, u8 data_type1, u8 data_type2, u32 vc_id);
 	int (*release_pipe)(struct device *dev, int pipe_id);
 	void (*reset_oneshot)(struct device *dev);
-	void (*retrigger_datapath)(struct device *dev);
+	int (*retrigger_datapath)(struct device *dev);
 	int (*get_active_pipe_count)(struct device *dev);
 	int (*get_link_locked)(struct device *dev);
 	
@@ -219,13 +219,9 @@ enum ds5_mux_pad {
 #define DS5_START_MAX_TIME			2000
 #define DS5_STOP_MAX_TIME			7000
 #define DS5_START_MAX_COUNT	(DS5_START_MAX_TIME / DS5_START_POLL_TIME)
-#define DS5_RGB_START_DEBOUNCE_MS		300
-#define DS5_RGB_START_WAIT_MS			3000
-#define DS5_IR_START_DEBOUNCE_MS		300
-#define DS5_IR_START_WAIT_MS			3000
+#define DS5_DEPENDENCY_DEBOUNCE_MS		300
+#define DS5_DEPENDENCY_WAIT_MS			3000
 #define DS5_DSER_REARM_COOLDOWN_MS		1800
-#define DS5_DSER_REARM_FALLBACK_MS		700
-#define DS5_DSER_REARM_WAIT_MS			3500
 #define MAX_DS5_CONFIG_RETRIES		5
 
 /* I2C retry configuration */
@@ -456,7 +452,6 @@ struct ds5_sensor {
 	u16 pipe_data_type1;
 	u16 pipe_data_type2;
 	u32 pipe_vc_id;
-	unsigned int pipe_reapply_gen;
 	u16 cached_dt_value;
 	u16 cached_md_value;
 	u16 cached_override_value;
@@ -535,6 +530,13 @@ struct ds5 {
 	struct ds5_dev *ds5_dev; /* pointer to DS5 device struct */
 };
 
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+struct ds5_start_state {
+	bool pending;
+	int error;
+};
+#endif
+
 struct ds5_dev {
 	struct mutex lock;
 	struct mutex stream_ctrl_lock;
@@ -579,10 +581,10 @@ struct ds5_dev {
 	bool ir_streaming;
 	bool rgb_streaming;
 	bool imu_streaming;
-	bool rgb_start_pending;
-	int rgb_start_error;
-	bool ir_start_pending;
-	int ir_start_error;
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+	struct ds5_start_state rgb_start;
+	struct ds5_start_state ir_start;
+#endif
 };
 
 #ifdef CONFIG_VIDEO_D5XX_SERDES
@@ -602,14 +604,6 @@ struct dser_control {
 	*/
 	atomic_t reset_gen;
 	struct device *dser_dev;
-	bool datapath_armed;
-	u8 datapath_pipe_mask;
-	bool post_start_kick_pending;
-	bool rearm_pending;
-	bool rearm_started;
-	int rearm_owner_pipe;
-	unsigned int rearm_waiters;
-	unsigned int rearm_gen;
 	unsigned long last_idle_jiffies;
 };
 static struct dser_control dser_inited[MAX_DSER_NUM];
@@ -644,153 +638,6 @@ static inline atomic_t *ds5_get_reset_gen(struct ds5 *state)
 static inline atomic_t *dser_get_reset_gen(struct ds5 *state)
 {
 	return &state->ds5_dev->dser_control->reset_gen;
-}
-
-static bool ds5_dser_datapath_armed(struct ds5 *state)
-{
-	bool armed;
-	struct dser_control *ctrl = state->ds5_dev->dser_control;
-
-	mutex_lock(&ctrl->lock);
-	armed = ctrl->datapath_armed;
-	mutex_unlock(&ctrl->lock);
-
-	return armed;
-}
-
-static void ds5_set_dser_datapath_armed(struct ds5 *state, bool armed)
-{
-	struct dser_control *ctrl = state->ds5_dev->dser_control;
-
-	mutex_lock(&ctrl->lock);
-	ctrl->datapath_armed = armed;
-	if (!armed)
-		ctrl->datapath_pipe_mask = 0;
-	mutex_unlock(&ctrl->lock);
-}
-
-static bool ds5_dser_datapath_matches(struct ds5 *state, u8 pipe_mask)
-{
-	bool matches;
-	struct dser_control *ctrl = state->ds5_dev->dser_control;
-
-	mutex_lock(&ctrl->lock);
-	matches = ctrl->datapath_armed &&
-		  ctrl->datapath_pipe_mask == pipe_mask;
-	mutex_unlock(&ctrl->lock);
-
-	return matches;
-}
-
-static void ds5_set_dser_datapath_pipe_mask(struct ds5 *state, u8 pipe_mask)
-{
-	struct dser_control *ctrl = state->ds5_dev->dser_control;
-
-	mutex_lock(&ctrl->lock);
-	ctrl->datapath_armed = true;
-	ctrl->datapath_pipe_mask = pipe_mask;
-	mutex_unlock(&ctrl->lock);
-}
-
-static bool ds5_dser_post_start_kick_pending(struct ds5 *state)
-{
-	bool pending;
-	struct dser_control *ctrl = state->ds5_dev->dser_control;
-
-	mutex_lock(&ctrl->lock);
-	pending = ctrl->post_start_kick_pending;
-	mutex_unlock(&ctrl->lock);
-
-	return pending;
-}
-
-static void ds5_set_dser_post_start_kick_pending(struct ds5 *state,
-						 bool pending)
-{
-	struct dser_control *ctrl = state->ds5_dev->dser_control;
-
-	mutex_lock(&ctrl->lock);
-	ctrl->post_start_kick_pending = pending;
-	mutex_unlock(&ctrl->lock);
-}
-
-static void ds5_cancel_dser_rearm(struct ds5 *state)
-{
-	struct dser_control *ctrl = state->ds5_dev->dser_control;
-
-	mutex_lock(&ctrl->lock);
-	ctrl->rearm_pending = false;
-	ctrl->rearm_started = false;
-	ctrl->post_start_kick_pending = false;
-	ctrl->rearm_owner_pipe = PIPE_NOT_CONFIGURED;
-	ctrl->rearm_waiters = 0;
-	mutex_unlock(&ctrl->lock);
-}
-
-static void ds5_schedule_dser_rearm(struct ds5 *state, int pipe_id)
-{
-	struct dser_control *ctrl = state->ds5_dev->dser_control;
-
-	mutex_lock(&ctrl->lock);
-	if (!ctrl->rearm_pending) {
-		ctrl->datapath_armed = false;
-		ctrl->rearm_pending = true;
-		ctrl->rearm_started = false;
-		ctrl->rearm_owner_pipe = pipe_id;
-		ctrl->rearm_waiters = 0;
-	}
-	mutex_unlock(&ctrl->lock);
-}
-
-static bool ds5_begin_dser_rearm(struct ds5 *state, int pipe_id,
-				 int *owner_pipe)
-{
-	struct dser_control *ctrl = state->ds5_dev->dser_control;
-	bool can_begin = true;
-
-	mutex_lock(&ctrl->lock);
-	if (ctrl->rearm_pending && ctrl->rearm_started &&
-	    ctrl->rearm_owner_pipe != pipe_id) {
-		can_begin = false;
-		if (owner_pipe)
-			*owner_pipe = ctrl->rearm_owner_pipe;
-	} else {
-		ctrl->datapath_armed = false;
-		ctrl->rearm_pending = true;
-		ctrl->rearm_started = true;
-		ctrl->rearm_owner_pipe = pipe_id;
-		if (owner_pipe)
-			*owner_pipe = pipe_id;
-	}
-	mutex_unlock(&ctrl->lock);
-
-	return can_begin;
-}
-
-static void ds5_mark_dser_rearm_done(struct ds5 *state, bool datapath_armed)
-{
-	struct dser_control *ctrl = state->ds5_dev->dser_control;
-
-	mutex_lock(&ctrl->lock);
-	ctrl->datapath_armed = datapath_armed;
-	ctrl->rearm_pending = false;
-	ctrl->rearm_started = false;
-	ctrl->rearm_owner_pipe = PIPE_NOT_CONFIGURED;
-	ctrl->rearm_waiters = 0;
-	ctrl->rearm_gen++;
-	mutex_unlock(&ctrl->lock);
-}
-
-static unsigned int ds5_dser_rearm_gen(struct ds5 *state)
-{
-	unsigned int gen;
-	struct dser_control *ctrl = state->ds5_dev->dser_control;
-
-	mutex_lock(&ctrl->lock);
-	gen = ctrl->rearm_gen;
-	mutex_unlock(&ctrl->lock);
-
-	return gen;
 }
 
 static unsigned int ds5_started_mipi_streams(struct ds5 *state)
@@ -853,25 +700,19 @@ static void ds5_post_start_dser_datapath_kick(struct ds5 *state, u16 stream_id)
 		goto out;
 	}
 
-	if (ds5_dser_datapath_matches(state, active_pipe_mask) &&
-	    !ds5_dser_post_start_kick_pending(state)) {
-		dev_info(&state->client->dev,
-			 "stream %u START ok; keeping locked GMSL Link A unchanged for pipe mask 0x%02x (%u/%d streams started)\n",
-			 stream_id, active_pipe_mask, started_streams, active_pipes);
-		goto out;
-	}
-
 	dev_info(&state->client->dev,
-		 "stream %u START ok; retriggering DES CSI datapath without resetting locked GMSL Link A for pipe mask 0x%02x (%u/%d streams started)\n",
+		 "stream %u START ok; updating DES CSI datapath without resetting locked GMSL Link A for pipe mask 0x%02x (%u/%d streams started)\n",
 		 stream_id, active_pipe_mask, started_streams, active_pipes);
 	/* PIPE_EN/mapping retrigger is local to the DES CSI datapath.  ONESHOT
 	 * would reset the whole Link A PHY/data path and invalidate queued VI
 	 * frames, while leaving the datapath untouched does not resynchronize
 	 * tunnel detection after the camera starts transmitting. */
-	state->dser_ops->retrigger_datapath(state->dser_dev);
-	ds5_cancel_dser_rearm(state);
-	ds5_set_dser_datapath_pipe_mask(state, active_pipe_mask);
-	ds5_set_dser_post_start_kick_pending(state, false);
+	if (state->dser_ops->retrigger_datapath(state->dser_dev) < 0) {
+		dev_warn(&state->client->dev,
+			 "stream %u START ok; DES CSI datapath retrigger failed\n",
+			 stream_id);
+		goto out;
+	}
 
 out:
 	mutex_unlock(&serdes_lock__);
@@ -902,109 +743,21 @@ static void ds5_wait_for_dser_rearm_cooldown(struct ds5 *state, const char *reas
 	msleep(wait_ms);
 }
 
-static bool ds5_rearm_dser_datapath_before_start(struct ds5 *state, int pipe_id,
-						 int active_pipes,
-						 int link_locked,
-						 const char *reason)
+static void ds5_reset_dser_datapath_before_start(struct ds5 *state, int pipe_id)
 {
-	/* ONESHOT resets the complete Link A PHY and data path, including the
-	 * tunnel carrying remote I2C.  A locked link does not need recovery;
-	 * the post-START path will retrigger only the DES CSI data path. */
-	if (link_locked > 0) {
-		dev_info(&state->client->dev,
-			 "pipe %d pre-start preserving locked Link A (%s, %d pipes active)\n",
-			 pipe_id, reason, active_pipes);
-		return false;
-	}
-
-	ds5_wait_for_dser_rearm_cooldown(state, reason);
+	ds5_wait_for_dser_rearm_cooldown(state, "unlocked link");
 	dev_info(&state->client->dev,
-		 "pipe %d pre-start resetting GMSL Link A PHY and datapath with ONESHOT (%s, %d pipes active, link %s)\n",
-		 pipe_id, reason, active_pipes,
-		 link_locked > 0 ? "locked" :
-		 (link_locked == 0 ? "unlocked" : "unknown"));
+		 "pipe %d pre-start resetting unlocked GMSL Link A PHY and datapath\n",
+		 pipe_id);
 	state->dser_ops->reset_oneshot(state->dser_dev);
 	max96717_retrigger_tx(state->ser_dev);
 	msleep(200);
-	ds5_set_dser_post_start_kick_pending(state, true);
-	return true;
-}
-
-static int ds5_wait_for_dser_rearm(struct ds5 *state, int pipe_id)
-{
-	struct dser_control *ctrl = state->ds5_dev->dser_control;
-	unsigned long timeout;
-	unsigned long fallback_timeout;
-	bool started;
-	bool pending;
-	int owner_pipe;
-
-	if (!state->dser_ops->get_active_pipe_count)
-		return 0;
-
-	mutex_lock(&ctrl->lock);
-	pending = ctrl->rearm_pending;
-	owner_pipe = ctrl->rearm_owner_pipe;
-	if (!pending) {
-		mutex_unlock(&ctrl->lock);
-		return 0;
-	}
-	mutex_unlock(&ctrl->lock);
-
-	dev_info(&state->client->dev,
-		 "pipe %d waiting for DES datapath re-arm owner pipe %d before camera I2C config\n",
-		 pipe_id, owner_pipe);
-	fallback_timeout = jiffies + msecs_to_jiffies(DS5_DSER_REARM_FALLBACK_MS);
-	timeout = jiffies + msecs_to_jiffies(DS5_DSER_REARM_WAIT_MS);
-	do {
-		mutex_lock(&ctrl->lock);
-		pending = ctrl->rearm_pending;
-		started = ctrl->rearm_started;
-		owner_pipe = ctrl->rearm_owner_pipe;
-		mutex_unlock(&ctrl->lock);
-		if (!pending)
-			return 0;
-
-		if (!started && owner_pipe == pipe_id &&
-		    time_after_eq(jiffies, fallback_timeout)) {
-			int active_pipes;
-			int link_locked;
-
-			if (!ds5_begin_dser_rearm(state, pipe_id, &owner_pipe))
-				continue;
-
-			active_pipes = state->dser_ops->get_active_pipe_count ?
-				state->dser_ops->get_active_pipe_count(state->dser_dev) : 1;
-			link_locked = state->dser_ops->get_link_locked ?
-				state->dser_ops->get_link_locked(state->dser_dev) : -1;
-
-			dev_info(&state->client->dev,
-				 "pipe %d fallback re-arming DES datapath after waiting for pipe 0\n",
-				 pipe_id);
-			mutex_lock(&serdes_lock__);
-			ds5_mark_dser_rearm_done(state,
-				ds5_rearm_dser_datapath_before_start(state, pipe_id,
-								      active_pipes,
-								      link_locked,
-								      "fallback owner"));
-			mutex_unlock(&serdes_lock__);
-			return 0;
-		}
-		msleep(20);
-	} while (time_before(jiffies, timeout));
-
-	dev_warn(&state->client->dev,
-		 "pipe %d timed out waiting for DES datapath re-arm owner pipe %d\n",
-		 pipe_id, owner_pipe);
-	return -ETIMEDOUT;
 }
 
 static void ds5_disarm_dser_datapath_if_idle(struct ds5 *state)
 {
 	int active_pipes;
 	int link_locked;
-	bool armed;
-	bool pending;
 	struct dser_control *ctrl = state->ds5_dev->dser_control;
 
 	if (!state->dser_ops->get_active_pipe_count)
@@ -1017,28 +770,17 @@ static void ds5_disarm_dser_datapath_if_idle(struct ds5 *state)
 	link_locked = state->dser_ops->get_link_locked ?
 		state->dser_ops->get_link_locked(state->dser_dev) : -1;
 	mutex_lock(&ctrl->lock);
-	armed = ctrl->datapath_armed;
-	pending = ctrl->rearm_pending;
-	ctrl->datapath_armed = false;
-	ctrl->datapath_pipe_mask = 0;
-	ctrl->post_start_kick_pending = false;
-	ctrl->rearm_pending = false;
-	ctrl->rearm_started = false;
-	ctrl->rearm_owner_pipe = PIPE_NOT_CONFIGURED;
-	ctrl->rearm_waiters = 0;
 	ctrl->last_idle_jiffies = jiffies;
 	mutex_unlock(&ctrl->lock);
 
 	if (link_locked > 0) {
-		if (armed || pending)
-			dev_info(&state->client->dev,
-				 "all DES pipes released; preserving locked Link A for next start\n");
+		dev_info(&state->client->dev,
+			 "all DES pipes released; preserving locked Link A for next start\n");
 		return;
 	}
 
-	if (armed || pending)
-		dev_info(&state->client->dev,
-			 "all DES pipes released; datapath marked unarmed for cooldown\n");
+	dev_info(&state->client->dev,
+		 "all DES pipes released; starting re-arm cooldown\n");
 }
 
 /* MAX96724 deserializer interface implementation */
@@ -1832,60 +1574,43 @@ static int ds5_setup_pipeline(struct ds5 *state, u8 data_type1, u8 data_type2,
 		state->dser_ops->get_active_pipe_count(state->dser_dev) : 1;
 	int link_locked = (state->dser_ops->get_link_locked != NULL) ?
 		state->dser_ops->get_link_locked(state->dser_dev) : -1;
-	bool datapath_armed = ds5_dser_datapath_armed(state);
 
-	if (link_locked > 0 && !datapath_armed && active_pipes <= 1)
-		dev_info(&state->client->dev,
-			 "link locked; DES datapath retrigger will run after camera START\n");
+	if (ser_pipe_id < 0)
+		return ser_pipe_id;
+	if (state->dser_ops->get_link_locked && link_locked < 0)
+		return link_locked;
 
-	ret |= state->dser_ops->bind_ser_to_dser_pipe(state->dser_dev, pipe_id, ser_pipe_id, vc_id);
+	ret = state->dser_ops->bind_ser_to_dser_pipe(state->dser_dev, pipe_id,
+						     ser_pipe_id, vc_id);
+	if (ret < 0)
+		goto error;
 	dev_dbg(&state->client->dev,
 			"set ser pipe %d, dser pipe %d, data_type1: 0x%x, data_type2: 0x%x, ser_vc_id: %u, vc_id: %u\n",
 			ser_pipe_id, pipe_id, data_type1, data_type2, ser_vc_id, vc_id);
-	ret |= max96717_set_pipe(state->ser_dev, ser_pipe_id,
-				data_type1, data_type2, ser_vc_id);
-	ret |= state->dser_ops->set_pipe(state->dser_dev, pipe_id,
-				data_type1, data_type2, vc_id);
-	if (ret >= 0 && link_locked > 0 && datapath_armed) {
+	ret = max96717_set_pipe(state->ser_dev, ser_pipe_id, data_type1,
+				data_type2, ser_vc_id);
+	if (ret < 0)
+		goto error;
+	ret = state->dser_ops->set_pipe(state->dser_dev, pipe_id, data_type1,
+					data_type2, vc_id);
+	if (ret < 0)
+		goto error;
+
+	if (link_locked > 0 && active_pipes > 1) {
 		unsigned int started_streams = ds5_started_mipi_streams(state);
 
 		dev_info(&state->client->dev,
 			 "pipe %d mapping updated while DES datapath armed (%u streams active); keeping datapath armed\n",
 			 pipe_id, started_streams);
 	}
-	/*
-	 * Prefer pipe 0 as the deterministic re-arm owner.  If RGB/IR arrives
-	 * first, it maps its pipe and waits before camera-side I2C config until
-	 * depth/pipe 0 performs the early re-arm.  On an already-locked link,
-	 * avoid ONESHOT and only retrigger the DES CSI datapath before START.
-	 */
-	if (pipe_id == 0 && (link_locked <= 0 || !datapath_armed)) {
-		int owner_pipe = PIPE_NOT_CONFIGURED;
-
-		dev_info(&state->client->dev,
-			 "pipe 0 re-arming DES datapath before camera I2C config (link %s, armed=%d, active_pipes=%d)\n",
-			 link_locked > 0 ? "locked" :
-			 (link_locked == 0 ? "unlocked" : "unknown"),
-			 datapath_armed, active_pipes);
-		if (ds5_begin_dser_rearm(state, pipe_id, &owner_pipe)) {
-			datapath_armed =
-				ds5_rearm_dser_datapath_before_start(state, pipe_id,
-								      active_pipes,
-								      link_locked,
-								      "pipe 0");
-			ds5_mark_dser_rearm_done(state, datapath_armed);
-		} else {
+	if (active_pipes <= 1) {
+		if (link_locked > 0) {
 			dev_info(&state->client->dev,
-				 "pipe 0 waiting for active DES datapath re-arm owner pipe %d\n",
-				 owner_pipe);
+				 "pipe %d preserving locked Link A; DES datapath retrigger will run after START\n",
+				 pipe_id);
+		} else {
+			ds5_reset_dser_datapath_before_start(state, pipe_id);
 		}
-	} else if (active_pipes <= 1 && !datapath_armed) {
-		dev_info(&state->client->dev,
-			 "first non-depth pipe %d scheduling DES datapath re-arm for pipe 0 (link %s, armed=%d)\n",
-			 pipe_id, link_locked > 0 ? "locked" :
-			 (link_locked == 0 ? "unlocked" : "unknown"),
-			 datapath_armed);
-		ds5_schedule_dser_rearm(state, pipe_id);
 	} else {
 		dev_info(&state->client->dev,
 			 "pipe %d mapping updated w/o link reset (%d pipes active, link %s)\n",
@@ -1893,11 +1618,12 @@ static int ds5_setup_pipeline(struct ds5 *state, u8 data_type1, u8 data_type2,
 			 link_locked > 0 ? "locked" :
 			 (link_locked == 0 ? "unlocked" : "unknown"));
 	}
-	if (ret)
-		dev_warn(&state->client->dev,
-			 "failed to set pipe %d, data_type1: 0x%x, data_type2: 0x%x, vc_id: %u\n",
-			 pipe_id, data_type1, data_type2, vc_id);
+	return 0;
 
+error:
+	dev_warn(&state->client->dev,
+		 "failed to set pipe %d, data_type1: 0x%x, data_type2: 0x%x, vc_id: %u (%d)\n",
+		 pipe_id, data_type1, data_type2, vc_id, ret);
 	return ret;
 }
 #endif
@@ -1925,7 +1651,6 @@ static void ds5_invalidate_sensor(struct ds5 *state, struct ds5_sensor *sensor)
 	sensor->pipe_data_type1 = 0;
 	sensor->pipe_data_type2 = 0;
 	sensor->pipe_vc_id = 0xFFFF;
-	sensor->pipe_reapply_gen = 0;
 }
 
 static int ds5_configure(struct ds5 *state)
@@ -1934,8 +1659,6 @@ static int ds5_configure(struct ds5 *state)
 	u16 md_fmt, vc_id;
 #ifdef CONFIG_VIDEO_D5XX_SERDES
 	u16 data_type1, data_type2;
-	bool is_calib = 0;
-	unsigned int pipe_reapply_gen;
 #endif
 #if !DS5_BYPASS_CAMERA_I2C
 	u16 dt_addr, md_addr, override_addr, fps_addr, width_addr, height_addr;
@@ -1996,7 +1719,6 @@ static int ds5_configure(struct ds5 *state)
 #ifdef CONFIG_VIDEO_D5XX_SERDES
 	data_type1 = sensor->config.format->data_type;
 	data_type2 = md_fmt;
-	is_calib = (state->is_y8 && (data_type1 == GMSL_CSI_DT_RGB_888));
 
 	vc_id = state->g_ctx.dst_vc;
 	dev_info(&state->client->dev,
@@ -2013,7 +1735,6 @@ static int ds5_configure(struct ds5 *state)
 				ds5_disarm_dser_datapath_if_idle(state);
 			mutex_unlock(&serdes_lock__);
 			dev_warn(&state->client->dev, "release pipe %d (%d)\n", sensor->pipe_id, ret);
-			sensor->pipe_reapply_gen = 0;
 		}
 		/*
 		* Serialize SERDES pipe allocation and configuration
@@ -2030,14 +1751,9 @@ static int ds5_configure(struct ds5 *state)
 			dev_err(&state->client->dev, "No free pipe in %s\n",state->dser_ops->name);
 			return -ENOSR;
 		}
-		pipe_reapply_gen = ds5_dser_rearm_gen(state);
-		sensor->pipe_reapply_gen = pipe_reapply_gen;
 		mutex_lock(&serdes_lock__);
 		ret = ds5_setup_pipeline(state, data_type1, data_type2,
 					 sensor->pipe_id, vc_id);
-		/* reset data path when switching to Y12I */
-		if (is_calib)
-			state->dser_ops->reset_oneshot(state->dser_dev);
 		mutex_unlock(&serdes_lock__);
 		if (ret < 0) {
 			dev_err(&state->client->dev,
@@ -2055,34 +1771,6 @@ static int ds5_configure(struct ds5 *state)
 		dev_info(&state->client->dev,
 				"pipe %d already configured (dt1=0x%x dt2=0x%x vc=%u)\n",
 				sensor->pipe_id, data_type1, data_type2, vc_id);
-	}
-
-	ret = ds5_wait_for_dser_rearm(state, sensor->pipe_id);
-	if (ret < 0)
-		return ret;
-
-	pipe_reapply_gen = ds5_dser_rearm_gen(state);
-	if (sensor->pipe_reapply_gen != pipe_reapply_gen) {
-		mutex_lock(&serdes_lock__);
-		ret = ds5_setup_pipeline(state, data_type1, data_type2,
-					 sensor->pipe_id, vc_id);
-		mutex_unlock(&serdes_lock__);
-		if (ret < 0) {
-			dev_err(&state->client->dev,
-				"pipe %d re-apply after DES re-arm FAILED (dt1=0x%x dt2=0x%x vc=%u gen=%u->%u) ret=%d\n",
-				sensor->pipe_id, data_type1, data_type2, vc_id,
-				sensor->pipe_reapply_gen, pipe_reapply_gen, ret);
-			return ret;
-		}
-		dev_info(&state->client->dev,
-			 "pipe %d re-applied after DES re-arm (dt1=0x%x dt2=0x%x vc=%u gen=%u)\n",
-			 sensor->pipe_id, data_type1, data_type2, vc_id,
-			 pipe_reapply_gen);
-		sensor->pipe_reapply_gen = pipe_reapply_gen;
-	} else {
-		dev_dbg(&state->client->dev,
-			"pipe %d already applied for DES re-arm gen %u (dt1=0x%x dt2=0x%x vc=%u)\n",
-			sensor->pipe_id, pipe_reapply_gen, data_type1, data_type2, vc_id);
 	}
 #else /* Non-SERDES configuration */
 	vc_id = (state->is_depth) ? 0 : (state->is_rgb) ? 1 : (state->is_y8) ? 2 : 3;
@@ -2607,189 +2295,150 @@ static void ds5_reset_streaming_flags(struct ds5_dev *ds5_dev)
 	ds5_dev->ir_streaming = false;
 	ds5_dev->rgb_streaming = false;
 	ds5_dev->imu_streaming = false;
-	ds5_dev->rgb_start_pending = false;
-	ds5_dev->rgb_start_error = 0;
-	ds5_dev->ir_start_pending = false;
-	ds5_dev->ir_start_error = 0;
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+	ds5_dev->rgb_start.pending = false;
+	ds5_dev->rgb_start.error = 0;
+	ds5_dev->ir_start.pending = false;
+	ds5_dev->ir_start.error = 0;
+#endif
 	mutex_unlock(&ds5_dev->lock);
 }
 
-static void ds5_set_rgb_start_pending(struct ds5 *state, u16 stream_id, bool pending)
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+static bool ds5_streams_idle(struct ds5 *state)
 {
-	if (stream_id != DS5_STREAM_RGB)
+	struct ds5_dev *ds5_dev = state->ds5_dev;
+	bool idle;
+
+	mutex_lock(&ds5_dev->lock);
+	idle = !ds5_dev->depth_streaming && !ds5_dev->rgb_streaming &&
+	       !ds5_dev->ir_streaming && !ds5_dev->imu_streaming;
+	mutex_unlock(&ds5_dev->lock);
+
+	return idle;
+}
+
+static struct ds5_start_state *ds5_get_start_state(struct ds5_dev *ds5_dev,
+						    u16 stream_id)
+{
+	if (stream_id == DS5_STREAM_RGB)
+		return &ds5_dev->rgb_start;
+	if (stream_id == DS5_STREAM_IR)
+		return &ds5_dev->ir_start;
+	return NULL;
+}
+
+static void ds5_set_start_pending(struct ds5 *state, u16 stream_id)
+{
+	struct ds5_start_state *start =
+		ds5_get_start_state(state->ds5_dev, stream_id);
+
+	if (!start)
 		return;
 
 	mutex_lock(&state->ds5_dev->lock);
-	state->ds5_dev->rgb_start_pending = pending;
-	if (pending)
-		state->ds5_dev->rgb_start_error = 0;
+	start->pending = true;
+	start->error = 0;
 	mutex_unlock(&state->ds5_dev->lock);
 }
 
-static void ds5_finish_rgb_start(struct ds5 *state, u16 stream_id, int ret)
+static void ds5_finish_start(struct ds5 *state, u16 stream_id, int ret)
 {
-	if (stream_id != DS5_STREAM_RGB)
+	struct ds5_start_state *start =
+		ds5_get_start_state(state->ds5_dev, stream_id);
+
+	if (!start)
 		return;
 
 	mutex_lock(&state->ds5_dev->lock);
-	state->ds5_dev->rgb_start_error = ret < 0 ? ret : 0;
-	state->ds5_dev->rgb_start_pending = false;
+	start->error = ret < 0 ? ret : 0;
+	start->pending = false;
 	mutex_unlock(&state->ds5_dev->lock);
 }
 
-static bool ds5_rgb_start_state(struct ds5 *state, int *error)
+static bool ds5_start_pending(struct ds5 *state, u16 stream_id, int *error)
 {
+	struct ds5_start_state *start =
+		ds5_get_start_state(state->ds5_dev, stream_id);
 	bool pending;
 
+	if (!start)
+		return false;
+
 	mutex_lock(&state->ds5_dev->lock);
-	pending = state->ds5_dev->rgb_start_pending;
+	pending = start->pending;
 	if (error)
-		*error = state->ds5_dev->rgb_start_error;
+		*error = start->error;
 	mutex_unlock(&state->ds5_dev->lock);
 
 	return pending;
 }
 
-static int ds5_wait_for_rgb_start_before_stereo(struct ds5 *state, u16 stream_id)
+static int ds5_wait_for_start(struct ds5 *state, u16 stream_id,
+			      u16 dependency_id, unsigned int debounce_ms,
+			      unsigned int wait_ms, const char *dependency_name)
 {
-#ifdef CONFIG_VIDEO_D5XX_SERDES
 	unsigned long discover_timeout;
 	unsigned long timeout;
-	int rgb_error = 0;
+	int start_error = 0;
 
-	if (stream_id == DS5_STREAM_RGB || stream_id == DS5_STREAM_IMU)
-		return 0;
-
-	/*
-	 * RGB joining an already-streaming stereo pipe can stall the shared HIF
-	 * CSI TX task (FW reports frame counter N, ack N-2).  Give a concurrent
-	 * RGB START a short window to announce itself, then let it complete first.
-	 */
-	discover_timeout = jiffies + msecs_to_jiffies(DS5_RGB_START_DEBOUNCE_MS);
-	while (!ds5_rgb_start_state(state, &rgb_error)) {
+	discover_timeout = jiffies + msecs_to_jiffies(debounce_ms);
+	while (!ds5_start_pending(state, dependency_id, &start_error)) {
 		if (!time_before(jiffies, discover_timeout))
 			return 0;
 		msleep(20);
 	}
 
 	dev_info(&state->client->dev,
-		 "stream %d waiting for RGB START to complete before stereo START\n",
-		 stream_id);
-	timeout = jiffies + msecs_to_jiffies(DS5_RGB_START_WAIT_MS);
-	while (ds5_rgb_start_state(state, &rgb_error)) {
+		 "stream %u waiting for %s START to complete\n",
+		 stream_id, dependency_name);
+	timeout = jiffies + msecs_to_jiffies(wait_ms);
+	while (ds5_start_pending(state, dependency_id, &start_error)) {
 		if (!time_before(jiffies, timeout)) {
 			dev_warn(&state->client->dev,
-				 "stream %d timed out waiting for RGB START; aborting stereo START\n",
-				 stream_id);
+				 "stream %u timed out waiting for %s START\n",
+				 stream_id, dependency_name);
 			return -ETIMEDOUT;
 		}
 		msleep(20);
 	}
 
-	if (rgb_error < 0) {
+	if (start_error < 0) {
 		dev_warn(&state->client->dev,
-			 "stream %d observed RGB START failure (%d); aborting stereo START\n",
-			 stream_id, rgb_error);
-		return rgb_error;
+			 "stream %u observed %s START failure (%d)\n",
+			 stream_id, dependency_name, start_error);
+		return start_error;
 	}
 
-	dev_info(&state->client->dev,
-		 "stream %d observed RGB START complete; continuing stereo START\n",
-		 stream_id);
 	return 0;
+}
 #else
+static void ds5_set_start_pending(struct ds5 *state, u16 stream_id)
+{
 	(void)state;
 	(void)stream_id;
-	return 0;
-#endif
 }
 
-static void ds5_set_ir_start_pending(struct ds5 *state, u16 stream_id, bool pending)
+static void ds5_finish_start(struct ds5 *state, u16 stream_id, int ret)
 {
-	if (stream_id != DS5_STREAM_IR)
-		return;
-
-	mutex_lock(&state->ds5_dev->lock);
-	state->ds5_dev->ir_start_pending = pending;
-	if (pending)
-		state->ds5_dev->ir_start_error = 0;
-	mutex_unlock(&state->ds5_dev->lock);
-}
-
-static void ds5_finish_ir_start(struct ds5 *state, u16 stream_id, int ret)
-{
-	if (stream_id != DS5_STREAM_IR)
-		return;
-
-	mutex_lock(&state->ds5_dev->lock);
-	state->ds5_dev->ir_start_error = ret < 0 ? ret : 0;
-	state->ds5_dev->ir_start_pending = false;
-	mutex_unlock(&state->ds5_dev->lock);
-}
-
-static bool ds5_ir_start_state(struct ds5 *state, int *error)
-{
-	bool pending;
-
-	mutex_lock(&state->ds5_dev->lock);
-	pending = state->ds5_dev->ir_start_pending;
-	if (error)
-		*error = state->ds5_dev->ir_start_error;
-	mutex_unlock(&state->ds5_dev->lock);
-
-	return pending;
-}
-
-static int ds5_wait_for_ir_start_before_depth(struct ds5 *state, u16 stream_id)
-{
-#ifdef CONFIG_VIDEO_D5XX_SERDES
-	unsigned long discover_timeout;
-	unsigned long timeout;
-	int ir_error = 0;
-
-	if (stream_id != DS5_STREAM_DEPTH)
-		return 0;
-
-	/* The PR #282 FW keeps one gated stereo pipeline alive, so IR can build
-	 * it first and Depth can enable its pre-built branch without a rebuild. */
-	discover_timeout = jiffies + msecs_to_jiffies(DS5_IR_START_DEBOUNCE_MS);
-	while (!ds5_ir_start_state(state, &ir_error)) {
-		if (!time_before(jiffies, discover_timeout))
-			return 0;
-		msleep(20);
-	}
-
-	dev_info(&state->client->dev,
-		 "stream %d waiting for IR START to complete before depth gate\n",
-		 stream_id);
-	timeout = jiffies + msecs_to_jiffies(DS5_IR_START_WAIT_MS);
-	while (ds5_ir_start_state(state, &ir_error)) {
-		if (!time_before(jiffies, timeout)) {
-			dev_warn(&state->client->dev,
-				 "stream %d timed out waiting for IR START; aborting depth START\n",
-				 stream_id);
-			return -ETIMEDOUT;
-		}
-		msleep(20);
-	}
-
-	if (ir_error < 0) {
-		dev_warn(&state->client->dev,
-			 "stream %d observed IR START failure (%d); aborting depth START\n",
-			 stream_id, ir_error);
-		return ir_error;
-	}
-
-	dev_info(&state->client->dev,
-		 "stream %d observed IR START complete; enabling depth gate\n",
-		 stream_id);
-	return 0;
-#else
 	(void)state;
 	(void)stream_id;
-	return 0;
-#endif
+	(void)ret;
 }
+
+static int ds5_wait_for_start(struct ds5 *state, u16 stream_id,
+			      u16 dependency_id, unsigned int debounce_ms,
+			      unsigned int wait_ms, const char *dependency_name)
+{
+	(void)state;
+	(void)stream_id;
+	(void)dependency_id;
+	(void)debounce_ms;
+	(void)wait_ms;
+	(void)dependency_name;
+	return 0;
+}
+#endif
 
 #ifdef CONFIG_VIDEO_D5XX_SERDES
 static void ds5_release_serdes_pipe(struct ds5 *state,
@@ -2810,7 +2459,6 @@ static void ds5_release_serdes_pipe(struct ds5 *state,
 	} else {
 		ds5_disarm_dser_datapath_if_idle(state);
 		sensor->pipe_id = PIPE_NOT_CONFIGURED;
-		sensor->pipe_reapply_gen = 0;
 	}
 	mutex_unlock(&serdes_lock__);
 }
@@ -3015,11 +2663,6 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	atomic_inc(ds5_get_reset_gen(state));
 	WRITE_ONCE(state->ds5_dev->cached_device_type, DS5_DEVICE_TYPE_UNKNOWN);
 	ds5_reset_streaming_flags(state->ds5_dev);
-#ifdef CONFIG_VIDEO_D5XX_SERDES
-	ds5_set_dser_datapath_armed(state, false);
-	ds5_cancel_dser_rearm(state);
-#endif
-
 	/* 3. Scratch one control-status register before reset.
 	 *    FW restores them to default 0x0000 only after reset completes.
 	 */
@@ -4189,11 +3832,6 @@ static int ds5_setup_and_link(struct ds5 *state)
 						mutex_lock(&dser_inited[j].lock);
 						if (NULL == dser_inited[j].dser_dev) {
 							dser_inited[j].dser_dev = state->dser_dev;
-							dser_inited[j].datapath_armed = false;
-							dser_inited[j].rearm_pending = false;
-							dser_inited[j].rearm_started = false;
-							dser_inited[j].rearm_owner_pipe = PIPE_NOT_CONFIGURED;
-							dser_inited[j].rearm_waiters = 0;
 							state->ds5_dev->dser_control = &dser_inited[j];
 						}
 						mutex_unlock(&dser_inited[j].lock);
@@ -4898,7 +4536,6 @@ static int ds5_sensor_init(struct i2c_client *c, struct ds5 *state,
 	char suffix = dpdata->suffix;
 #endif
 	sensor->pipe_id = PIPE_NOT_CONFIGURED;
-	sensor->pipe_reapply_gen = 0;
 	v4l2_i2c_subdev_init(sd, c, ops);
 	/* See tegracam_v4l2.c tegracam_v4l2subdev_register() */
 	/* Set owner to NULL so we can unload the driver module */
@@ -5447,27 +5084,13 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 	} else {
 		/* On stream off, release SERDES pipe */
 #ifdef CONFIG_VIDEO_D5XX_SERDES
-		if (sensor->pipe_id >= 0) {
-			mutex_lock(&serdes_lock__);
-			if (state->dser_ops->release_pipe(state->dser_dev, sensor->pipe_id) < 0)
-				dev_warn(&state->client->dev, "release pipe failed\n");
-			else {
-				ds5_disarm_dser_datapath_if_idle(state);
-				sensor->pipe_id = PIPE_NOT_CONFIGURED;
-				sensor->pipe_reapply_gen = 0;
-			}
-			mutex_unlock(&serdes_lock__);
-		}
+		ds5_release_serdes_pipe(state, sensor, "stream stop");
 		/*
 		 * Tear down the DES FSYNC generator when the last stream
 		 * stops.  Serializer GPIO tunneling remains tied to
 		 * camera_sync_mode and is disabled by the control callback.
 		 */
-		if (ds5_sync_mode_uses_esync(state) &&
-		    !state->ds5_dev->depth_streaming &&
-		    !state->ds5_dev->rgb_streaming &&
-		    !state->ds5_dev->ir_streaming &&
-		    !state->ds5_dev->imu_streaming)
+		if (ds5_sync_mode_uses_esync(state) && ds5_streams_idle(state))
 			ds5_set_des_fsync(state, false);
 #endif
 	}
@@ -5559,10 +5182,7 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 			ds5_release_serdes_pipe(state, sensor,
 						"duplicate stream stop");
 			if (ds5_sync_mode_uses_esync(state) &&
-			    !state->ds5_dev->depth_streaming &&
-			    !state->ds5_dev->rgb_streaming &&
-			    !state->ds5_dev->ir_streaming &&
-			    !state->ds5_dev->imu_streaming)
+			    ds5_streams_idle(state))
 				ds5_set_des_fsync(state, false);
 #endif
 		}
@@ -5570,8 +5190,7 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 	}
 
 	if (on) {
-		ds5_set_rgb_start_pending(state, stream_id, true);
-		ds5_set_ir_start_pending(state, stream_id, true);
+		ds5_set_start_pending(state, stream_id);
 	}
 
 	if (on) {
@@ -5585,22 +5204,27 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 	}
 
 	if (on) {
-		ret = ds5_wait_for_rgb_start_before_stereo(state, stream_id);
+		ret = 0;
+		if (stream_id != DS5_STREAM_RGB && stream_id != DS5_STREAM_IMU)
+			ret = ds5_wait_for_start(state, stream_id, DS5_STREAM_RGB,
+						 DS5_DEPENDENCY_DEBOUNCE_MS,
+						 DS5_DEPENDENCY_WAIT_MS, "RGB");
 		if (ret < 0) {
 #ifdef CONFIG_VIDEO_D5XX_SERDES
 			ds5_release_serdes_pipe(state, sensor, "RGB START dependency failure");
 #endif
-			ds5_finish_rgb_start(state, stream_id, ret);
-			ds5_finish_ir_start(state, stream_id, ret);
+			ds5_finish_start(state, stream_id, ret);
 			return ret;
 		}
-		ret = ds5_wait_for_ir_start_before_depth(state, stream_id);
+		if (stream_id == DS5_STREAM_DEPTH)
+			ret = ds5_wait_for_start(state, stream_id, DS5_STREAM_IR,
+						 DS5_DEPENDENCY_DEBOUNCE_MS,
+						 DS5_DEPENDENCY_WAIT_MS, "IR");
 		if (ret < 0) {
 #ifdef CONFIG_VIDEO_D5XX_SERDES
 			ds5_release_serdes_pipe(state, sensor, "IR START dependency failure");
 #endif
-			ds5_finish_rgb_start(state, stream_id, ret);
-			ds5_finish_ir_start(state, stream_id, ret);
+			ds5_finish_start(state, stream_id, ret);
 			return ret;
 		}
 	}
@@ -5622,8 +5246,7 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 #endif
 			mutex_unlock(&state->ds5_dev->stream_ctrl_lock);
 			stream_ctrl_locked = false;
-			ds5_finish_rgb_start(state, stream_id, ret);
-			ds5_finish_ir_start(state, stream_id, ret);
+			ds5_finish_start(state, stream_id, ret);
 			return ret;
 		}
 		ds5_config_done = true;
@@ -5714,18 +5337,14 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 			ds5_release_serdes_pipe(state, sensor,
 						"stream already stopped");
 			if (ds5_sync_mode_uses_esync(state) &&
-			    !state->ds5_dev->depth_streaming &&
-			    !state->ds5_dev->rgb_streaming &&
-			    !state->ds5_dev->ir_streaming &&
-			    !state->ds5_dev->imu_streaming)
+			    ds5_streams_idle(state))
 				ds5_set_des_fsync(state, false);
 #endif
 			if (stream_ctrl_locked) {
 				mutex_unlock(&state->ds5_dev->stream_ctrl_lock);
 				stream_ctrl_locked = false;
 			}
-			ds5_finish_rgb_start(state, stream_id, 0);
-			ds5_finish_ir_start(state, stream_id, 0);
+			ds5_finish_start(state, stream_id, 0);
 			return 0;
 		}
 	}
@@ -5756,8 +5375,7 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 						mutex_unlock(&state->ds5_dev->stream_ctrl_lock);
 						stream_ctrl_locked = false;
 					}
-					ds5_finish_rgb_start(state, stream_id, ret);
-					ds5_finish_ir_start(state, stream_id, ret);
+					ds5_finish_start(state, stream_id, ret);
 					return ret;
 				}
 				dev_warn(&state->client->dev, "stream %d config failed, retry %d, %dms\n",
@@ -5856,19 +5474,8 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 				mutex_unlock(&state->ds5_dev->stream_ctrl_lock);
 		}
 #ifdef CONFIG_VIDEO_D5XX_SERDES
-		if (on && sensor->pipe_id >= 0) {
-			mutex_lock(&serdes_lock__);
-			ret = state->dser_ops->release_pipe(state->dser_dev, sensor->pipe_id);
-			if (ret >= 0)
-				ds5_disarm_dser_datapath_if_idle(state);
-			mutex_unlock(&serdes_lock__);
-			if (ret < 0) {
-				dev_warn(&state->client->dev, "release pipe failed\n");
-			} else {
-				sensor->pipe_id = PIPE_NOT_CONFIGURED;
-				sensor->pipe_reapply_gen = 0;
-			}
-		}
+		if (on)
+			ds5_release_serdes_pipe(state, sensor, "stream start timeout");
 #endif
 		mutex_lock(&state->ds5_dev->lock);
 		*streaming_flag = restore_val;
@@ -5879,20 +5486,7 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 	else if (!on)
 	{
 #ifdef CONFIG_VIDEO_D5XX_SERDES
-		mutex_lock(&serdes_lock__);
-		if (state->dser_ops->release_pipe(state->dser_dev, sensor->pipe_id) < 0)
-			dev_warn(&state->client->dev, "release pipe failed\n");
-		else {
-			ds5_disarm_dser_datapath_if_idle(state);
-			sensor->pipe_id = PIPE_NOT_CONFIGURED;
-			sensor->pipe_reapply_gen = 0;
-		}
-		if (state->is_y8
-			&& (state->ir.sensor.config.format->data_type == GMSL_CSI_DT_RGB_888))
-		{
-			state->dser_ops->reset_oneshot(state->dser_dev);
-		}
-		mutex_unlock(&serdes_lock__);
+		ds5_release_serdes_pipe(state, sensor, "stream stop");
 		msleep_range(100);
 
 		/*
@@ -5901,11 +5495,7 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		 * cleared for *this* sensor before we entered the polling
 		 * loop) to decide whether any stream is still active.
 		 */
-		if (ds5_sync_mode_uses_esync(state) &&
-		    !state->ds5_dev->depth_streaming &&
-		    !state->ds5_dev->rgb_streaming &&
-		    !state->ds5_dev->ir_streaming &&
-		    !state->ds5_dev->imu_streaming)
+		if (ds5_sync_mode_uses_esync(state) && ds5_streams_idle(state))
 			ds5_set_des_fsync(state, false);
 #endif
 	}
@@ -5925,8 +5515,7 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 #endif
 	if (stream_ctrl_locked)
 		mutex_unlock(&state->ds5_dev->stream_ctrl_lock);
-	ds5_finish_rgb_start(state, stream_id, ret);
-	ds5_finish_ir_start(state, stream_id, ret);
+	ds5_finish_start(state, stream_id, ret);
 	return ret;
 #endif /* !DS5_BYPASS_CAMERA_I2C */
 }

--- a/kernel/realsense/d5xx.c
+++ b/kernel/realsense/d5xx.c
@@ -3190,7 +3190,11 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 		break;
 
 	case V4L2_CID_EXPOSURE_ABSOLUTE:
-		ret = ds5_hw_set_exposure(state, base, ctrl->val);
+		if (!ctrl->p_new.p_u32)
+			ret = -EINVAL;
+		else
+			ret = ds5_hw_set_exposure(state, base,
+						 *ctrl->p_new.p_u32);
 		break;
 	case DS5_CAMERA_CID_LASER_POWER:
 		if (!state->is_rgb)
@@ -3792,6 +3796,36 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 static const struct v4l2_ctrl_ops ds5_ctrl_ops = {
 	.s_ctrl	= ds5_s_ctrl,
 	.g_volatile_ctrl = ds5_g_volatile_ctrl,
+};
+
+static const struct v4l2_ctrl_config ds5_ctrl_depth_exposure = {
+	.ops = &ds5_ctrl_ops,
+	.id = V4L2_CID_EXPOSURE_ABSOLUTE,
+	.name = "Exposure Time, Absolute",
+	.type = V4L2_CTRL_TYPE_U32,
+	.min = 1,
+	.max = MAX_DEPTH_EXP,
+	.step = 1,
+	.def = DEF_DEPTH_EXP,
+	.dims = {1},
+	.elem_size = sizeof(u32),
+	.flags = V4L2_CTRL_FLAG_VOLATILE |
+		 V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
+};
+
+static const struct v4l2_ctrl_config ds5_ctrl_rgb_exposure = {
+	.ops = &ds5_ctrl_ops,
+	.id = V4L2_CID_EXPOSURE_ABSOLUTE,
+	.name = "Exposure Time, Absolute",
+	.type = V4L2_CTRL_TYPE_U32,
+	.min = 1,
+	.max = MAX_RGB_EXP,
+	.step = 1,
+	.def = DEF_RGB_EXP,
+	.dims = {1},
+	.elem_size = sizeof(u32),
+	.flags = V4L2_CTRL_FLAG_VOLATILE |
+		 V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
 };
 
 static const struct v4l2_ctrl_config ds5_ctrl_log = {
@@ -4754,23 +4788,13 @@ static int ds5_ctrl_init(struct ds5 *state, int sid)
 		}
 	}
 
-	/* Exposure time: V4L2_CID_EXPOSURE_ABSOLUTE default unit: 100 us. */
+	/* Exposure time is a one-element U32 payload in microseconds. */
 	if (sid == DEPTH_SID || sid == IR_SID) {
-		ctrls->exposure = v4l2_ctrl_new_std(hdl, ops,
-					V4L2_CID_EXPOSURE_ABSOLUTE,
-					1, MAX_DEPTH_EXP, 1, DEF_DEPTH_EXP);
+		ctrls->exposure = v4l2_ctrl_new_custom(
+				hdl, &ds5_ctrl_depth_exposure, sensor);
 	} else if (sid == RGB_SID) {
-		ctrls->exposure = v4l2_ctrl_new_std(hdl, ops,
-					V4L2_CID_EXPOSURE_ABSOLUTE,
-					1, MAX_RGB_EXP, 1, DEF_RGB_EXP);
-	}
-
-	if ((ctrls->exposure) && (sid >= DEPTH_SID && sid < IMU_SID)) {
-		ctrls->exposure->priv = sensor;
-		ctrls->exposure->flags |=
-				V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_EXECUTE_ON_WRITE;
-		/* override default int type to u32 to match SKU & UVC */
-		ctrls->exposure->type = V4L2_CTRL_TYPE_U32;
+		ctrls->exposure = v4l2_ctrl_new_custom(
+				hdl, &ds5_ctrl_rgb_exposure, sensor);
 	}
 	if (hdl->error) {
 		v4l2_err(sd, "error creating controls (%d)\n", hdl->error);
@@ -5520,9 +5544,30 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		state->reset_ref_dser = cur_dser;
 	}
 
-	/* spare duplicate calls */
-	if (sensor->streaming == on)
+	/*
+	 * A duplicate STREAMOFF can arrive after HKR has already stopped the
+	 * stream.  The camera state may be idle while the DES pipe allocated by
+	 * the previous STREAMON is still owned by this sensor, so STREAMOFF must
+	 * still perform the host-side cleanup.
+	 */
+	if (sensor->streaming == on) {
+		if (!on) {
+			mutex_lock(&state->ds5_dev->lock);
+			*streaming_flag = false;
+			mutex_unlock(&state->ds5_dev->lock);
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+			ds5_release_serdes_pipe(state, sensor,
+						"duplicate stream stop");
+			if (ds5_sync_mode_uses_esync(state) &&
+			    !state->ds5_dev->depth_streaming &&
+			    !state->ds5_dev->rgb_streaming &&
+			    !state->ds5_dev->ir_streaming &&
+			    !state->ds5_dev->imu_streaming)
+				ds5_set_des_fsync(state, false);
+#endif
+		}
 		return 0;
+	}
 
 	if (on) {
 		ds5_set_rgb_start_pending(state, stream_id, true);
@@ -5624,10 +5669,7 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		/*
 		 * If state was invalidated by a reset-generation bump and FW
 		 * still reports this stream as active, force a stop to guarantee
-		 * the next start goes through full reconfiguration.  During a
-		 * normal batched stereo/RGB start, another stream may legitimately
-		 * bring the shared datapath up first; treat that as an already-on
-		 * no-op below.
+		 * the next start goes through full reconfiguration.
 		 */
 		if (on && reset_invalidated && (status & DS5_STATUS_STREAMING)) {
 			dev_warn(&state->client->dev,
@@ -5645,13 +5687,21 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 			*streaming_flag = false;
 			mutex_unlock(&state->ds5_dev->lock);
 			sensor->streaming = false;
+		} else if (on && (status & DS5_STATUS_STREAMING)) {
+			/*
+			 * CONFIG_STATUS reflects the shared HKR pipeline.  With gated
+			 * Depth/IR outputs it can be active before this stream's cadence
+			 * is enabled, so a stream-specific START must still be sent.
+			 */
+			dev_info(&state->client->dev,
+				 "stream %d reports shared pipeline active; issuing stream-specific START\n",
+				 stream_id);
 		} else {
-			/* 
+			/*
 			 * After HW reset the FW reboots and all streams return to
-			 * idle.  If VI error recovery tries to stop a stream that
-			 * is already stopped (or start one already started), treat
-			 * it as a no-op so the upper layer can proceed with
-			 * restart instead of getting stuck in an EBUSY loop.
+			 * idle.  If VI error recovery tries to stop a stream that is
+			 * already stopped, clean up host resources and let the upper
+			 * layer proceed instead of getting stuck in an EBUSY loop.
 			 */
 			dev_warn(&state->client->dev,
 				"stream %d in %d state already (status: 0x%04x) %dms, treating as no-op\n",
@@ -5661,8 +5711,14 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 			mutex_unlock(&state->ds5_dev->lock);
 			sensor->streaming = on;
 #ifdef CONFIG_VIDEO_D5XX_SERDES
-			if (on)
-				ds5_post_start_dser_datapath_kick(state, stream_id);
+			ds5_release_serdes_pipe(state, sensor,
+						"stream already stopped");
+			if (ds5_sync_mode_uses_esync(state) &&
+			    !state->ds5_dev->depth_streaming &&
+			    !state->ds5_dev->rgb_streaming &&
+			    !state->ds5_dev->ir_streaming &&
+			    !state->ds5_dev->imu_streaming)
+				ds5_set_des_fsync(state, false);
 #endif
 			if (stream_ctrl_locked) {
 				mutex_unlock(&state->ds5_dev->stream_ctrl_lock);

--- a/nvidia-oot/files/6.2/drivers/media/i2c/max96717.c
+++ b/nvidia-oot/files/6.2/drivers/media/i2c/max96717.c
@@ -26,6 +26,10 @@
 /* REG0: Device ID (read-only, returns 0x40) */
 #define MAX96717_DEV_ADDR		0x00
 
+/* Errata #5: force the negative GMSL output on for 6Gbps coax links. */
+#define MAX96717_RLMSCE_ADDR		0x14CE
+#define MAX96717_ENMINUS_FORCE_ON	(BIT(4) | BIT(3))
+
 /*
  *   REG1: GMSL2 link rate, CC pin routing, pass-through I2C enables
  *   TX_RATE[3:2]: 01=3Gbps, 10=6Gbps
@@ -178,8 +182,8 @@
 
 /* REG1: TX_RATE[3:2]=01, RX_RATE[1:0]=00 */
 #define MAX96717_LINK_SPEED_3GBPS	0x04
-/* REG1: IIC_2_EN=1, DIS_LOCAL_CC=0, TX_RATE[3:2]=10, RX_RATE[1:0]=00 */
-#define MAX96717_LINK_SPEED_6GBPS	0x88
+/* REG1: main CC enabled, TX_RATE[3:2]=10, RX_RATE[1:0]=00. */
+#define MAX96717_LINK_SPEED_6GBPS	0x08
 
 /* EXT11 tunnel mode pre-config (0x0383=0x80) */
 #define MAX96717_EXT11_TUN_PRE		0x80
@@ -269,6 +273,35 @@ static int max96717_set_registers(struct device *dev, struct reg_pair *map,
 	return err;
 }
 
+void max96717_log_control_status(struct device *dev)
+{
+	static const u16 regs[] = {
+		MAX96717_DEV_ADDR, MAX96717_REG1_ADDR, MAX96717_PIPE_EN_ADDR,
+		MAX96717_CTRL0_ADDR, MAX96717_CTRL3_ADDR,
+		MAX96717_SRC_A_ADDR, MAX96717_DST_A_ADDR,
+		MAX96717_I2C4_ADDR, MAX96717_I2C5_ADDR,
+		MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX1_ADDR,
+		MAX96717_EXT11_ADDR,
+	};
+	struct max96717 *priv = dev_get_drvdata(dev);
+	unsigned int val[ARRAY_SIZE(regs)] = { 0 };
+	u16 failed = 0;
+	unsigned int i;
+
+	mutex_lock(&priv->lock);
+	for (i = 0; i < ARRAY_SIZE(regs); i++) {
+		if (regmap_read(priv->regmap, regs[i], &val[i]))
+			failed |= BIT(i);
+	}
+	mutex_unlock(&priv->lock);
+
+	dev_err(dev,
+		"GMSL SER CC snapshot: failed=0x%03x dev=0x%02x reg1=0x%02x pipe=0x%02x ctrl0=0x%02x ctrl3=0x%02x srcA=0x%02x dstA=0x%02x srcB=0x%02x dstB=0x%02x video0=0x%02x video1=0x%02x tun=0x%02x\n",
+		failed, val[0], val[1], val[2], val[3], val[4], val[5],
+		val[6], val[7], val[8], val[9], val[10], val[11]);
+}
+EXPORT_SYMBOL(max96717_log_control_status);
+
 /* ===== Streaming Setup ===== */
 
 /*
@@ -352,31 +385,79 @@ int max96717_setup_control(struct device *dev)
 	g_ctx = priv->g_client.g_ctx;
 
 	if (prim_priv__) {
-		unsigned int dev_id;
-		int probe_ret;
+		unsigned int default_id = 0;
+		unsigned int target_id = 0;
+		int default_ret = -EREMOTEIO;
+		int target_ret = -EREMOTEIO;
+		int retry;
 
-		probe_ret = regmap_read(prim_priv__->regmap,
-					MAX96717_DEV_ADDR, &dev_id);
-		if (probe_ret == 0) {
+		for (retry = 0; retry < 10; retry++) {
+			default_ret = regmap_read(prim_priv__->regmap,
+						  MAX96717_DEV_ADDR, &default_id);
+			if (!default_ret)
+				break;
+
+			target_ret = regmap_read(priv->regmap,
+						 MAX96717_DEV_ADDR, &target_id);
+			if (!target_ret)
+				break;
+
+			msleep(20);
+		}
+
+		if (!default_ret) {
 			/* Primary address (0x40) still responsive — do reassign */
 			err = max96717_write_reg(&prim_priv__->i2c_client->dev,
 						 MAX96717_DEV_ADDR,
 						 (g_ctx->ser_reg << 1));
 			if (err)
 				goto error;
-			msleep(20);
-		} else {
+
+			for (retry = 0; retry < 10; retry++) {
+				msleep(20);
+				target_ret = regmap_read(priv->regmap,
+							 MAX96717_DEV_ADDR,
+							 &target_id);
+				if (!target_ret)
+					break;
+			}
+			if (target_ret) {
+				dev_err(dev,
+					"%s: SER target address 0x%02x did not ACK after reassignment\n",
+					__func__, g_ctx->ser_reg);
+				err = target_ret;
+				goto error;
+			}
+		} else if (!target_ret) {
 			dev_info(&prim_priv__->i2c_client->dev,
-				 "%s: SER already reassigned (addr 0x40 NACK), skipping DEV_ADDR write\n",
-				 __func__);
+				 "%s: SER already reassigned (target 0x%02x ACK, addr 0x40 NACK)\n",
+				 __func__, g_ctx->ser_reg);
+		} else {
+			dev_err(dev,
+				"%s: SER did not ACK at default 0x40 or target 0x%02x\n",
+				__func__, g_ctx->ser_reg);
+			err = target_ret;
+			goto error;
 		}
 	}
 
-	/* Enable 6Gbps GMSL and keep local CC on MFP9/MFP10 for HKR I2C. */
+	/*
+	 * Enable 6Gbps while keeping main CC on MFP9/MFP10. IIC_2 must
+	 * remain disabled because its pass-through pins overlap main CC.
+	 */
 	err = max96717_write_reg(dev, MAX96717_REG1_ADDR,
 				 MAX96717_LINK_SPEED_6GBPS);
 	if (err) {
 		dev_err(dev, "%s: failed to configure serializer link rate\n",
+			__func__);
+		goto error;
+	}
+
+	err = regmap_update_bits(priv->regmap, MAX96717_RLMSCE_ADDR,
+				 MAX96717_ENMINUS_FORCE_ON,
+				 MAX96717_ENMINUS_FORCE_ON);
+	if (err) {
+		dev_err(dev, "%s: failed to force SION on for 6Gbps coax\n",
 			__func__);
 		goto error;
 	}
@@ -386,7 +467,7 @@ int max96717_setup_control(struct device *dev)
 	else
 		ctrl0_val = MAX96717_CTRL0_LINK_B;
 
-	dev_info(dev, "%s: SER rate=6Gbps/187.5Mbps local_CC(MFP9/10)=on PT2_I2C=on link=%c CTRL0=0x%02x\n",
+	dev_info(dev, "%s: SER rate=6Gbps/187.5Mbps main_CC(MFP9/10)=on IIC_2=off link=%c CTRL0=0x%02x\n",
 		 __func__,
 		 (g_ctx->serdes_csi_link == GMSL_SERDES_CSI_LINK_A) ? 'A' : 'B',
 		 ctrl0_val);
@@ -848,9 +929,13 @@ EXPORT_SYMBOL(max96717_set_pipe);
  */
 void max96717_retrigger_tx(struct device *dev)
 {
+	struct max96717 *priv = dev_get_drvdata(dev);
+
+	mutex_lock(&priv->lock);
 	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET);
 	msleep(30);
 	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL);
+	mutex_unlock(&priv->lock);
 }
 EXPORT_SYMBOL(max96717_retrigger_tx);
 
@@ -912,16 +997,11 @@ static int max96717_probe(struct i2c_client *client,
 
 static int max96717_remove(struct i2c_client *client)
 {
-	struct max96717 *priv;
+	struct max96717 *priv = dev_get_drvdata(&client->dev);
 
-	if (client != NULL) {
-		priv = dev_get_drvdata(&client->dev);
-		if (priv == prim_priv__)
-			prim_priv__ = NULL;
-		mutex_destroy(&priv->lock);
-		i2c_unregister_device(client);
-		client = NULL;
-	}
+	if (priv == prim_priv__)
+		prim_priv__ = NULL;
+	mutex_destroy(&priv->lock);
 
 	return 0;
 }

--- a/nvidia-oot/files/6.2/drivers/media/i2c/max96717.c
+++ b/nvidia-oot/files/6.2/drivers/media/i2c/max96717.c
@@ -273,35 +273,6 @@ static int max96717_set_registers(struct device *dev, struct reg_pair *map,
 	return err;
 }
 
-void max96717_log_control_status(struct device *dev)
-{
-	static const u16 regs[] = {
-		MAX96717_DEV_ADDR, MAX96717_REG1_ADDR, MAX96717_PIPE_EN_ADDR,
-		MAX96717_CTRL0_ADDR, MAX96717_CTRL3_ADDR,
-		MAX96717_SRC_A_ADDR, MAX96717_DST_A_ADDR,
-		MAX96717_I2C4_ADDR, MAX96717_I2C5_ADDR,
-		MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX1_ADDR,
-		MAX96717_EXT11_ADDR,
-	};
-	struct max96717 *priv = dev_get_drvdata(dev);
-	unsigned int val[ARRAY_SIZE(regs)] = { 0 };
-	u16 failed = 0;
-	unsigned int i;
-
-	mutex_lock(&priv->lock);
-	for (i = 0; i < ARRAY_SIZE(regs); i++) {
-		if (regmap_read(priv->regmap, regs[i], &val[i]))
-			failed |= BIT(i);
-	}
-	mutex_unlock(&priv->lock);
-
-	dev_err(dev,
-		"GMSL SER CC snapshot: failed=0x%03x dev=0x%02x reg1=0x%02x pipe=0x%02x ctrl0=0x%02x ctrl3=0x%02x srcA=0x%02x dstA=0x%02x srcB=0x%02x dstB=0x%02x video0=0x%02x video1=0x%02x tun=0x%02x\n",
-		failed, val[0], val[1], val[2], val[3], val[4], val[5],
-		val[6], val[7], val[8], val[9], val[10], val[11]);
-}
-EXPORT_SYMBOL(max96717_log_control_status);
-
 /* ===== Streaming Setup ===== */
 
 /*

--- a/nvidia-oot/files/6.2/drivers/media/i2c/max96724.c
+++ b/nvidia-oot/files/6.2/drivers/media/i2c/max96724.c
@@ -451,9 +451,12 @@ struct max96724_source_ctx {
 struct pipe_ctx {
 	u32 id;
 	u32 dt_type;
+	u32 dt_type2;
+	u32 vc_id;
 	u32 dst_csi_ctrl;
 	u32 st_count;
 	u32 st_id_sel;
+	bool map_configured;
 };
 
 struct max96724 {
@@ -479,6 +482,8 @@ struct max96724 {
 	u8 link_speed;  /* DT-configurable: 3 or 6 Gbps */
 	bool pixel_mode;
 	bool poc_enabled; /* FG24-4CH board POC/IO enable applied once */
+	bool datapath_retriggered;
+	u8 retriggered_pipe_mask;
 };
 
 struct reg_pair {
@@ -574,6 +579,40 @@ static void max96724_log_link_status(struct device *dev, const char *tag)
 		 lock_d, (lock_d & MAX96724_LINK_LOCKED) ? "LOCK" : "noLk",
 		 reg10, reg11);
 }
+
+void max96724_log_control_status(struct device *dev)
+{
+	static const u16 regs[] = {
+		0x0001, 0x0003, 0x0007, 0x0006, 0x0010, 0x001A, 0x002E,
+		0x00C7, 0x0500, 0x0501, 0x0503, 0x0504, 0x0506, 0x0507,
+		0x0560, 0x0561, 0x0563, 0x0564, 0x0566, 0x0567, 0x0640,
+		0x0641, 0x0680, 0x0681, 0x1003, 0x1004,
+	};
+	struct max96724 *priv = dev_get_drvdata(dev);
+	unsigned int val[ARRAY_SIZE(regs)] = { 0 };
+	u32 failed = 0;
+	unsigned int i;
+
+	mutex_lock(&priv->lock);
+	for (i = 0; i < ARRAY_SIZE(regs); i++) {
+		if (regmap_read(priv->regmap, regs[i], &val[i]))
+			failed |= BIT(i);
+	}
+	mutex_unlock(&priv->lock);
+
+	dev_err(dev,
+		"GMSL CC snapshot: failed=0x%08x local=0x%02x remote=0x%02x cross=0x%02x link_en=0x%02x rate=0x%02x lock=0x%02x intr11=0x%02x i2c7=0x%02x\n",
+		failed, val[0], val[1], val[2], val[3], val[4], val[5],
+		val[6], val[7]);
+	dev_err(dev,
+		"GMSL CC0/1 A: cc0 tr0=0x%02x tr1=0x%02x tr3=0x%02x tr4=0x%02x arq1=0x%02x arq2=0x%02x; cc1 tr0=0x%02x tr1=0x%02x tr3=0x%02x tr4=0x%02x arq1=0x%02x arq2=0x%02x\n",
+		val[8], val[9], val[10], val[11], val[12], val[13], val[14],
+		val[15], val[16], val[17], val[18], val[19]);
+	dev_err(dev,
+		"GMSL I2C bridge A: p0 i2c0=0x%02x i2c1=0x%02x p1 i2c0=0x%02x i2c1=0x%02x tx3=0x%02x rx0=0x%02x\n",
+		val[20], val[21], val[22], val[23], val[24], val[25]);
+}
+EXPORT_SYMBOL(max96724_log_control_status);
 
 static int max96724_wait_link_lock(struct device *dev, u32 link)
 {
@@ -895,12 +934,19 @@ static int max96724_write_link(struct device *dev, u32 link)
 	/* [UG Table 3] Set link rates + CC routing */
 	max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR, link_rate_ab);
 	max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR, link_rate_cd);
+	if (priv->link_speed == 6) {
+		u16 errch_addr = link == GMSL_SERDES_CSI_LINK_B ?
+			MAX96724_ERRCH_B_ADDR : MAX96724_ERRCH_A_ADDR;
+
+		/* Errata #5 requires this immediately after power-up/reset. */
+		max96724_write_reg(dev, errch_addr,
+				   MAX96724_ERRCH_FORCE_ON);
+	}
 
 	/*
 	 * [XML-verified sequence] One-shot reset applies rate configuration
 	 * to the link state machine, then link enable starts training.
 	 * XML order: rate → ONE-SHOT → LINK_EN → wait 1000ms.
-	 * Note: Error channel registers omitted (not in reference XML).
 	 */
 	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
 			   MAX96724_ONESHOT_ALL);
@@ -1483,11 +1529,53 @@ int max96724_release_pipe(struct device *dev, int pipe_id)
 
 	mutex_lock(&priv->lock);
 	priv->pipe[pipe_id].st_count = 0;
+	priv->retriggered_pipe_mask &= ~BIT(pipe_id);
 	mutex_unlock(&priv->lock);
 
 	return 0;
 }
 EXPORT_SYMBOL(max96724_release_pipe);
+
+/*
+ * Number of pipes currently allocated (st_count != 0).  Used by the
+ * sensor driver to decide whether a link ONESHOT reset is required
+ * (first pipe on an idle link) or must be avoided (additional pipe on
+ * a link that is already carrying live streams).
+ */
+int max96724_active_pipe_count(struct device *dev)
+{
+	struct max96724 *priv = dev_get_drvdata(dev);
+	int i;
+	int cnt = 0;
+
+	mutex_lock(&priv->lock);
+	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
+		if (priv->pipe[i].st_count)
+			cnt++;
+	}
+	mutex_unlock(&priv->lock);
+
+	return cnt;
+}
+EXPORT_SYMBOL(max96724_active_pipe_count);
+
+/*
+ * Whether GMSL link A is currently locked.  Used by the sensor driver
+ * to decide if a link ONESHOT reset is actually required at stream
+ * start: a locked link forwards tunnel traffic as-is and the ONESHOT
+ * would only break it (and any concurrent camera-side CSI transition
+ * can race the re-lock and take the whole link down, including the
+ * I2C control passthrough).
+ */
+int max96724_link_locked(struct device *dev)
+{
+	struct max96724 *priv = dev_get_drvdata(dev);
+	unsigned int lock = 0;
+
+	regmap_read(priv->regmap, MAX96724_LINK_A_LOCK_ADDR, &lock);
+	return (lock & MAX96724_LINK_LOCKED) ? 1 : 0;
+}
+EXPORT_SYMBOL(max96724_link_locked);
 
 int max96724_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id)
 {
@@ -1506,8 +1594,12 @@ void max96724_reset_oneshot(struct device *dev)
 	u8 vid_rx6_cfg;
 	u8 st_sel_cfg;
 	u8 dpll_cfg;
+	u16 errch_addr;
+	int err;
 
 	mutex_lock(&priv->lock);
+	priv->datapath_retriggered = false;
+	priv->retriggered_pipe_mask = 0;
 	if (priv->splitter_enabled) {
 		/* Multi-camera: reset all links */
 		u8 link_rate = (priv->link_speed == 6) ? 0x22 : 0x11;
@@ -1620,9 +1712,51 @@ void max96724_reset_oneshot(struct device *dev)
 	 * setup_streaming because the sensor's oneshot path overwrites it.
 	 */
 	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
-			   MAX96724_CSI_OUT_EN_VAL);
+				   MAX96724_CSI_OUT_EN_VAL);
 
 	msleep(200);
+
+	/*
+	 * ONESHOT resets the complete link PHY and data path.  Restore the
+	 * 6Gbps Error Channel workaround only after that reset has settled.
+	 */
+	if (priv->link_speed == 6) {
+		if (priv->splitter_enabled) {
+			err = max96724_write_reg(dev, MAX96724_ERRCH_A_ADDR,
+						 MAX96724_ERRCH_FORCE_ON);
+			if (!err)
+				err = max96724_write_reg(dev, MAX96724_ERRCH_B_ADDR,
+							 MAX96724_ERRCH_FORCE_ON);
+			if (!err)
+				err = max96724_write_reg(dev, MAX96724_ERRCH_C_ADDR,
+							 MAX96724_ERRCH_FORCE_ON);
+			if (!err)
+				err = max96724_write_reg(dev, MAX96724_ERRCH_D_ADDR,
+							 MAX96724_ERRCH_FORCE_ON);
+			if (err)
+				dev_err(dev,
+					"failed to restore GMSL Error Channels after Link reset: %d\n",
+					err);
+			else
+				dev_info(dev,
+					 "restored all GMSL Error Channels after Link reset\n");
+		} else {
+			errch_addr = priv->src_link == GMSL_SERDES_CSI_LINK_B ?
+				MAX96724_ERRCH_B_ADDR : MAX96724_ERRCH_A_ADDR;
+			err = max96724_write_reg(dev, errch_addr,
+						 MAX96724_ERRCH_FORCE_ON);
+			if (err)
+				dev_err(dev,
+					"failed to restore GMSL Error Channel after Link reset: %d\n",
+					err);
+			else
+				dev_info(dev,
+					 "restored GMSL Error Channel after Link reset (0x%04x=0x%02x)\n",
+					 errch_addr, MAX96724_ERRCH_FORCE_ON);
+		}
+	}
+
+	priv->datapath_retriggered = true;
 	mutex_unlock(&priv->lock);
 }
 EXPORT_SYMBOL(max96724_reset_oneshot);
@@ -1730,9 +1864,201 @@ static int __max96724_set_pipe(struct device *dev, int pipe_id,
 
 	err = max96724_set_registers(dev, map_pipe_control,
 				     ARRAY_SIZE(map_pipe_control));
+	if (!err) {
+		priv->pipe[pipe_id].dt_type = data_type1;
+		priv->pipe[pipe_id].dt_type2 = data_type2;
+		priv->pipe[pipe_id].vc_id = vc_id;
+		priv->pipe[pipe_id].map_configured = true;
+	}
 
 	return err;
 }
+
+void max96724_retrigger_datapath(struct device *dev)
+{
+	struct max96724 *priv = dev_get_drvdata(dev);
+	unsigned int pipe_en = MAX96724_PIPE_EN_4;
+	u8 active_mask = 0;
+	u8 retrigger_mask;
+	u8 pipe_sel0;
+	u8 pipe_sel1;
+	u8 vid_rx0_cfg;
+	u8 vid_rx6_cfg;
+	u8 st_sel_cfg;
+	u8 dpll_cfg;
+	bool full_retrigger;
+	unsigned int i;
+	int err = 0;
+
+	mutex_lock(&priv->lock);
+	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
+		if (priv->pipe[i].st_count)
+			active_mask |= BIT(i);
+	}
+	if (!active_mask) {
+		dev_warn(dev, "datapath retrigger requested with no active pipes\n");
+		goto out;
+	}
+
+	full_retrigger = !priv->datapath_retriggered;
+	retrigger_mask = active_mask & ~priv->retriggered_pipe_mask;
+	if (!full_retrigger && !retrigger_mask) {
+		dev_info(dev, "CSI datapath already retriggered for active pipes 0x%02x\n",
+			 active_mask);
+		goto out;
+	}
+	if (!full_retrigger && priv->retriggered_pipe_mask) {
+		/* All logical pipes on Link A share one tunnel detector. Once the
+		 * first stream has armed it, toggling any PIPE_EN bit can interrupt
+		 * VCs that are already live. set_pipe() has already installed the
+		 * joining stream's mapping, so only track it here. */
+		dev_info(dev,
+			 "Link A tunnel already active; adding CSI pipes 0x%02x without toggling live pipes 0x%02x\n",
+			 retrigger_mask, priv->retriggered_pipe_mask);
+		priv->retriggered_pipe_mask |= retrigger_mask;
+		goto out;
+	}
+	if (full_retrigger)
+		retrigger_mask = active_mask;
+
+	if (full_retrigger) {
+		if (max96724_is_pixel_mode(priv)) {
+			pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
+			pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
+			vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
+			vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
+			st_sel_cfg = 0x00;
+			dpll_cfg = MAX96724_DPLL_2000MBPS;
+		} else {
+			pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
+			pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
+			vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
+			vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
+			st_sel_cfg = 0x10;
+			dpll_cfg = MAX96724_DPLL_2000MBPS;
+		}
+
+		dev_info(dev,
+			 "retriggering full CSI datapath for first stream batch\n");
+		err = max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
+		msleep(20);
+		err |= max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR,
+					  pipe_sel0);
+		err |= max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR,
+					  pipe_sel1);
+		max96724_apply_porta_subset(dev, priv);
+		err |= max96724_write_reg(dev, MAX96724_DPLL_FREQ0_ADDR,
+					  dpll_cfg);
+		err |= max96724_write_reg(dev, MAX96724_DPLL_FREQ1_ADDR,
+					  dpll_cfg);
+		err |= max96724_write_reg(dev, MAX96724_DPLL_FREQ2_ADDR,
+					  dpll_cfg);
+		err |= max96724_write_reg(dev, MAX96724_DPLL_FREQ3_ADDR,
+					  dpll_cfg);
+		err |= max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR,
+					  MAX96724_MIPI_CTRL_SEL_PIXEL);
+		err |= max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
+					  MAX96724_BACKTOP_CSIB_EN);
+		for (i = 0; i < MAX96724_MAX_PIPES; i++) {
+			u16 pipe_off = 0x40 * i;
+			u16 vid_off = MAX96724_VID_RX_STRIDE * i;
+
+			err |= max96724_write_reg(dev,
+				MAX96724_PIPE_X_ST_SEL_ADDR + pipe_off,
+				st_sel_cfg);
+			err |= max96724_write_reg(dev,
+				MAX96724_VID_RX0_P0_ADDR + vid_off,
+				vid_rx0_cfg);
+			err |= max96724_write_reg(dev,
+				MAX96724_VID_RX6_P0_ADDR + vid_off,
+				vid_rx6_cfg);
+			err |= max96724_write_reg(dev,
+				MAX96724_TX49_PIPE_X_ADDR + pipe_off, 0x00);
+			if (max96724_is_pixel_mode(priv)) {
+				err |= max96724_write_reg(dev,
+					MAX96724_PIPE0_TUN_EN_ADDR + pipe_off,
+					MAX96724_TUN_DISABLED);
+				err |= max96724_write_reg(dev,
+					MAX96724_TX45_PIPE_X_DST_CTRL_ADDR + pipe_off,
+					MAX96724_ALL_MAP_CTRL0);
+				err |= max96724_write_reg(dev,
+					MAX96724_TX46_PIPE_X_ADDR + pipe_off,
+					MAX96724_ALL_MAP_CTRL0);
+				err |= max96724_write_reg(dev,
+					MAX96724_TX47_PIPE_X_ADDR + pipe_off,
+					MAX96724_ALL_MAP_CTRL0);
+				err |= max96724_write_reg(dev,
+					MAX96724_TX48_PIPE_X_ADDR + pipe_off,
+					MAX96724_ALL_MAP_CTRL0);
+			} else {
+				err |= max96724_write_reg(dev,
+					MAX96724_PIPE0_TUN_EN_ADDR + pipe_off,
+					MAX96724_TUN_EN);
+				err |= max96724_write_reg(dev,
+					MAX96724_PIPE0_TUN_DEST_ADDR + pipe_off,
+					MAX96724_TUN_DEST_CTRL1);
+				err |= max96724_write_reg(dev,
+					MAX96724_TX45_PIPE_X_DST_CTRL_ADDR + pipe_off,
+					MAX96724_ALL_MAP_CTRL1);
+				err |= max96724_write_reg(dev,
+					MAX96724_TX46_PIPE_X_ADDR + pipe_off,
+					MAX96724_ALL_MAP_CTRL1);
+				err |= max96724_write_reg(dev,
+					MAX96724_TX47_PIPE_X_ADDR + pipe_off,
+					MAX96724_ALL_MAP_CTRL1);
+				err |= max96724_write_reg(dev,
+					MAX96724_TX48_PIPE_X_ADDR + pipe_off,
+					MAX96724_ALL_MAP_CTRL1);
+			}
+		}
+	} else {
+		if (regmap_read(priv->regmap, MAX96724_PIPE_EN_ADDR, &pipe_en))
+			pipe_en = MAX96724_PIPE_EN_4;
+		dev_info(dev,
+			 "retriggering newly active CSI pipes 0x%02x (active 0x%02x)\n",
+			 retrigger_mask, active_mask);
+		err = max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR,
+					 pipe_en & ~retrigger_mask);
+		msleep(20);
+	}
+
+	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
+		struct pipe_ctx *pipe = &priv->pipe[i];
+
+		if (!(retrigger_mask & BIT(i)) || !pipe->st_count ||
+		    !pipe->map_configured)
+			continue;
+		dev_info(dev,
+			 "re-applying pipe %u mapping dt1 0x%x dt2 0x%x vc %u\n",
+			 i, pipe->dt_type, pipe->dt_type2, pipe->vc_id);
+		err |= __max96724_set_pipe(dev, i, pipe->dt_type,
+					   pipe->dt_type2, pipe->vc_id);
+	}
+	if (err)
+		dev_warn(dev, "failed to re-apply active pipe mappings: %d\n",
+			 err);
+
+	err |= max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
+				  MAX96724_CSI_OUT_EN_VAL);
+	if (full_retrigger) {
+		err |= max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR,
+					  MAX96724_PIPE_EN_4);
+		if (!err)
+			priv->datapath_retriggered = true;
+	} else {
+		err |= max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR,
+					  pipe_en | retrigger_mask);
+	}
+	if (err) {
+		dev_warn(dev, "failed to retrigger CSI datapath: %d\n", err);
+	} else {
+		priv->retriggered_pipe_mask |= retrigger_mask;
+	}
+
+out:
+	mutex_unlock(&priv->lock);
+}
+EXPORT_SYMBOL(max96724_retrigger_datapath);
 
 /*
  * max96724_init_settings - Initialize default pipe and tunnel configuration
@@ -2091,14 +2417,9 @@ static int max96724_probe(struct i2c_client *client,
 
 static int max96724_remove(struct i2c_client *client)
 {
-	struct max96724 *priv;
+	struct max96724 *priv = dev_get_drvdata(&client->dev);
 
-	if (client != NULL) {
-		priv = dev_get_drvdata(&client->dev);
-		mutex_destroy(&priv->lock);
-		i2c_unregister_device(client);
-		client = NULL;
-	}
+	mutex_destroy(&priv->lock);
 
 	return 0;
 }

--- a/nvidia-oot/files/6.2/drivers/media/i2c/max96724.c
+++ b/nvidia-oot/files/6.2/drivers/media/i2c/max96724.c
@@ -483,7 +483,6 @@ struct max96724 {
 	bool pixel_mode;
 	bool poc_enabled; /* FG24-4CH board POC/IO enable applied once */
 	bool datapath_retriggered;
-	u8 retriggered_pipe_mask;
 };
 
 struct reg_pair {
@@ -579,40 +578,6 @@ static void max96724_log_link_status(struct device *dev, const char *tag)
 		 lock_d, (lock_d & MAX96724_LINK_LOCKED) ? "LOCK" : "noLk",
 		 reg10, reg11);
 }
-
-void max96724_log_control_status(struct device *dev)
-{
-	static const u16 regs[] = {
-		0x0001, 0x0003, 0x0007, 0x0006, 0x0010, 0x001A, 0x002E,
-		0x00C7, 0x0500, 0x0501, 0x0503, 0x0504, 0x0506, 0x0507,
-		0x0560, 0x0561, 0x0563, 0x0564, 0x0566, 0x0567, 0x0640,
-		0x0641, 0x0680, 0x0681, 0x1003, 0x1004,
-	};
-	struct max96724 *priv = dev_get_drvdata(dev);
-	unsigned int val[ARRAY_SIZE(regs)] = { 0 };
-	u32 failed = 0;
-	unsigned int i;
-
-	mutex_lock(&priv->lock);
-	for (i = 0; i < ARRAY_SIZE(regs); i++) {
-		if (regmap_read(priv->regmap, regs[i], &val[i]))
-			failed |= BIT(i);
-	}
-	mutex_unlock(&priv->lock);
-
-	dev_err(dev,
-		"GMSL CC snapshot: failed=0x%08x local=0x%02x remote=0x%02x cross=0x%02x link_en=0x%02x rate=0x%02x lock=0x%02x intr11=0x%02x i2c7=0x%02x\n",
-		failed, val[0], val[1], val[2], val[3], val[4], val[5],
-		val[6], val[7]);
-	dev_err(dev,
-		"GMSL CC0/1 A: cc0 tr0=0x%02x tr1=0x%02x tr3=0x%02x tr4=0x%02x arq1=0x%02x arq2=0x%02x; cc1 tr0=0x%02x tr1=0x%02x tr3=0x%02x tr4=0x%02x arq1=0x%02x arq2=0x%02x\n",
-		val[8], val[9], val[10], val[11], val[12], val[13], val[14],
-		val[15], val[16], val[17], val[18], val[19]);
-	dev_err(dev,
-		"GMSL I2C bridge A: p0 i2c0=0x%02x i2c1=0x%02x p1 i2c0=0x%02x i2c1=0x%02x tx3=0x%02x rx0=0x%02x\n",
-		val[20], val[21], val[22], val[23], val[24], val[25]);
-}
-EXPORT_SYMBOL(max96724_log_control_status);
 
 static int max96724_wait_link_lock(struct device *dev, u32 link)
 {
@@ -1523,13 +1488,19 @@ EXPORT_SYMBOL(max96724_get_available_pipe_id);
 int max96724_release_pipe(struct device *dev, int pipe_id)
 {
 	struct max96724 *priv = dev_get_drvdata(dev);
+	int i;
 
 	if (pipe_id < 0 || pipe_id >= MAX96724_MAX_PIPES)
 		return -EINVAL;
 
 	mutex_lock(&priv->lock);
 	priv->pipe[pipe_id].st_count = 0;
-	priv->retriggered_pipe_mask &= ~BIT(pipe_id);
+	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
+		if (priv->pipe[i].st_count)
+			break;
+	}
+	if (i == MAX96724_MAX_PIPES)
+		priv->datapath_retriggered = false;
 	mutex_unlock(&priv->lock);
 
 	return 0;
@@ -1560,7 +1531,7 @@ int max96724_active_pipe_count(struct device *dev)
 EXPORT_SYMBOL(max96724_active_pipe_count);
 
 /*
- * Whether GMSL link A is currently locked.  Used by the sensor driver
+ * Whether the selected GMSL link is currently locked.  Used by the sensor driver
  * to decide if a link ONESHOT reset is actually required at stream
  * start: a locked link forwards tunnel traffic as-is and the ONESHOT
  * would only break it (and any concurrent camera-side CSI transition
@@ -1570,9 +1541,17 @@ EXPORT_SYMBOL(max96724_active_pipe_count);
 int max96724_link_locked(struct device *dev)
 {
 	struct max96724 *priv = dev_get_drvdata(dev);
+	u16 lock_addr = max96724_link_lock_addr(priv->src_link);
 	unsigned int lock = 0;
+	int err;
 
-	regmap_read(priv->regmap, MAX96724_LINK_A_LOCK_ADDR, &lock);
+	if (!lock_addr)
+		return -EINVAL;
+
+	err = regmap_read(priv->regmap, lock_addr, &lock);
+	if (err)
+		return err;
+
 	return (lock & MAX96724_LINK_LOCKED) ? 1 : 0;
 }
 EXPORT_SYMBOL(max96724_link_locked);
@@ -1599,7 +1578,6 @@ void max96724_reset_oneshot(struct device *dev)
 
 	mutex_lock(&priv->lock);
 	priv->datapath_retriggered = false;
-	priv->retriggered_pipe_mask = 0;
 	if (priv->splitter_enabled) {
 		/* Multi-camera: reset all links */
 		u8 link_rate = (priv->link_speed == 6) ? 0x22 : 0x11;
@@ -1756,7 +1734,6 @@ void max96724_reset_oneshot(struct device *dev)
 		}
 	}
 
-	priv->datapath_retriggered = true;
 	mutex_unlock(&priv->lock);
 }
 EXPORT_SYMBOL(max96724_reset_oneshot);
@@ -1874,19 +1851,16 @@ static int __max96724_set_pipe(struct device *dev, int pipe_id,
 	return err;
 }
 
-void max96724_retrigger_datapath(struct device *dev)
+int max96724_retrigger_datapath(struct device *dev)
 {
 	struct max96724 *priv = dev_get_drvdata(dev);
-	unsigned int pipe_en = MAX96724_PIPE_EN_4;
 	u8 active_mask = 0;
-	u8 retrigger_mask;
 	u8 pipe_sel0;
 	u8 pipe_sel1;
 	u8 vid_rx0_cfg;
 	u8 vid_rx6_cfg;
 	u8 st_sel_cfg;
 	u8 dpll_cfg;
-	bool full_retrigger;
 	unsigned int i;
 	int err = 0;
 
@@ -1897,135 +1871,99 @@ void max96724_retrigger_datapath(struct device *dev)
 	}
 	if (!active_mask) {
 		dev_warn(dev, "datapath retrigger requested with no active pipes\n");
+		err = -EINVAL;
 		goto out;
 	}
 
-	full_retrigger = !priv->datapath_retriggered;
-	retrigger_mask = active_mask & ~priv->retriggered_pipe_mask;
-	if (!full_retrigger && !retrigger_mask) {
+	if (priv->datapath_retriggered) {
 		dev_info(dev, "CSI datapath already retriggered for active pipes 0x%02x\n",
 			 active_mask);
 		goto out;
 	}
-	if (!full_retrigger && priv->retriggered_pipe_mask) {
-		/* All logical pipes on Link A share one tunnel detector. Once the
-		 * first stream has armed it, toggling any PIPE_EN bit can interrupt
-		 * VCs that are already live. set_pipe() has already installed the
-		 * joining stream's mapping, so only track it here. */
-		dev_info(dev,
-			 "Link A tunnel already active; adding CSI pipes 0x%02x without toggling live pipes 0x%02x\n",
-			 retrigger_mask, priv->retriggered_pipe_mask);
-		priv->retriggered_pipe_mask |= retrigger_mask;
-		goto out;
-	}
-	if (full_retrigger)
-		retrigger_mask = active_mask;
-
-	if (full_retrigger) {
-		if (max96724_is_pixel_mode(priv)) {
-			pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
-			pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
-			vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
-			vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
-			st_sel_cfg = 0x00;
-			dpll_cfg = MAX96724_DPLL_2000MBPS;
-		} else {
-			pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
-			pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
-			vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
-			vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
-			st_sel_cfg = 0x10;
-			dpll_cfg = MAX96724_DPLL_2000MBPS;
-		}
-
-		dev_info(dev,
-			 "retriggering full CSI datapath for first stream batch\n");
-		err = max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
-		msleep(20);
-		err |= max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR,
-					  pipe_sel0);
-		err |= max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR,
-					  pipe_sel1);
-		max96724_apply_porta_subset(dev, priv);
-		err |= max96724_write_reg(dev, MAX96724_DPLL_FREQ0_ADDR,
-					  dpll_cfg);
-		err |= max96724_write_reg(dev, MAX96724_DPLL_FREQ1_ADDR,
-					  dpll_cfg);
-		err |= max96724_write_reg(dev, MAX96724_DPLL_FREQ2_ADDR,
-					  dpll_cfg);
-		err |= max96724_write_reg(dev, MAX96724_DPLL_FREQ3_ADDR,
-					  dpll_cfg);
-		err |= max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR,
-					  MAX96724_MIPI_CTRL_SEL_PIXEL);
-		err |= max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
-					  MAX96724_BACKTOP_CSIB_EN);
-		for (i = 0; i < MAX96724_MAX_PIPES; i++) {
-			u16 pipe_off = 0x40 * i;
-			u16 vid_off = MAX96724_VID_RX_STRIDE * i;
-
-			err |= max96724_write_reg(dev,
-				MAX96724_PIPE_X_ST_SEL_ADDR + pipe_off,
-				st_sel_cfg);
-			err |= max96724_write_reg(dev,
-				MAX96724_VID_RX0_P0_ADDR + vid_off,
-				vid_rx0_cfg);
-			err |= max96724_write_reg(dev,
-				MAX96724_VID_RX6_P0_ADDR + vid_off,
-				vid_rx6_cfg);
-			err |= max96724_write_reg(dev,
-				MAX96724_TX49_PIPE_X_ADDR + pipe_off, 0x00);
-			if (max96724_is_pixel_mode(priv)) {
-				err |= max96724_write_reg(dev,
-					MAX96724_PIPE0_TUN_EN_ADDR + pipe_off,
-					MAX96724_TUN_DISABLED);
-				err |= max96724_write_reg(dev,
-					MAX96724_TX45_PIPE_X_DST_CTRL_ADDR + pipe_off,
-					MAX96724_ALL_MAP_CTRL0);
-				err |= max96724_write_reg(dev,
-					MAX96724_TX46_PIPE_X_ADDR + pipe_off,
-					MAX96724_ALL_MAP_CTRL0);
-				err |= max96724_write_reg(dev,
-					MAX96724_TX47_PIPE_X_ADDR + pipe_off,
-					MAX96724_ALL_MAP_CTRL0);
-				err |= max96724_write_reg(dev,
-					MAX96724_TX48_PIPE_X_ADDR + pipe_off,
-					MAX96724_ALL_MAP_CTRL0);
-			} else {
-				err |= max96724_write_reg(dev,
-					MAX96724_PIPE0_TUN_EN_ADDR + pipe_off,
-					MAX96724_TUN_EN);
-				err |= max96724_write_reg(dev,
-					MAX96724_PIPE0_TUN_DEST_ADDR + pipe_off,
-					MAX96724_TUN_DEST_CTRL1);
-				err |= max96724_write_reg(dev,
-					MAX96724_TX45_PIPE_X_DST_CTRL_ADDR + pipe_off,
-					MAX96724_ALL_MAP_CTRL1);
-				err |= max96724_write_reg(dev,
-					MAX96724_TX46_PIPE_X_ADDR + pipe_off,
-					MAX96724_ALL_MAP_CTRL1);
-				err |= max96724_write_reg(dev,
-					MAX96724_TX47_PIPE_X_ADDR + pipe_off,
-					MAX96724_ALL_MAP_CTRL1);
-				err |= max96724_write_reg(dev,
-					MAX96724_TX48_PIPE_X_ADDR + pipe_off,
-					MAX96724_ALL_MAP_CTRL1);
-			}
-		}
+	if (max96724_is_pixel_mode(priv)) {
+		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
+		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
+		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
+		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
+		st_sel_cfg = 0x00;
+		dpll_cfg = MAX96724_DPLL_2000MBPS;
 	} else {
-		if (regmap_read(priv->regmap, MAX96724_PIPE_EN_ADDR, &pipe_en))
-			pipe_en = MAX96724_PIPE_EN_4;
-		dev_info(dev,
-			 "retriggering newly active CSI pipes 0x%02x (active 0x%02x)\n",
-			 retrigger_mask, active_mask);
-		err = max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR,
-					 pipe_en & ~retrigger_mask);
-		msleep(20);
+		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
+		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
+		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
+		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
+		st_sel_cfg = 0x10;
+		dpll_cfg = MAX96724_DPLL_2000MBPS;
+	}
+
+	dev_info(dev, "retriggering full CSI datapath for first stream batch\n");
+	err = max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
+	msleep(20);
+	err |= max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR, pipe_sel0);
+	err |= max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR, pipe_sel1);
+	max96724_apply_porta_subset(dev, priv);
+	err |= max96724_write_reg(dev, MAX96724_DPLL_FREQ0_ADDR, dpll_cfg);
+	err |= max96724_write_reg(dev, MAX96724_DPLL_FREQ1_ADDR, dpll_cfg);
+	err |= max96724_write_reg(dev, MAX96724_DPLL_FREQ2_ADDR, dpll_cfg);
+	err |= max96724_write_reg(dev, MAX96724_DPLL_FREQ3_ADDR, dpll_cfg);
+	err |= max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR,
+				  MAX96724_MIPI_CTRL_SEL_PIXEL);
+	err |= max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
+				  MAX96724_BACKTOP_CSIB_EN);
+	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
+		u16 pipe_off = 0x40 * i;
+		u16 vid_off = MAX96724_VID_RX_STRIDE * i;
+
+		err |= max96724_write_reg(dev,
+			MAX96724_PIPE_X_ST_SEL_ADDR + pipe_off, st_sel_cfg);
+		err |= max96724_write_reg(dev,
+			MAX96724_VID_RX0_P0_ADDR + vid_off, vid_rx0_cfg);
+		err |= max96724_write_reg(dev,
+			MAX96724_VID_RX6_P0_ADDR + vid_off, vid_rx6_cfg);
+		err |= max96724_write_reg(dev,
+			MAX96724_TX49_PIPE_X_ADDR + pipe_off, 0x00);
+		if (max96724_is_pixel_mode(priv)) {
+			err |= max96724_write_reg(dev,
+				MAX96724_PIPE0_TUN_EN_ADDR + pipe_off,
+				MAX96724_TUN_DISABLED);
+			err |= max96724_write_reg(dev,
+				MAX96724_TX45_PIPE_X_DST_CTRL_ADDR + pipe_off,
+				MAX96724_ALL_MAP_CTRL0);
+			err |= max96724_write_reg(dev,
+				MAX96724_TX46_PIPE_X_ADDR + pipe_off,
+				MAX96724_ALL_MAP_CTRL0);
+			err |= max96724_write_reg(dev,
+				MAX96724_TX47_PIPE_X_ADDR + pipe_off,
+				MAX96724_ALL_MAP_CTRL0);
+			err |= max96724_write_reg(dev,
+				MAX96724_TX48_PIPE_X_ADDR + pipe_off,
+				MAX96724_ALL_MAP_CTRL0);
+		} else {
+			err |= max96724_write_reg(dev,
+				MAX96724_PIPE0_TUN_EN_ADDR + pipe_off,
+				MAX96724_TUN_EN);
+			err |= max96724_write_reg(dev,
+				MAX96724_PIPE0_TUN_DEST_ADDR + pipe_off,
+				MAX96724_TUN_DEST_CTRL1);
+			err |= max96724_write_reg(dev,
+				MAX96724_TX45_PIPE_X_DST_CTRL_ADDR + pipe_off,
+				MAX96724_ALL_MAP_CTRL1);
+			err |= max96724_write_reg(dev,
+				MAX96724_TX46_PIPE_X_ADDR + pipe_off,
+				MAX96724_ALL_MAP_CTRL1);
+			err |= max96724_write_reg(dev,
+				MAX96724_TX47_PIPE_X_ADDR + pipe_off,
+				MAX96724_ALL_MAP_CTRL1);
+			err |= max96724_write_reg(dev,
+				MAX96724_TX48_PIPE_X_ADDR + pipe_off,
+				MAX96724_ALL_MAP_CTRL1);
+		}
 	}
 
 	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
 		struct pipe_ctx *pipe = &priv->pipe[i];
 
-		if (!(retrigger_mask & BIT(i)) || !pipe->st_count ||
+		if (!(active_mask & BIT(i)) || !pipe->st_count ||
 		    !pipe->map_configured)
 			continue;
 		dev_info(dev,
@@ -2040,23 +1978,17 @@ void max96724_retrigger_datapath(struct device *dev)
 
 	err |= max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
 				  MAX96724_CSI_OUT_EN_VAL);
-	if (full_retrigger) {
-		err |= max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR,
-					  MAX96724_PIPE_EN_4);
-		if (!err)
-			priv->datapath_retriggered = true;
-	} else {
-		err |= max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR,
-					  pipe_en | retrigger_mask);
-	}
+	err |= max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR,
+				  MAX96724_PIPE_EN_4);
 	if (err) {
 		dev_warn(dev, "failed to retrigger CSI datapath: %d\n", err);
 	} else {
-		priv->retriggered_pipe_mask |= retrigger_mask;
+		priv->datapath_retriggered = true;
 	}
 
 out:
 	mutex_unlock(&priv->lock);
+	return err;
 }
 EXPORT_SYMBOL(max96724_retrigger_datapath);
 

--- a/nvidia-oot/files/6.2/drivers/media/i2c/max96724.c
+++ b/nvidia-oot/files/6.2/drivers/media/i2c/max96724.c
@@ -1523,6 +1523,7 @@ EXPORT_SYMBOL(max96724_get_available_pipe_id);
 int max96724_release_pipe(struct device *dev, int pipe_id)
 {
 	struct max96724 *priv = dev_get_drvdata(dev);
+	int i;
 
 	if (pipe_id < 0 || pipe_id >= MAX96724_MAX_PIPES)
 		return -EINVAL;
@@ -1530,6 +1531,14 @@ int max96724_release_pipe(struct device *dev, int pipe_id)
 	mutex_lock(&priv->lock);
 	priv->pipe[pipe_id].st_count = 0;
 	priv->retriggered_pipe_mask &= ~BIT(pipe_id);
+	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
+		if (priv->pipe[i].st_count)
+			break;
+	}
+	if (i == MAX96724_MAX_PIPES) {
+		priv->datapath_retriggered = false;
+		priv->retriggered_pipe_mask = 0;
+	}
 	mutex_unlock(&priv->lock);
 
 	return 0;

--- a/nvidia-oot/files/6.2/drivers/media/i2c/max96724.c
+++ b/nvidia-oot/files/6.2/drivers/media/i2c/max96724.c
@@ -327,11 +327,10 @@
 /*
  *   Tunnel controller destination (MIPI_TX57, 0x0939):
  *   bits[5:4]: TUN_DEST (00=PHY0, 01=PHY1, 10=PHY2, 11=PHY3)
- *   Bit 6 disables auto tunnel detection because TUN_EN is set manually.
- *   0x50 = manual tunnel mode routed to PHY1.
+ *   Verified value: 0x10 = PHY1 destination with auto-detect enabled
  */
-#define MAX96724_TUN_DEST_CTRL0		0x40  /* Manual tunnel + PHY0 */
-#define MAX96724_TUN_DEST_CTRL1		0x50  /* Manual tunnel + PHY1 (Port A master) */
+#define MAX96724_TUN_DEST_CTRL0		0x00  /* Auto-detect + PHY0 */
+#define MAX96724_TUN_DEST_CTRL1		0x10  /* Auto-detect + PHY1 (Port A master) */
 
 #define MAX96724_CSI_MODE_2X4_VAL	0x04  /* bit[2] = clean 2x4: Port A = PHY0+PHY1 */
 
@@ -484,6 +483,7 @@ struct max96724 {
 	bool pixel_mode;
 	bool poc_enabled; /* FG24-4CH board POC/IO enable applied once */
 	bool datapath_retriggered;
+	u8 retriggered_pipe_mask;
 };
 
 struct reg_pair {
@@ -579,6 +579,40 @@ static void max96724_log_link_status(struct device *dev, const char *tag)
 		 lock_d, (lock_d & MAX96724_LINK_LOCKED) ? "LOCK" : "noLk",
 		 reg10, reg11);
 }
+
+void max96724_log_control_status(struct device *dev)
+{
+	static const u16 regs[] = {
+		0x0001, 0x0003, 0x0007, 0x0006, 0x0010, 0x001A, 0x002E,
+		0x00C7, 0x0500, 0x0501, 0x0503, 0x0504, 0x0506, 0x0507,
+		0x0560, 0x0561, 0x0563, 0x0564, 0x0566, 0x0567, 0x0640,
+		0x0641, 0x0680, 0x0681, 0x1003, 0x1004,
+	};
+	struct max96724 *priv = dev_get_drvdata(dev);
+	unsigned int val[ARRAY_SIZE(regs)] = { 0 };
+	u32 failed = 0;
+	unsigned int i;
+
+	mutex_lock(&priv->lock);
+	for (i = 0; i < ARRAY_SIZE(regs); i++) {
+		if (regmap_read(priv->regmap, regs[i], &val[i]))
+			failed |= BIT(i);
+	}
+	mutex_unlock(&priv->lock);
+
+	dev_err(dev,
+		"GMSL CC snapshot: failed=0x%08x local=0x%02x remote=0x%02x cross=0x%02x link_en=0x%02x rate=0x%02x lock=0x%02x intr11=0x%02x i2c7=0x%02x\n",
+		failed, val[0], val[1], val[2], val[3], val[4], val[5],
+		val[6], val[7]);
+	dev_err(dev,
+		"GMSL CC0/1 A: cc0 tr0=0x%02x tr1=0x%02x tr3=0x%02x tr4=0x%02x arq1=0x%02x arq2=0x%02x; cc1 tr0=0x%02x tr1=0x%02x tr3=0x%02x tr4=0x%02x arq1=0x%02x arq2=0x%02x\n",
+		val[8], val[9], val[10], val[11], val[12], val[13], val[14],
+		val[15], val[16], val[17], val[18], val[19]);
+	dev_err(dev,
+		"GMSL I2C bridge A: p0 i2c0=0x%02x i2c1=0x%02x p1 i2c0=0x%02x i2c1=0x%02x tx3=0x%02x rx0=0x%02x\n",
+		val[20], val[21], val[22], val[23], val[24], val[25]);
+}
+EXPORT_SYMBOL(max96724_log_control_status);
 
 static int max96724_wait_link_lock(struct device *dev, u32 link)
 {
@@ -1067,9 +1101,7 @@ int max96724_setup_control(struct device *dev, struct device *s_dev)
 	/*
 	 * [SC20190112] Enable tunnel mode and route to Controller 1.
 	 *   - TUN_EN   (0x0936): 0x01 (TUN_EN=1)
-	 *   - TUN_DEST (0x0939): 0x50 = disable auto detection + Controller 1
-	 * TUN_EN is programmed explicitly, so automatic tunnel detection must be
-	 * disabled to keep it from racing the manual state after Link resets.
+	 *   - TUN_DEST (0x0939): 0x10 = Controller 1
 	 *   CSI_OUT_CFG=0x04 (2x4 mode): Controller 1 -> PHY0+1 -> Port A -> Orin
 	 */
 	{
@@ -1491,19 +1523,13 @@ EXPORT_SYMBOL(max96724_get_available_pipe_id);
 int max96724_release_pipe(struct device *dev, int pipe_id)
 {
 	struct max96724 *priv = dev_get_drvdata(dev);
-	int i;
 
 	if (pipe_id < 0 || pipe_id >= MAX96724_MAX_PIPES)
 		return -EINVAL;
 
 	mutex_lock(&priv->lock);
 	priv->pipe[pipe_id].st_count = 0;
-	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
-		if (priv->pipe[i].st_count)
-			break;
-	}
-	if (i == MAX96724_MAX_PIPES)
-		priv->datapath_retriggered = false;
+	priv->retriggered_pipe_mask &= ~BIT(pipe_id);
 	mutex_unlock(&priv->lock);
 
 	return 0;
@@ -1534,7 +1560,7 @@ int max96724_active_pipe_count(struct device *dev)
 EXPORT_SYMBOL(max96724_active_pipe_count);
 
 /*
- * Whether the selected GMSL link is currently locked.  Used by the sensor driver
+ * Whether GMSL link A is currently locked.  Used by the sensor driver
  * to decide if a link ONESHOT reset is actually required at stream
  * start: a locked link forwards tunnel traffic as-is and the ONESHOT
  * would only break it (and any concurrent camera-side CSI transition
@@ -1544,17 +1570,9 @@ EXPORT_SYMBOL(max96724_active_pipe_count);
 int max96724_link_locked(struct device *dev)
 {
 	struct max96724 *priv = dev_get_drvdata(dev);
-	u16 lock_addr = max96724_link_lock_addr(priv->src_link);
 	unsigned int lock = 0;
-	int err;
 
-	if (!lock_addr)
-		return -EINVAL;
-
-	err = regmap_read(priv->regmap, lock_addr, &lock);
-	if (err)
-		return err;
-
+	regmap_read(priv->regmap, MAX96724_LINK_A_LOCK_ADDR, &lock);
 	return (lock & MAX96724_LINK_LOCKED) ? 1 : 0;
 }
 EXPORT_SYMBOL(max96724_link_locked);
@@ -1581,6 +1599,7 @@ void max96724_reset_oneshot(struct device *dev)
 
 	mutex_lock(&priv->lock);
 	priv->datapath_retriggered = false;
+	priv->retriggered_pipe_mask = 0;
 	if (priv->splitter_enabled) {
 		/* Multi-camera: reset all links */
 		u8 link_rate = (priv->link_speed == 6) ? 0x22 : 0x11;
@@ -1674,9 +1693,7 @@ void max96724_reset_oneshot(struct device *dev)
 		max96724_write_reg(dev, MAX96724_PIPE1_TUN_EN_ADDR, MAX96724_TUN_EN);
 		max96724_write_reg(dev, MAX96724_PIPE2_TUN_EN_ADDR, MAX96724_TUN_EN);
 		max96724_write_reg(dev, MAX96724_PIPE3_TUN_EN_ADDR, MAX96724_TUN_EN);
-		/* Force manual tunnel mode to Controller 1, the Port A master in
-		 * 2x4 mode. Automatic detection can otherwise overwrite TUN_EN after
-		 * ONESHOT while the source is still idle. */
+		/* TUN_DEST: set to Controller 1 (0x10) = Port A master in 2x4 mode */
 		max96724_write_reg(dev, MAX96724_PIPE0_TUN_DEST_ADDR,
 				   MAX96724_TUN_DEST_CTRL1);
 		max96724_write_reg(dev, MAX96724_PIPE1_TUN_DEST_ADDR,
@@ -1739,6 +1756,7 @@ void max96724_reset_oneshot(struct device *dev)
 		}
 	}
 
+	priv->datapath_retriggered = true;
 	mutex_unlock(&priv->lock);
 }
 EXPORT_SYMBOL(max96724_reset_oneshot);
@@ -1856,16 +1874,19 @@ static int __max96724_set_pipe(struct device *dev, int pipe_id,
 	return err;
 }
 
-int max96724_retrigger_datapath(struct device *dev)
+void max96724_retrigger_datapath(struct device *dev)
 {
 	struct max96724 *priv = dev_get_drvdata(dev);
+	unsigned int pipe_en = MAX96724_PIPE_EN_4;
 	u8 active_mask = 0;
+	u8 retrigger_mask;
 	u8 pipe_sel0;
 	u8 pipe_sel1;
 	u8 vid_rx0_cfg;
 	u8 vid_rx6_cfg;
 	u8 st_sel_cfg;
 	u8 dpll_cfg;
+	bool full_retrigger;
 	unsigned int i;
 	int err = 0;
 
@@ -1876,99 +1897,135 @@ int max96724_retrigger_datapath(struct device *dev)
 	}
 	if (!active_mask) {
 		dev_warn(dev, "datapath retrigger requested with no active pipes\n");
-		err = -EINVAL;
 		goto out;
 	}
 
-	if (priv->datapath_retriggered) {
+	full_retrigger = !priv->datapath_retriggered;
+	retrigger_mask = active_mask & ~priv->retriggered_pipe_mask;
+	if (!full_retrigger && !retrigger_mask) {
 		dev_info(dev, "CSI datapath already retriggered for active pipes 0x%02x\n",
 			 active_mask);
 		goto out;
 	}
-	if (max96724_is_pixel_mode(priv)) {
-		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
-		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
-		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
-		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
-		st_sel_cfg = 0x00;
-		dpll_cfg = MAX96724_DPLL_2000MBPS;
-	} else {
-		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
-		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
-		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
-		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
-		st_sel_cfg = 0x10;
-		dpll_cfg = MAX96724_DPLL_2000MBPS;
+	if (!full_retrigger && priv->retriggered_pipe_mask) {
+		/* All logical pipes on Link A share one tunnel detector. Once the
+		 * first stream has armed it, toggling any PIPE_EN bit can interrupt
+		 * VCs that are already live. set_pipe() has already installed the
+		 * joining stream's mapping, so only track it here. */
+		dev_info(dev,
+			 "Link A tunnel already active; adding CSI pipes 0x%02x without toggling live pipes 0x%02x\n",
+			 retrigger_mask, priv->retriggered_pipe_mask);
+		priv->retriggered_pipe_mask |= retrigger_mask;
+		goto out;
 	}
+	if (full_retrigger)
+		retrigger_mask = active_mask;
 
-	dev_info(dev, "retriggering full CSI datapath for first stream batch\n");
-	err = max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
-	msleep(20);
-	err |= max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR, pipe_sel0);
-	err |= max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR, pipe_sel1);
-	max96724_apply_porta_subset(dev, priv);
-	err |= max96724_write_reg(dev, MAX96724_DPLL_FREQ0_ADDR, dpll_cfg);
-	err |= max96724_write_reg(dev, MAX96724_DPLL_FREQ1_ADDR, dpll_cfg);
-	err |= max96724_write_reg(dev, MAX96724_DPLL_FREQ2_ADDR, dpll_cfg);
-	err |= max96724_write_reg(dev, MAX96724_DPLL_FREQ3_ADDR, dpll_cfg);
-	err |= max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR,
-				  MAX96724_MIPI_CTRL_SEL_PIXEL);
-	err |= max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
-				  MAX96724_BACKTOP_CSIB_EN);
-	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
-		u16 pipe_off = 0x40 * i;
-		u16 vid_off = MAX96724_VID_RX_STRIDE * i;
-
-		err |= max96724_write_reg(dev,
-			MAX96724_PIPE_X_ST_SEL_ADDR + pipe_off, st_sel_cfg);
-		err |= max96724_write_reg(dev,
-			MAX96724_VID_RX0_P0_ADDR + vid_off, vid_rx0_cfg);
-		err |= max96724_write_reg(dev,
-			MAX96724_VID_RX6_P0_ADDR + vid_off, vid_rx6_cfg);
-		err |= max96724_write_reg(dev,
-			MAX96724_TX49_PIPE_X_ADDR + pipe_off, 0x00);
+	if (full_retrigger) {
 		if (max96724_is_pixel_mode(priv)) {
-			err |= max96724_write_reg(dev,
-				MAX96724_PIPE0_TUN_EN_ADDR + pipe_off,
-				MAX96724_TUN_DISABLED);
-			err |= max96724_write_reg(dev,
-				MAX96724_TX45_PIPE_X_DST_CTRL_ADDR + pipe_off,
-				MAX96724_ALL_MAP_CTRL0);
-			err |= max96724_write_reg(dev,
-				MAX96724_TX46_PIPE_X_ADDR + pipe_off,
-				MAX96724_ALL_MAP_CTRL0);
-			err |= max96724_write_reg(dev,
-				MAX96724_TX47_PIPE_X_ADDR + pipe_off,
-				MAX96724_ALL_MAP_CTRL0);
-			err |= max96724_write_reg(dev,
-				MAX96724_TX48_PIPE_X_ADDR + pipe_off,
-				MAX96724_ALL_MAP_CTRL0);
+			pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
+			pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
+			vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
+			vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
+			st_sel_cfg = 0x00;
+			dpll_cfg = MAX96724_DPLL_2000MBPS;
 		} else {
-			err |= max96724_write_reg(dev,
-				MAX96724_PIPE0_TUN_EN_ADDR + pipe_off,
-				MAX96724_TUN_EN);
-			err |= max96724_write_reg(dev,
-				MAX96724_PIPE0_TUN_DEST_ADDR + pipe_off,
-				MAX96724_TUN_DEST_CTRL1);
-			err |= max96724_write_reg(dev,
-				MAX96724_TX45_PIPE_X_DST_CTRL_ADDR + pipe_off,
-				MAX96724_ALL_MAP_CTRL1);
-			err |= max96724_write_reg(dev,
-				MAX96724_TX46_PIPE_X_ADDR + pipe_off,
-				MAX96724_ALL_MAP_CTRL1);
-			err |= max96724_write_reg(dev,
-				MAX96724_TX47_PIPE_X_ADDR + pipe_off,
-				MAX96724_ALL_MAP_CTRL1);
-			err |= max96724_write_reg(dev,
-				MAX96724_TX48_PIPE_X_ADDR + pipe_off,
-				MAX96724_ALL_MAP_CTRL1);
+			pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
+			pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
+			vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
+			vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
+			st_sel_cfg = 0x10;
+			dpll_cfg = MAX96724_DPLL_2000MBPS;
 		}
+
+		dev_info(dev,
+			 "retriggering full CSI datapath for first stream batch\n");
+		err = max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
+		msleep(20);
+		err |= max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR,
+					  pipe_sel0);
+		err |= max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR,
+					  pipe_sel1);
+		max96724_apply_porta_subset(dev, priv);
+		err |= max96724_write_reg(dev, MAX96724_DPLL_FREQ0_ADDR,
+					  dpll_cfg);
+		err |= max96724_write_reg(dev, MAX96724_DPLL_FREQ1_ADDR,
+					  dpll_cfg);
+		err |= max96724_write_reg(dev, MAX96724_DPLL_FREQ2_ADDR,
+					  dpll_cfg);
+		err |= max96724_write_reg(dev, MAX96724_DPLL_FREQ3_ADDR,
+					  dpll_cfg);
+		err |= max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR,
+					  MAX96724_MIPI_CTRL_SEL_PIXEL);
+		err |= max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
+					  MAX96724_BACKTOP_CSIB_EN);
+		for (i = 0; i < MAX96724_MAX_PIPES; i++) {
+			u16 pipe_off = 0x40 * i;
+			u16 vid_off = MAX96724_VID_RX_STRIDE * i;
+
+			err |= max96724_write_reg(dev,
+				MAX96724_PIPE_X_ST_SEL_ADDR + pipe_off,
+				st_sel_cfg);
+			err |= max96724_write_reg(dev,
+				MAX96724_VID_RX0_P0_ADDR + vid_off,
+				vid_rx0_cfg);
+			err |= max96724_write_reg(dev,
+				MAX96724_VID_RX6_P0_ADDR + vid_off,
+				vid_rx6_cfg);
+			err |= max96724_write_reg(dev,
+				MAX96724_TX49_PIPE_X_ADDR + pipe_off, 0x00);
+			if (max96724_is_pixel_mode(priv)) {
+				err |= max96724_write_reg(dev,
+					MAX96724_PIPE0_TUN_EN_ADDR + pipe_off,
+					MAX96724_TUN_DISABLED);
+				err |= max96724_write_reg(dev,
+					MAX96724_TX45_PIPE_X_DST_CTRL_ADDR + pipe_off,
+					MAX96724_ALL_MAP_CTRL0);
+				err |= max96724_write_reg(dev,
+					MAX96724_TX46_PIPE_X_ADDR + pipe_off,
+					MAX96724_ALL_MAP_CTRL0);
+				err |= max96724_write_reg(dev,
+					MAX96724_TX47_PIPE_X_ADDR + pipe_off,
+					MAX96724_ALL_MAP_CTRL0);
+				err |= max96724_write_reg(dev,
+					MAX96724_TX48_PIPE_X_ADDR + pipe_off,
+					MAX96724_ALL_MAP_CTRL0);
+			} else {
+				err |= max96724_write_reg(dev,
+					MAX96724_PIPE0_TUN_EN_ADDR + pipe_off,
+					MAX96724_TUN_EN);
+				err |= max96724_write_reg(dev,
+					MAX96724_PIPE0_TUN_DEST_ADDR + pipe_off,
+					MAX96724_TUN_DEST_CTRL1);
+				err |= max96724_write_reg(dev,
+					MAX96724_TX45_PIPE_X_DST_CTRL_ADDR + pipe_off,
+					MAX96724_ALL_MAP_CTRL1);
+				err |= max96724_write_reg(dev,
+					MAX96724_TX46_PIPE_X_ADDR + pipe_off,
+					MAX96724_ALL_MAP_CTRL1);
+				err |= max96724_write_reg(dev,
+					MAX96724_TX47_PIPE_X_ADDR + pipe_off,
+					MAX96724_ALL_MAP_CTRL1);
+				err |= max96724_write_reg(dev,
+					MAX96724_TX48_PIPE_X_ADDR + pipe_off,
+					MAX96724_ALL_MAP_CTRL1);
+			}
+		}
+	} else {
+		if (regmap_read(priv->regmap, MAX96724_PIPE_EN_ADDR, &pipe_en))
+			pipe_en = MAX96724_PIPE_EN_4;
+		dev_info(dev,
+			 "retriggering newly active CSI pipes 0x%02x (active 0x%02x)\n",
+			 retrigger_mask, active_mask);
+		err = max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR,
+					 pipe_en & ~retrigger_mask);
+		msleep(20);
 	}
 
 	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
 		struct pipe_ctx *pipe = &priv->pipe[i];
 
-		if (!(active_mask & BIT(i)) || !pipe->st_count ||
+		if (!(retrigger_mask & BIT(i)) || !pipe->st_count ||
 		    !pipe->map_configured)
 			continue;
 		dev_info(dev,
@@ -1983,17 +2040,23 @@ int max96724_retrigger_datapath(struct device *dev)
 
 	err |= max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
 				  MAX96724_CSI_OUT_EN_VAL);
-	err |= max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR,
-				  MAX96724_PIPE_EN_4);
+	if (full_retrigger) {
+		err |= max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR,
+					  MAX96724_PIPE_EN_4);
+		if (!err)
+			priv->datapath_retriggered = true;
+	} else {
+		err |= max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR,
+					  pipe_en | retrigger_mask);
+	}
 	if (err) {
 		dev_warn(dev, "failed to retrigger CSI datapath: %d\n", err);
 	} else {
-		priv->datapath_retriggered = true;
+		priv->retriggered_pipe_mask |= retrigger_mask;
 	}
 
 out:
 	mutex_unlock(&priv->lock);
-	return err;
 }
 EXPORT_SYMBOL(max96724_retrigger_datapath);
 

--- a/nvidia-oot/files/6.2/drivers/media/i2c/max96724.c
+++ b/nvidia-oot/files/6.2/drivers/media/i2c/max96724.c
@@ -327,10 +327,11 @@
 /*
  *   Tunnel controller destination (MIPI_TX57, 0x0939):
  *   bits[5:4]: TUN_DEST (00=PHY0, 01=PHY1, 10=PHY2, 11=PHY3)
- *   Verified value: 0x10 = PHY1 destination with auto-detect enabled
+ *   Bit 6 disables auto tunnel detection because TUN_EN is set manually.
+ *   0x50 = manual tunnel mode routed to PHY1.
  */
-#define MAX96724_TUN_DEST_CTRL0		0x00  /* Auto-detect + PHY0 */
-#define MAX96724_TUN_DEST_CTRL1		0x10  /* Auto-detect + PHY1 (Port A master) */
+#define MAX96724_TUN_DEST_CTRL0		0x40  /* Manual tunnel + PHY0 */
+#define MAX96724_TUN_DEST_CTRL1		0x50  /* Manual tunnel + PHY1 (Port A master) */
 
 #define MAX96724_CSI_MODE_2X4_VAL	0x04  /* bit[2] = clean 2x4: Port A = PHY0+PHY1 */
 
@@ -1066,7 +1067,9 @@ int max96724_setup_control(struct device *dev, struct device *s_dev)
 	/*
 	 * [SC20190112] Enable tunnel mode and route to Controller 1.
 	 *   - TUN_EN   (0x0936): 0x01 (TUN_EN=1)
-	 *   - TUN_DEST (0x0939): 0x10 = Controller 1
+	 *   - TUN_DEST (0x0939): 0x50 = disable auto detection + Controller 1
+	 * TUN_EN is programmed explicitly, so automatic tunnel detection must be
+	 * disabled to keep it from racing the manual state after Link resets.
 	 *   CSI_OUT_CFG=0x04 (2x4 mode): Controller 1 -> PHY0+1 -> Port A -> Orin
 	 */
 	{
@@ -1671,7 +1674,9 @@ void max96724_reset_oneshot(struct device *dev)
 		max96724_write_reg(dev, MAX96724_PIPE1_TUN_EN_ADDR, MAX96724_TUN_EN);
 		max96724_write_reg(dev, MAX96724_PIPE2_TUN_EN_ADDR, MAX96724_TUN_EN);
 		max96724_write_reg(dev, MAX96724_PIPE3_TUN_EN_ADDR, MAX96724_TUN_EN);
-		/* TUN_DEST: set to Controller 1 (0x10) = Port A master in 2x4 mode */
+		/* Force manual tunnel mode to Controller 1, the Port A master in
+		 * 2x4 mode. Automatic detection can otherwise overwrite TUN_EN after
+		 * ONESHOT while the source is still idle. */
 		max96724_write_reg(dev, MAX96724_PIPE0_TUN_DEST_ADDR,
 				   MAX96724_TUN_DEST_CTRL1);
 		max96724_write_reg(dev, MAX96724_PIPE1_TUN_DEST_ADDR,

--- a/nvidia-oot/files/6.2/include/media/max96717.h
+++ b/nvidia-oot/files/6.2/include/media/max96717.h
@@ -67,6 +67,7 @@ int max96717_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
  * @param  [in]  dev          The serializer device handle.
  */
 void max96717_retrigger_tx(struct device *dev);
+void max96717_log_control_status(struct device *dev);
 
 /**
  * @brief  Powers on the serializer and performs I2C overrides

--- a/nvidia-oot/files/6.2/include/media/max96717.h
+++ b/nvidia-oot/files/6.2/include/media/max96717.h
@@ -67,7 +67,6 @@ int max96717_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
  * @param  [in]  dev          The serializer device handle.
  */
 void max96717_retrigger_tx(struct device *dev);
-void max96717_log_control_status(struct device *dev);
 
 /**
  * @brief  Powers on the serializer and performs I2C overrides

--- a/nvidia-oot/files/6.2/include/media/max96724.h
+++ b/nvidia-oot/files/6.2/include/media/max96724.h
@@ -45,8 +45,7 @@ int max96724_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
 		      u8 data_type2, u32 vc_id);
 int max96724_release_pipe(struct device *dev, int pipe_id);
 void max96724_reset_oneshot(struct device *dev);
-void max96724_retrigger_datapath(struct device *dev);
-void max96724_log_control_status(struct device *dev);
+int max96724_retrigger_datapath(struct device *dev);
 int max96724_active_pipe_count(struct device *dev);
 int max96724_link_locked(struct device *dev);
 

--- a/nvidia-oot/files/6.2/include/media/max96724.h
+++ b/nvidia-oot/files/6.2/include/media/max96724.h
@@ -45,6 +45,10 @@ int max96724_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
 		      u8 data_type2, u32 vc_id);
 int max96724_release_pipe(struct device *dev, int pipe_id);
 void max96724_reset_oneshot(struct device *dev);
+void max96724_retrigger_datapath(struct device *dev);
+void max96724_log_control_status(struct device *dev);
+int max96724_active_pipe_count(struct device *dev);
+int max96724_link_locked(struct device *dev);
 
 /**
  * @brief  Puts the deserializer in single exclusive link mode.

--- a/nvidia-oot/files/6.2/include/media/max96724.h
+++ b/nvidia-oot/files/6.2/include/media/max96724.h
@@ -45,7 +45,8 @@ int max96724_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
 		      u8 data_type2, u32 vc_id);
 int max96724_release_pipe(struct device *dev, int pipe_id);
 void max96724_reset_oneshot(struct device *dev);
-int max96724_retrigger_datapath(struct device *dev);
+void max96724_retrigger_datapath(struct device *dev);
+void max96724_log_control_status(struct device *dev);
 int max96724_active_pipe_count(struct device *dev);
 int max96724_link_locked(struct device *dev);
 


### PR DESCRIPTION
- keep stream command and status read in one atomic I2C transfer
- avoid recursively unregistering an I2C client from its remove callback
- clear serializer state safely during driver removal
- retain errors for unrecoverable VI events
- demote per-frame correctable VI events to debug logging