### PR TITLE
[Host][GMSL]: Add D5xx metadata sidecar ops

### DIFF
--- a/kernel/nvidia/5.0.2/0021-D5xx-metadata-sidecar-ops.patch
+++ b/kernel/nvidia/5.0.2/0021-D5xx-metadata-sidecar-ops.patch
@@ -1,0 +1,388 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zhou <shengyong.zhou@realsenseai.com>
+Date: Fri, 17 Jul 2026 13:30:00 +0800
+Subject: [PATCH] media: tegra: support sensor metadata ops
+
+Add a small per-sensor metadata ops hook for embedded metadata sidecar
+format negotiation, queue capacity, and runtime bytesused calculation.
+
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
+---
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index a9fadae0..3ee83f5a 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -2668,44 +2668,137 @@ static int tegra_metadata_querycap(struct file *file, void *fh,
+ 	return 0;
+ }
+ 
++static u32 tegra_metadata_native_dataformat(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->dataformat)
++		return chan->embedded.ops->dataformat;
++
++	return V4L2_META_FMT_D4XX;
++}
++
++static u32 tegra_metadata_compat_dataformat(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->compat_dataformat)
++		return chan->embedded.ops->compat_dataformat;
++
++	return tegra_metadata_native_dataformat(chan);
++}
++
++static u32 tegra_metadata_current_dataformat(struct tegra_channel *chan)
++{
++	if (chan->embedded.dataformat)
++		return chan->embedded.dataformat;
++
++	return tegra_metadata_native_dataformat(chan);
++}
++
++static bool tegra_metadata_dataformat_supported(struct tegra_channel *chan,
++						u32 dataformat)
++{
++	u32 native = tegra_metadata_native_dataformat(chan);
++	u32 compat = tegra_metadata_compat_dataformat(chan);
++
++	return dataformat == native || dataformat == compat;
++}
++
++static unsigned int tegra_metadata_buffer_size(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->max_buffer_size)
++		return chan->embedded.ops->max_buffer_size;
++
++	return 255;
++}
++
++static void tegra_metadata_format_description(u32 dataformat, char *description,
++					      size_t size)
++{
++	if (dataformat == V4L2_META_FMT_RSMD)
++		strlcpy(description, "RealSense D5xx CSI metadata", size);
++	else if (dataformat == V4L2_META_FMT_D4XX)
++		strlcpy(description, "D4XX metadata format", size);
++	else
++		strlcpy(description, "Embedded metadata format", size);
++}
++
+ static int tegra_metadata_enum_format(struct file *file, void *fh,
+                                      struct v4l2_fmtdesc *f)
+ {
+-	if (f->index)
++	struct tegra_channel *chan = video_drvdata(file);
++	u32 native = tegra_metadata_native_dataformat(chan);
++	u32 compat = tegra_metadata_compat_dataformat(chan);
++
++	if (f->index > 1 || (f->index == 1 && compat == native))
+ 		return -EINVAL;
+ 
+-	f->pixelformat = V4L2_META_FMT_D4XX;
+-	strlcpy(f->description, "D4XX metadata format", sizeof(f->description));
++	f->pixelformat = f->index ? compat : native;
++	tegra_metadata_format_description(f->pixelformat, f->description,
++					   sizeof(f->description));
+ 
+ 	return 0;
+ }
+ 
+-static int tegra_metadata_get_format(struct file *file, void *fh,
+-                                    struct v4l2_format *format)
++static int tegra_metadata_fill_format(struct tegra_channel *chan,
++				      struct v4l2_format *format,
++				      u32 dataformat)
+ {
+-	struct v4l2_fh *vfh = file->private_data;
+ 	struct v4l2_meta_format *fmt = &format->fmt.meta;
+ 
+-	if (format->type != vfh->vdev->queue->type)
++	if (format->type != V4L2_BUF_TYPE_META_CAPTURE)
+ 		return -EINVAL;
+ 
+ 	memset(fmt, 0, sizeof(*fmt));
+-
+-	fmt->dataformat = V4L2_META_FMT_D4XX;
+-	fmt->buffersize = 255;
++	fmt->dataformat = dataformat;
++	fmt->buffersize = tegra_metadata_buffer_size(chan);
+ 
+ 	return 0;
+ }
++
++static int tegra_metadata_get_format(struct file *file, void *fh,
++                                    struct v4l2_format *format)
++{
++	struct v4l2_fh *vfh = file->private_data;
++	struct tegra_channel *chan = video_drvdata(file);
++
++	if (format->type != vfh->vdev->queue->type)
++		return -EINVAL;
++
++	return tegra_metadata_fill_format(chan, format,
++					  tegra_metadata_current_dataformat(chan));
++}
+ static int tegra_metadata_set_format(struct file *file, void *fh,
+                                     struct v4l2_format *format)
+ {
+-   return 0;
++	struct tegra_channel *chan = video_drvdata(file);
++	u32 dataformat = format->fmt.meta.dataformat;
++
++	if (format->type != V4L2_BUF_TYPE_META_CAPTURE)
++		return -EINVAL;
++
++	if (!dataformat)
++		dataformat = tegra_metadata_native_dataformat(chan);
++	if (!tegra_metadata_dataformat_supported(chan, dataformat))
++		return -EINVAL;
++
++	chan->embedded.dataformat = dataformat;
++
++	return tegra_metadata_fill_format(chan, format, dataformat);
+ }
+ 
+ static int tegra_metadata_try_format(struct file *file, void *fh,
+                                     struct v4l2_format *format)
+ {
+-    return 0;
++	struct tegra_channel *chan = video_drvdata(file);
++	u32 dataformat = format->fmt.meta.dataformat;
++
++	if (format->type != V4L2_BUF_TYPE_META_CAPTURE)
++		return -EINVAL;
++
++	if (!dataformat)
++		dataformat = tegra_metadata_native_dataformat(chan);
++	if (!tegra_metadata_dataformat_supported(chan, dataformat))
++		return -EINVAL;
++
++	return tegra_metadata_fill_format(chan, format, dataformat);
+ }
+ static const struct v4l2_ioctl_ops tegra_metadata_ioctl_ops = {
+ 	.vidioc_querycap                = tegra_metadata_querycap,
+@@ -2728,19 +2821,20 @@ static int tegra_metadata_queue_setup(struct vb2_queue *vq,
+                     unsigned int sizes[], struct device *alloc_devs[])
+ {
+ 	struct tegra_channel *chan = vb2_get_drv_priv(vq);
++	unsigned int size = tegra_metadata_buffer_size(chan);
+ 
+ 	if (*nplanes) {
+ 		if (*nplanes != 1)
+ 			return -EINVAL;
+ 
+-		if (sizes[0] < 255)
++		if (sizes[0] < size)
+ 			return -EINVAL;
+ 
+ 		return 0;
+ 	}
+ 
+ 	*nplanes = 1;
+-	sizes[0] = 255;
++	sizes[0] = size;
+ 	alloc_devs[0] = chan->vi->dev;
+ 
+ 
+@@ -2749,10 +2843,12 @@ static int tegra_metadata_queue_setup(struct vb2_queue *vq,
+ 
+ static int tegra_metadata_buffer_prepare(struct vb2_buffer *vb)
+ {
++	struct tegra_channel *chan = vb2_get_drv_priv(vb->vb2_queue);
++
+ 	if (vb->num_planes != 1)
+ 		return -EINVAL;
+ 
+-	if (vb2_plane_size(vb, 0) < 255)
++	if (vb2_plane_size(vb, 0) < tegra_metadata_buffer_size(chan))
+ 		return -EINVAL;
+ 
+ 	return 0;
+@@ -2761,6 +2857,7 @@ static int tegra_metadata_buffer_prepare(struct vb2_buffer *vb)
+ static void tegra_metadata_buffer_queue(struct vb2_buffer *vb)
+ {
+ 	struct tegra_channel *chan = vb2_get_drv_priv(vb->vb2_queue);
++	bool queued = false;
+ 
+ 	spin_lock(&chan->embedded.spin_lock);
+ 	if (chan->embedded.num_buffers < 16) {
+@@ -2769,8 +2866,12 @@ static void tegra_metadata_buffer_queue(struct vb2_buffer *vb)
+ 		if (chan->embedded.head > 15)
+ 			chan->embedded.head = chan->embedded.head - 16;
+ 		chan->embedded.num_buffers++;
++		queued = true;
+ 	}
+ 	spin_unlock(&chan->embedded.spin_lock);
++
++	if (!queued)
++		vb2_buffer_done(vb, VB2_BUF_STATE_ERROR);
+ }
+ 
+ static int tegra_metadata_start_streaming(struct vb2_queue *vq, unsigned int count)
+diff --git a/drivers/media/platform/tegra/camera/vi/graph.c b/drivers/media/platform/tegra/camera/vi/graph.c
+index 5e25cf6a..10956580 100644
+--- a/drivers/media/platform/tegra/camera/vi/graph.c
++++ b/drivers/media/platform/tegra/camera/vi/graph.c
+@@ -341,6 +341,8 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
+ 
+ 	if (sensor_mode &&
+ 		sensor_mode->image_properties.embedded_metadata_height > 0) {
++		chan->embedded.ops = s_data ? s_data->embedded_metadata_ops : NULL;
++		chan->embedded.dataformat = 0;
+ 		ret = tegra_channel_init_video_embedded(chan);
+ 		if (ret < 0) {
+ 			dev_err(chan->vi->dev,
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index 7f0cd1df..abb1df43 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -372,5 +372,40 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ }
+ 
++#define VI5_METADATA_LEGACY_D4XX_BYTESUSED 68
++
++/*
++ * No sensor ops means the pre-existing Tegra sidecar path: D4XX format,
++ * 255-byte queue capacity, and 68-byte payload. Sensors that register ops
++ * own their bytesused policy; invalid runtime sizes become error buffers.
++ */
++static unsigned int vi5_metadata_buffer_size(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->max_buffer_size)
++		return chan->embedded.ops->max_buffer_size;
++
++	return 255;
++}
++
++static unsigned int vi5_metadata_bytesused(struct tegra_channel *chan,
++	unsigned int captured_size)
++{
++	const struct tegra_embedded_metadata_ops *ops = chan->embedded.ops;
++	size_t bytesused;
++
++	if (!ops)
++		return min_t(unsigned int, captured_size,
++			     VI5_METADATA_LEGACY_D4XX_BYTESUSED);
++
++	if (!ops->get_bytesused)
++		return captured_size;
++
++	bytesused = ops->get_bytesused(chan->emb_buf_addr, captured_size);
++	if (bytesused && bytesused <= captured_size)
++		return bytesused;
++
++	return 0;
++}
++
+ static void vi5_release_metadata_buffer(struct tegra_channel *chan,
+ 	struct vb2_v4l2_buffer *vbuf)
+ {
+@@ -379,6 +413,8 @@ static void vi5_release_metadata_buffer(struct tegra_channel *chan,
+ 	struct vb2_buffer *evb = NULL;
+ 	struct vb2_v4l2_buffer *evbuf;
+ 	void* frm_buffer;
++	unsigned int copy_size;
++	unsigned int bytesused;
+ 
+ 	spin_lock(&chan->embedded.spin_lock);
+ 	if (0 < chan->embedded.num_buffers) {
+@@ -394,14 +431,37 @@ static void vi5_release_metadata_buffer(struct tegra_channel *chan,
+ 
+ 	frm_buffer = vb2_plane_vaddr(evb, 0);
+ 	if (!frm_buffer)
+-		return;
+-
+-	memcpy(frm_buffer, chan->emb_buf_addr, 255);
++		goto error;
++
++	copy_size = min_t(unsigned int, vi5_metadata_buffer_size(chan),
++		vb2_plane_size(evb, 0));
++	if (chan->embedded_data_width && chan->embedded_data_height)
++		copy_size = min_t(unsigned int, copy_size,
++			chan->embedded_data_width * chan->embedded_data_height *
++			BPP_MEM);
++	if (chan->emb_buf_size)
++		copy_size = min_t(unsigned int, copy_size, chan->emb_buf_size);
++	if (!copy_size)
++		goto error;
++
++	bytesused = vi5_metadata_bytesused(chan, copy_size);
++	if (!bytesused || bytesused > copy_size)
++		goto error;
++
++	memcpy(frm_buffer, chan->emb_buf_addr, bytesused);
+ 	evbuf = to_vb2_v4l2_buffer(evb);
+ 	evbuf->sequence = vbuf->sequence;
+-	vb2_set_plane_payload(evb, 0, 68);
++	vb2_set_plane_payload(evb, 0, bytesused);
+ 	evb->timestamp = vbuf->vb2_buf.timestamp;
+ 	vb2_buffer_done(evb, VB2_BUF_STATE_DONE);
++	return;
++
++error:
++	evbuf = to_vb2_v4l2_buffer(evb);
++	evbuf->sequence = vbuf->sequence;
++	vb2_set_plane_payload(evb, 0, 0);
++	evb->timestamp = vbuf->vb2_buf.timestamp;
++	vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
+ }
+ 
+ static void vi5_release_buffer(struct tegra_channel *chan,
+diff --git a/include/media/camera_common.h b/include/media/camera_common.h
+index 6b5ae91d..45cdff1f 100644
+--- a/include/media/camera_common.h
++++ b/include/media/camera_common.h
+@@ -30,6 +30,19 @@
+ #include <media/v4l2-ctrls.h>
+ #include <media/tegracam_core.h>
+ 
++#ifndef V4L2_META_FMT_RSMD
++#define V4L2_META_FMT_RSMD v4l2_fourcc('R', 'S', 'M', 'D') /* RealSense D5xx CSI metadata */
++#endif
++
++#define CONFIG_TEGRA_EMBEDDED_METADATA_OPS 1
++
++struct tegra_embedded_metadata_ops {
++	u32 dataformat;
++	u32 compat_dataformat;
++	u32 max_buffer_size;
++	size_t (*get_bytesused)(const u8 *data, size_t captured_size);
++};
++
+ /*
+  * Scaling factor for converting a Q10.22 fixed point value
+  * back to its original floating point value
+@@ -244,6 +257,7 @@ struct camera_common_data {
+ 	int	sensor_mode_id;
+ 	bool	use_sensor_mode_id;
+ 	bool	override_enable;
++	const struct tegra_embedded_metadata_ops *embedded_metadata_ops;
+ 	u32	version;
+ };
+ 
+diff --git a/include/media/mc_common.h b/include/media/mc_common.h
+index b87f527e..3e2f7eaf 100644
+--- a/include/media/mc_common.h
++++ b/include/media/mc_common.h
+@@ -70,6 +70,8 @@ enum interlaced_type {
+ 	Interleaved,
+ };
+ 
++struct tegra_embedded_metadata_ops;
++
+ /**
+  * struct tegra_channel_buffer - video channel buffer
+  * @buf: vb2 buffer base object
+@@ -253,6 +255,8 @@ struct tegra_channel {
+ 		void *alloc_ctx;
+ 		struct media_pad pad;
+ 		struct v4l2_ctrl_handler ctrl_handler;
++		const struct tegra_embedded_metadata_ops *ops;
++		u32 dataformat;
+ 	} embedded;
+ 
+ 	DECLARE_BITMAP(fmts_bitmap, MAX_FORMAT_NUM);
+
+-- 
+2.34.1

--- a/kernel/nvidia/5.1.2/0011-D5xx-metadata-sidecar-ops.patch
+++ b/kernel/nvidia/5.1.2/0011-D5xx-metadata-sidecar-ops.patch
@@ -1,0 +1,387 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zhou <shengyong.zhou@realsenseai.com>
+Date: Fri, 17 Jul 2026 13:30:00 +0800
+Subject: [PATCH] media: tegra: support sensor metadata ops
+
+Add a small per-sensor metadata ops hook for embedded metadata sidecar
+format negotiation, queue capacity, and runtime bytesused calculation.
+
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
+---
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index a9fadae0..3ee83f5a 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -2668,44 +2668,137 @@ static int tegra_metadata_querycap(struct file *file, void *fh,
+ 	return 0;
+ }
+ 
++static u32 tegra_metadata_native_dataformat(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->dataformat)
++		return chan->embedded.ops->dataformat;
++
++	return V4L2_META_FMT_D4XX;
++}
++
++static u32 tegra_metadata_compat_dataformat(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->compat_dataformat)
++		return chan->embedded.ops->compat_dataformat;
++
++	return tegra_metadata_native_dataformat(chan);
++}
++
++static u32 tegra_metadata_current_dataformat(struct tegra_channel *chan)
++{
++	if (chan->embedded.dataformat)
++		return chan->embedded.dataformat;
++
++	return tegra_metadata_native_dataformat(chan);
++}
++
++static bool tegra_metadata_dataformat_supported(struct tegra_channel *chan,
++						u32 dataformat)
++{
++	u32 native = tegra_metadata_native_dataformat(chan);
++	u32 compat = tegra_metadata_compat_dataformat(chan);
++
++	return dataformat == native || dataformat == compat;
++}
++
++static unsigned int tegra_metadata_buffer_size(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->max_buffer_size)
++		return chan->embedded.ops->max_buffer_size;
++
++	return 255;
++}
++
++static void tegra_metadata_format_description(u32 dataformat, char *description,
++					      size_t size)
++{
++	if (dataformat == V4L2_META_FMT_RSMD)
++		strlcpy(description, "RealSense D5xx CSI metadata", size);
++	else if (dataformat == V4L2_META_FMT_D4XX)
++		strlcpy(description, "D4XX metadata format", size);
++	else
++		strlcpy(description, "Embedded metadata format", size);
++}
++
+ static int tegra_metadata_enum_format(struct file *file, void *fh,
+                                      struct v4l2_fmtdesc *f)
+ {
+-	if (f->index)
++	struct tegra_channel *chan = video_drvdata(file);
++	u32 native = tegra_metadata_native_dataformat(chan);
++	u32 compat = tegra_metadata_compat_dataformat(chan);
++
++	if (f->index > 1 || (f->index == 1 && compat == native))
+ 		return -EINVAL;
+ 
+-	f->pixelformat = V4L2_META_FMT_D4XX;
+-	strlcpy(f->description, "D4XX metadata format", sizeof(f->description));
++	f->pixelformat = f->index ? compat : native;
++	tegra_metadata_format_description(f->pixelformat, f->description,
++					   sizeof(f->description));
+ 
+ 	return 0;
+ }
+ 
+-static int tegra_metadata_get_format(struct file *file, void *fh,
+-                                    struct v4l2_format *format)
++static int tegra_metadata_fill_format(struct tegra_channel *chan,
++				      struct v4l2_format *format,
++				      u32 dataformat)
+ {
+-	struct v4l2_fh *vfh = file->private_data;
+ 	struct v4l2_meta_format *fmt = &format->fmt.meta;
+ 
+-	if (format->type != vfh->vdev->queue->type)
++	if (format->type != V4L2_BUF_TYPE_META_CAPTURE)
+ 		return -EINVAL;
+ 
+ 	memset(fmt, 0, sizeof(*fmt));
+-
+-	fmt->dataformat = V4L2_META_FMT_D4XX;
+-	fmt->buffersize = 255;
++	fmt->dataformat = dataformat;
++	fmt->buffersize = tegra_metadata_buffer_size(chan);
+ 
+ 	return 0;
+ }
++
++static int tegra_metadata_get_format(struct file *file, void *fh,
++                                    struct v4l2_format *format)
++{
++	struct v4l2_fh *vfh = file->private_data;
++	struct tegra_channel *chan = video_drvdata(file);
++
++	if (format->type != vfh->vdev->queue->type)
++		return -EINVAL;
++
++	return tegra_metadata_fill_format(chan, format,
++					  tegra_metadata_current_dataformat(chan));
++}
+ static int tegra_metadata_set_format(struct file *file, void *fh,
+                                     struct v4l2_format *format)
+ {
+-   return 0;
++	struct tegra_channel *chan = video_drvdata(file);
++	u32 dataformat = format->fmt.meta.dataformat;
++
++	if (format->type != V4L2_BUF_TYPE_META_CAPTURE)
++		return -EINVAL;
++
++	if (!dataformat)
++		dataformat = tegra_metadata_native_dataformat(chan);
++	if (!tegra_metadata_dataformat_supported(chan, dataformat))
++		return -EINVAL;
++
++	chan->embedded.dataformat = dataformat;
++
++	return tegra_metadata_fill_format(chan, format, dataformat);
+ }
+ 
+ static int tegra_metadata_try_format(struct file *file, void *fh,
+                                     struct v4l2_format *format)
+ {
+-    return 0;
++	struct tegra_channel *chan = video_drvdata(file);
++	u32 dataformat = format->fmt.meta.dataformat;
++
++	if (format->type != V4L2_BUF_TYPE_META_CAPTURE)
++		return -EINVAL;
++
++	if (!dataformat)
++		dataformat = tegra_metadata_native_dataformat(chan);
++	if (!tegra_metadata_dataformat_supported(chan, dataformat))
++		return -EINVAL;
++
++	return tegra_metadata_fill_format(chan, format, dataformat);
+ }
+ static const struct v4l2_ioctl_ops tegra_metadata_ioctl_ops = {
+ 	.vidioc_querycap                = tegra_metadata_querycap,
+@@ -2728,19 +2821,20 @@ static int tegra_metadata_queue_setup(struct vb2_queue *vq,
+                     unsigned int sizes[], struct device *alloc_devs[])
+ {
+ 	struct tegra_channel *chan = vb2_get_drv_priv(vq);
++	unsigned int size = tegra_metadata_buffer_size(chan);
+ 
+ 	if (*nplanes) {
+ 		if (*nplanes != 1)
+ 			return -EINVAL;
+ 
+-		if (sizes[0] < 255)
++		if (sizes[0] < size)
+ 			return -EINVAL;
+ 
+ 		return 0;
+ 	}
+ 
+ 	*nplanes = 1;
+-	sizes[0] = 255;
++	sizes[0] = size;
+ 	alloc_devs[0] = chan->vi->dev;
+ 
+ 
+@@ -2749,10 +2843,12 @@ static int tegra_metadata_queue_setup(struct vb2_queue *vq,
+ 
+ static int tegra_metadata_buffer_prepare(struct vb2_buffer *vb)
+ {
++	struct tegra_channel *chan = vb2_get_drv_priv(vb->vb2_queue);
++
+ 	if (vb->num_planes != 1)
+ 		return -EINVAL;
+ 
+-	if (vb2_plane_size(vb, 0) < 255)
++	if (vb2_plane_size(vb, 0) < tegra_metadata_buffer_size(chan))
+ 		return -EINVAL;
+ 
+ 	return 0;
+@@ -2761,6 +2857,7 @@ static int tegra_metadata_buffer_prepare(struct vb2_buffer *vb)
+ static void tegra_metadata_buffer_queue(struct vb2_buffer *vb)
+ {
+ 	struct tegra_channel *chan = vb2_get_drv_priv(vb->vb2_queue);
++	bool queued = false;
+ 
+ 	spin_lock(&chan->embedded.spin_lock);
+ 	if (chan->embedded.num_buffers < 16) {
+@@ -2769,8 +2866,12 @@ static void tegra_metadata_buffer_queue(struct vb2_buffer *vb)
+ 		if (chan->embedded.head > 15)
+ 			chan->embedded.head = chan->embedded.head - 16;
+ 		chan->embedded.num_buffers++;
++		queued = true;
+ 	}
+ 	spin_unlock(&chan->embedded.spin_lock);
++
++	if (!queued)
++		vb2_buffer_done(vb, VB2_BUF_STATE_ERROR);
+ }
+ 
+ static int tegra_metadata_start_streaming(struct vb2_queue *vq, unsigned int count)
+diff --git a/drivers/media/platform/tegra/camera/vi/graph.c b/drivers/media/platform/tegra/camera/vi/graph.c
+index 5e25cf6a..10956580 100644
+--- a/drivers/media/platform/tegra/camera/vi/graph.c
++++ b/drivers/media/platform/tegra/camera/vi/graph.c
+@@ -341,6 +341,8 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
+ 
+ 	if (sensor_mode &&
+ 		sensor_mode->image_properties.embedded_metadata_height > 0) {
++		chan->embedded.ops = s_data ? s_data->embedded_metadata_ops : NULL;
++		chan->embedded.dataformat = 0;
+ 		ret = tegra_channel_init_video_embedded(chan);
+ 		if (ret < 0) {
+ 			dev_err(chan->vi->dev,
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index 7f0cd1df..abb1df43 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -423,11 +423,48 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ }
+ 
++#define VI5_METADATA_LEGACY_D4XX_BYTESUSED 68
++
++/*
++ * No sensor ops means the pre-existing Tegra sidecar path: D4XX format,
++ * 255-byte queue capacity, and 68-byte payload. Sensors that register ops
++ * own their bytesused policy; invalid runtime sizes become error buffers.
++ */
++static unsigned int vi5_metadata_buffer_size(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->max_buffer_size)
++		return chan->embedded.ops->max_buffer_size;
++
++	return 255;
++}
++
++static unsigned int vi5_metadata_bytesused(struct tegra_channel *chan,
++	unsigned int captured_size)
++{
++	const struct tegra_embedded_metadata_ops *ops = chan->embedded.ops;
++	size_t bytesused;
++
++	if (!ops)
++		return min_t(unsigned int, captured_size,
++			     VI5_METADATA_LEGACY_D4XX_BYTESUSED);
++
++	if (!ops->get_bytesused)
++		return captured_size;
++
++	bytesused = ops->get_bytesused(chan->emb_buf_addr, captured_size);
++	if (bytesused && bytesused <= captured_size)
++		return bytesused;
++
++	return 0;
++}
++
+ static void vi5_release_metadata_buffer(struct tegra_channel *chan,
+ 	struct vb2_v4l2_buffer *vbuf)
+ {
+ 	struct vb2_buffer *evb = NULL;
+ 	struct vb2_v4l2_buffer *evbuf;
+ 	void* frm_buffer;
++	unsigned int copy_size;
++	unsigned int bytesused;
+ 
+ 	spin_lock(&chan->embedded.spin_lock);
+ 	if (0 < chan->embedded.num_buffers) {
+@@ -445,14 +482,37 @@ static void vi5_release_metadata_buffer(struct tegra_channel *chan,
+ 
+ 	frm_buffer = vb2_plane_vaddr(evb, 0);
+ 	if (!frm_buffer)
+-		return;
+-
+-	memcpy(frm_buffer, chan->emb_buf_addr, 255);
++		goto error;
++
++	copy_size = min_t(unsigned int, vi5_metadata_buffer_size(chan),
++		vb2_plane_size(evb, 0));
++	if (chan->embedded_data_width && chan->embedded_data_height)
++		copy_size = min_t(unsigned int, copy_size,
++			chan->embedded_data_width * chan->embedded_data_height *
++			BPP_MEM);
++	if (chan->emb_buf_size)
++		copy_size = min_t(unsigned int, copy_size, chan->emb_buf_size);
++	if (!copy_size)
++		goto error;
++
++	bytesused = vi5_metadata_bytesused(chan, copy_size);
++	if (!bytesused || bytesused > copy_size)
++		goto error;
++
++	memcpy(frm_buffer, chan->emb_buf_addr, bytesused);
+ 	evbuf = to_vb2_v4l2_buffer(evb);
+ 	evbuf->sequence = vbuf->sequence;
+-	vb2_set_plane_payload(evb, 0, 68);
++	vb2_set_plane_payload(evb, 0, bytesused);
+ 	evb->timestamp = vbuf->vb2_buf.timestamp;
+ 	vb2_buffer_done(evb, VB2_BUF_STATE_DONE);
++	return;
++
++error:
++	evbuf = to_vb2_v4l2_buffer(evb);
++	evbuf->sequence = vbuf->sequence;
++	vb2_set_plane_payload(evb, 0, 0);
++	evb->timestamp = vbuf->vb2_buf.timestamp;
++	vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
+ }
+ 
+ static void vi5_release_buffer(struct tegra_channel *chan,
+diff --git a/include/media/camera_common.h b/include/media/camera_common.h
+index 6b5ae91d..45cdff1f 100644
+--- a/include/media/camera_common.h
++++ b/include/media/camera_common.h
+@@ -30,6 +30,19 @@
+ #include <media/v4l2-ctrls.h>
+ #include <media/tegracam_core.h>
+ 
++#ifndef V4L2_META_FMT_RSMD
++#define V4L2_META_FMT_RSMD v4l2_fourcc('R', 'S', 'M', 'D') /* RealSense D5xx CSI metadata */
++#endif
++
++#define CONFIG_TEGRA_EMBEDDED_METADATA_OPS 1
++
++struct tegra_embedded_metadata_ops {
++	u32 dataformat;
++	u32 compat_dataformat;
++	u32 max_buffer_size;
++	size_t (*get_bytesused)(const u8 *data, size_t captured_size);
++};
++
+ /*
+  * Scaling factor for converting a Q10.22 fixed point value
+  * back to its original floating point value
+@@ -244,6 +257,7 @@ struct camera_common_data {
+ 	int	sensor_mode_id;
+ 	bool	use_sensor_mode_id;
+ 	bool	override_enable;
++	const struct tegra_embedded_metadata_ops *embedded_metadata_ops;
+ 	u32	version;
+ };
+ 
+diff --git a/include/media/mc_common.h b/include/media/mc_common.h
+index b87f527e..3e2f7eaf 100644
+--- a/include/media/mc_common.h
++++ b/include/media/mc_common.h
+@@ -70,6 +70,8 @@ enum interlaced_type {
+ 	Interleaved,
+ };
+ 
++struct tegra_embedded_metadata_ops;
++
+ /**
+  * struct tegra_channel_buffer - video channel buffer
+  * @buf: vb2 buffer base object
+@@ -253,6 +255,8 @@ struct tegra_channel {
+ 		void *alloc_ctx;
+ 		struct media_pad pad;
+ 		struct v4l2_ctrl_handler ctrl_handler;
++		const struct tegra_embedded_metadata_ops *ops;
++		u32 dataformat;
+ 	} embedded;
+ 
+ 	DECLARE_BITMAP(fmts_bitmap, MAX_FORMAT_NUM);
+
+-- 
+2.34.1

--- a/kernel/nvidia/5.1.6/0011-D5xx-metadata-sidecar-ops.patch
+++ b/kernel/nvidia/5.1.6/0011-D5xx-metadata-sidecar-ops.patch
@@ -1,0 +1,366 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zhou <shengyong.zhou@realsenseai.com>
+Date: Fri, 17 Jul 2026 13:30:00 +0800
+Subject: [PATCH] media: tegra: support sensor metadata ops
+
+Add a small per-sensor metadata ops hook for embedded metadata sidecar
+format negotiation, queue capacity, and runtime bytesused calculation.
+
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
+---
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index a9fadae0..3ee83f5a 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -2668,44 +2668,137 @@ static int tegra_metadata_querycap(struct file *file, void *fh,
+ 	return 0;
+ }
+ 
++static u32 tegra_metadata_native_dataformat(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->dataformat)
++		return chan->embedded.ops->dataformat;
++
++	return V4L2_META_FMT_D4XX;
++}
++
++static u32 tegra_metadata_compat_dataformat(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->compat_dataformat)
++		return chan->embedded.ops->compat_dataformat;
++
++	return tegra_metadata_native_dataformat(chan);
++}
++
++static u32 tegra_metadata_current_dataformat(struct tegra_channel *chan)
++{
++	if (chan->embedded.dataformat)
++		return chan->embedded.dataformat;
++
++	return tegra_metadata_native_dataformat(chan);
++}
++
++static bool tegra_metadata_dataformat_supported(struct tegra_channel *chan,
++						u32 dataformat)
++{
++	u32 native = tegra_metadata_native_dataformat(chan);
++	u32 compat = tegra_metadata_compat_dataformat(chan);
++
++	return dataformat == native || dataformat == compat;
++}
++
++static unsigned int tegra_metadata_buffer_size(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->max_buffer_size)
++		return chan->embedded.ops->max_buffer_size;
++
++	return 255;
++}
++
++static void tegra_metadata_format_description(u32 dataformat, char *description,
++					      size_t size)
++{
++	if (dataformat == V4L2_META_FMT_RSMD)
++		strlcpy(description, "RealSense D5xx CSI metadata", size);
++	else if (dataformat == V4L2_META_FMT_D4XX)
++		strlcpy(description, "D4XX metadata format", size);
++	else
++		strlcpy(description, "Embedded metadata format", size);
++}
++
+ static int tegra_metadata_enum_format(struct file *file, void *fh,
+                                      struct v4l2_fmtdesc *f)
+ {
+-	if (f->index)
++	struct tegra_channel *chan = video_drvdata(file);
++	u32 native = tegra_metadata_native_dataformat(chan);
++	u32 compat = tegra_metadata_compat_dataformat(chan);
++
++	if (f->index > 1 || (f->index == 1 && compat == native))
+ 		return -EINVAL;
+ 
+-	f->pixelformat = V4L2_META_FMT_D4XX;
+-	strlcpy(f->description, "D4XX metadata format", sizeof(f->description));
++	f->pixelformat = f->index ? compat : native;
++	tegra_metadata_format_description(f->pixelformat, f->description,
++					   sizeof(f->description));
+ 
+ 	return 0;
+ }
+ 
+-static int tegra_metadata_get_format(struct file *file, void *fh,
+-                                    struct v4l2_format *format)
++static int tegra_metadata_fill_format(struct tegra_channel *chan,
++				      struct v4l2_format *format,
++				      u32 dataformat)
+ {
+-	struct v4l2_fh *vfh = file->private_data;
+ 	struct v4l2_meta_format *fmt = &format->fmt.meta;
+ 
+-	if (format->type != vfh->vdev->queue->type)
++	if (format->type != V4L2_BUF_TYPE_META_CAPTURE)
+ 		return -EINVAL;
+ 
+ 	memset(fmt, 0, sizeof(*fmt));
+-
+-	fmt->dataformat = V4L2_META_FMT_D4XX;
+-	fmt->buffersize = 255;
++	fmt->dataformat = dataformat;
++	fmt->buffersize = tegra_metadata_buffer_size(chan);
+ 
+ 	return 0;
+ }
++
++static int tegra_metadata_get_format(struct file *file, void *fh,
++                                    struct v4l2_format *format)
++{
++	struct v4l2_fh *vfh = file->private_data;
++	struct tegra_channel *chan = video_drvdata(file);
++
++	if (format->type != vfh->vdev->queue->type)
++		return -EINVAL;
++
++	return tegra_metadata_fill_format(chan, format,
++					  tegra_metadata_current_dataformat(chan));
++}
+ static int tegra_metadata_set_format(struct file *file, void *fh,
+                                     struct v4l2_format *format)
+ {
+-   return 0;
++	struct tegra_channel *chan = video_drvdata(file);
++	u32 dataformat = format->fmt.meta.dataformat;
++
++	if (format->type != V4L2_BUF_TYPE_META_CAPTURE)
++		return -EINVAL;
++
++	if (!dataformat)
++		dataformat = tegra_metadata_native_dataformat(chan);
++	if (!tegra_metadata_dataformat_supported(chan, dataformat))
++		return -EINVAL;
++
++	chan->embedded.dataformat = dataformat;
++
++	return tegra_metadata_fill_format(chan, format, dataformat);
+ }
+ 
+ static int tegra_metadata_try_format(struct file *file, void *fh,
+                                     struct v4l2_format *format)
+ {
+-    return 0;
++	struct tegra_channel *chan = video_drvdata(file);
++	u32 dataformat = format->fmt.meta.dataformat;
++
++	if (format->type != V4L2_BUF_TYPE_META_CAPTURE)
++		return -EINVAL;
++
++	if (!dataformat)
++		dataformat = tegra_metadata_native_dataformat(chan);
++	if (!tegra_metadata_dataformat_supported(chan, dataformat))
++		return -EINVAL;
++
++	return tegra_metadata_fill_format(chan, format, dataformat);
+ }
+ static const struct v4l2_ioctl_ops tegra_metadata_ioctl_ops = {
+ 	.vidioc_querycap                = tegra_metadata_querycap,
+@@ -2728,19 +2821,20 @@ static int tegra_metadata_queue_setup(struct vb2_queue *vq,
+                     unsigned int sizes[], struct device *alloc_devs[])
+ {
+ 	struct tegra_channel *chan = vb2_get_drv_priv(vq);
++	unsigned int size = tegra_metadata_buffer_size(chan);
+ 
+ 	if (*nplanes) {
+ 		if (*nplanes != 1)
+ 			return -EINVAL;
+ 
+-		if (sizes[0] < 255)
++		if (sizes[0] < size)
+ 			return -EINVAL;
+ 
+ 		return 0;
+ 	}
+ 
+ 	*nplanes = 1;
+-	sizes[0] = 255;
++	sizes[0] = size;
+ 	alloc_devs[0] = chan->vi->dev;
+ 
+ 
+@@ -2749,10 +2843,12 @@ static int tegra_metadata_queue_setup(struct vb2_queue *vq,
+ 
+ static int tegra_metadata_buffer_prepare(struct vb2_buffer *vb)
+ {
++	struct tegra_channel *chan = vb2_get_drv_priv(vb->vb2_queue);
++
+ 	if (vb->num_planes != 1)
+ 		return -EINVAL;
+ 
+-	if (vb2_plane_size(vb, 0) < 255)
++	if (vb2_plane_size(vb, 0) < tegra_metadata_buffer_size(chan))
+ 		return -EINVAL;
+ 
+ 	return 0;
+diff --git a/drivers/media/platform/tegra/camera/vi/graph.c b/drivers/media/platform/tegra/camera/vi/graph.c
+index 5e25cf6a..10956580 100644
+--- a/drivers/media/platform/tegra/camera/vi/graph.c
++++ b/drivers/media/platform/tegra/camera/vi/graph.c
+@@ -969,6 +969,8 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
+ 
+ 	if (sensor_mode &&
+ 			sensor_mode->image_properties.embedded_metadata_height > 0) {
++		chan->embedded.ops = s_data ? s_data->embedded_metadata_ops : NULL;
++		chan->embedded.dataformat = 0;
+ 		ret = tegra_channel_init_video_embedded(chan);
+ 		if (ret < 0) {
+ 			dev_err(chan->vi->dev,
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index 7f0cd1df..abb1df43 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -423,11 +423,48 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ }
+ 
++#define VI5_METADATA_LEGACY_D4XX_BYTESUSED 68
++
++/*
++ * No sensor ops means the pre-existing Tegra sidecar path: D4XX format,
++ * 255-byte queue capacity, and 68-byte payload. Sensors that register ops
++ * own their bytesused policy; invalid runtime sizes become error buffers.
++ */
++static unsigned int vi5_metadata_buffer_size(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->max_buffer_size)
++		return chan->embedded.ops->max_buffer_size;
++
++	return 255;
++}
++
++static unsigned int vi5_metadata_bytesused(struct tegra_channel *chan,
++	unsigned int captured_size)
++{
++	const struct tegra_embedded_metadata_ops *ops = chan->embedded.ops;
++	size_t bytesused;
++
++	if (!ops)
++		return min_t(unsigned int, captured_size,
++			     VI5_METADATA_LEGACY_D4XX_BYTESUSED);
++
++	if (!ops->get_bytesused)
++		return captured_size;
++
++	bytesused = ops->get_bytesused(chan->emb_buf_addr, captured_size);
++	if (bytesused && bytesused <= captured_size)
++		return bytesused;
++
++	return 0;
++}
++
+ static void vi5_release_metadata_buffer(struct tegra_channel *chan,
+ 	struct vb2_v4l2_buffer *vbuf)
+ {
+ 	struct vb2_buffer *evb = NULL;
+ 	struct vb2_v4l2_buffer *evbuf;
+ 	void* frm_buffer;
++	unsigned int copy_size;
++	unsigned int bytesused;
+ 
+ 	spin_lock(&chan->embedded.spin_lock);
+ 	if (0 < chan->embedded.num_buffers) {
+@@ -445,14 +482,37 @@ static void vi5_release_metadata_buffer(struct tegra_channel *chan,
+ 
+ 	frm_buffer = vb2_plane_vaddr(evb, 0);
+ 	if (!frm_buffer)
+-		return;
+-
+-	memcpy(frm_buffer, chan->emb_buf_addr, 255);
++		goto error;
++
++	copy_size = min_t(unsigned int, vi5_metadata_buffer_size(chan),
++		vb2_plane_size(evb, 0));
++	if (chan->embedded_data_width && chan->embedded_data_height)
++		copy_size = min_t(unsigned int, copy_size,
++			chan->embedded_data_width * chan->embedded_data_height *
++			BPP_MEM);
++	if (chan->emb_buf_size)
++		copy_size = min_t(unsigned int, copy_size, chan->emb_buf_size);
++	if (!copy_size)
++		goto error;
++
++	bytesused = vi5_metadata_bytesused(chan, copy_size);
++	if (!bytesused || bytesused > copy_size)
++		goto error;
++
++	memcpy(frm_buffer, chan->emb_buf_addr, bytesused);
+ 	evbuf = to_vb2_v4l2_buffer(evb);
+ 	evbuf->sequence = vbuf->sequence;
+-	vb2_set_plane_payload(evb, 0, 68);
++	vb2_set_plane_payload(evb, 0, bytesused);
+ 	evb->timestamp = vbuf->vb2_buf.timestamp;
+ 	vb2_buffer_done(evb, VB2_BUF_STATE_DONE);
++	return;
++
++error:
++	evbuf = to_vb2_v4l2_buffer(evb);
++	evbuf->sequence = vbuf->sequence;
++	vb2_set_plane_payload(evb, 0, 0);
++	evb->timestamp = vbuf->vb2_buf.timestamp;
++	vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
+ }
+ 
+ static void vi5_release_buffer(struct tegra_channel *chan,
+diff --git a/include/media/camera_common.h b/include/media/camera_common.h
+index 6b5ae91d..45cdff1f 100644
+--- a/include/media/camera_common.h
++++ b/include/media/camera_common.h
+@@ -30,6 +30,19 @@
+ #include <media/v4l2-ctrls.h>
+ #include <media/tegracam_core.h>
+ 
++#ifndef V4L2_META_FMT_RSMD
++#define V4L2_META_FMT_RSMD v4l2_fourcc('R', 'S', 'M', 'D') /* RealSense D5xx CSI metadata */
++#endif
++
++#define CONFIG_TEGRA_EMBEDDED_METADATA_OPS 1
++
++struct tegra_embedded_metadata_ops {
++	u32 dataformat;
++	u32 compat_dataformat;
++	u32 max_buffer_size;
++	size_t (*get_bytesused)(const u8 *data, size_t captured_size);
++};
++
+ /*
+  * Scaling factor for converting a Q10.22 fixed point value
+  * back to its original floating point value
+@@ -244,6 +257,7 @@ struct camera_common_data {
+ 	int	sensor_mode_id;
+ 	bool	use_sensor_mode_id;
+ 	bool	override_enable;
++	const struct tegra_embedded_metadata_ops *embedded_metadata_ops;
+ 	u32	version;
+ };
+ 
+diff --git a/include/media/mc_common.h b/include/media/mc_common.h
+index b87f527e..3e2f7eaf 100644
+--- a/include/media/mc_common.h
++++ b/include/media/mc_common.h
+@@ -70,6 +70,8 @@ enum interlaced_type {
+ 	Interleaved,
+ };
+ 
++struct tegra_embedded_metadata_ops;
++
+ /**
+  * struct tegra_channel_buffer - video channel buffer
+  * @buf: vb2 buffer base object
+@@ -253,6 +255,8 @@ struct tegra_channel {
+ 		void *alloc_ctx;
+ 		struct media_pad pad;
+ 		struct v4l2_ctrl_handler ctrl_handler;
++		const struct tegra_embedded_metadata_ops *ops;
++		u32 dataformat;
+ 	} embedded;
+ 
+ 	DECLARE_BITMAP(fmts_bitmap, MAX_FORMAT_NUM);
+
+-- 
+2.34.1

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -179,6 +179,8 @@ struct dser_interface {
 #define DS5_STATUS_INVALID_FPS		0x8
 
 #define MIPI_LANE_RATE			1000
+#define DS5_MIPI_METADATA_CAPACITY	255
+#define DS5_MIPI_METADATA_BYTESUSED	68
 
 #define MAX_DEPTH_EXP			200000
 #define MAX_RGB_EXP			10000
@@ -2677,6 +2679,26 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 }
 
 static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on);
+
+#if defined(CONFIG_TEGRA_CAMERA_PLATFORM) && defined(CONFIG_TEGRA_EMBEDDED_METADATA_OPS)
+/*
+ * Legacy D4xx MIPI sidecar ABI on Tegra allocates a 255-byte metadata
+ * buffer but reports only the fixed 68-byte D4XX payload as bytesused.
+ * Keep this policy in the D4xx sensor ops instead of the generic VI path.
+ */
+static size_t ds5_mipi_metadata_bytesused(const u8 *data, size_t captured_size)
+{
+	(void)data;
+
+	return min_t(size_t, captured_size, DS5_MIPI_METADATA_BYTESUSED);
+}
+
+static const struct tegra_embedded_metadata_ops ds5_mipi_metadata_ops = {
+	.dataformat = V4L2_META_FMT_D4XX,
+	.max_buffer_size = DS5_MIPI_METADATA_CAPACITY,
+	.get_bytesused = ds5_mipi_metadata_bytesused,
+};
+#endif
 
 static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 {
@@ -5376,6 +5398,9 @@ static int ds5_mux_init(struct i2c_client *c, struct ds5 *state)
 		state->mux.last_set = &state->imu.sensor;
 
 	state->mux.sd.dev = &c->dev;
+#if defined(CONFIG_TEGRA_CAMERA_PLATFORM) && defined(CONFIG_TEGRA_EMBEDDED_METADATA_OPS)
+	state->mux.sd.embedded_metadata_ops = &ds5_mipi_metadata_ops;
+#endif
 	ret = camera_common_initialize(&state->mux.sd, "d4xx");
 	if (ret) {
 		dev_err(&c->dev, "Failed to initialize d4xx.\n");

--- a/kernel/realsense/d5xx.c
+++ b/kernel/realsense/d5xx.c
@@ -31,6 +31,7 @@
 #include <linux/videodev2.h>
 #include <linux/version.h>
 #include <linux/mutex.h>
+#include <asm/unaligned.h>
 #include <media/media-entity.h>
 #include <media/v4l2-ctrls.h>
 #include <media/v4l2-device.h>
@@ -192,6 +193,10 @@ struct dser_interface {
 #define DS5_STATUS_UNAVAILABLE		0xffff
 
 #define MIPI_LANE_RATE				1300
+#define DS5_CSI_METADATA_MAGIC		0x484B524D
+#define DS5_CSI_METADATA_HEADER_SIZE	20
+#define DS5_CSI_METADATA_PAYLOAD_OFFSET	8
+#define DS5_CSI_METADATA_MAX_WC		4096
 
 #define MAX_DEPTH_EXP				200000
 #define MAX_RGB_EXP					10000
@@ -2818,6 +2823,39 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 }
 
 static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on);
+
+#if defined(CONFIG_TEGRA_CAMERA_PLATFORM) && defined(CONFIG_TEGRA_EMBEDDED_METADATA_OPS)
+/*
+ * D5xx CSI metadata carries an HKRM transport header. The kernel only
+ * validates the framing needed to publish the actual sidecar bytesused;
+ * semantic metadata parsing stays in userspace.
+ */
+static size_t ds5_csi_metadata_bytesused(const u8 *data, size_t captured_size)
+{
+	u16 payload_size;
+	size_t bytesused;
+
+	if (!data || captured_size < DS5_CSI_METADATA_HEADER_SIZE)
+		return 0;
+
+	if (get_unaligned_le32(data) != DS5_CSI_METADATA_MAGIC)
+		return 0;
+
+	payload_size = get_unaligned_le16(data + DS5_CSI_METADATA_PAYLOAD_OFFSET);
+	bytesused = DS5_CSI_METADATA_HEADER_SIZE + payload_size;
+	if (!payload_size || bytesused > captured_size)
+		return 0;
+
+	return bytesused;
+}
+
+static const struct tegra_embedded_metadata_ops ds5_csi_metadata_ops = {
+	.dataformat = V4L2_META_FMT_RSMD,
+	.compat_dataformat = V4L2_META_FMT_D4XX,
+	.max_buffer_size = DS5_CSI_METADATA_MAX_WC,
+	.get_bytesused = ds5_csi_metadata_bytesused,
+};
+#endif
 
 static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 {
@@ -5505,8 +5543,9 @@ static int ds5_mux_get_frame_desc(struct v4l2_subdev *sd,
 		desc->entry[i].pixelcode = MEDIA_BUS_FMT_FIXED;
 		desc->entry[i].length = 0;
 		if (i == desc->num_entries - 1) {
-			desc->entry[i].pixelcode = 0x12;
-			desc->entry[i].length = 68;
+			desc->entry[i].flags = V4L2_MBUS_FRAME_DESC_FL_LEN_MAX;
+			desc->entry[i].pixelcode = MEDIA_BUS_FMT_FIXED;
+			desc->entry[i].length = DS5_CSI_METADATA_MAX_WC;
 		}
 	}
 	return 0;
@@ -5737,6 +5776,9 @@ static int ds5_mux_init(struct i2c_client *c, struct ds5 *state)
 		state->mux.last_set = &state->imu.sensor;
 
 	state->mux.sd.dev = &c->dev;
+#if defined(CONFIG_TEGRA_CAMERA_PLATFORM) && defined(CONFIG_TEGRA_EMBEDDED_METADATA_OPS)
+	state->mux.sd.embedded_metadata_ops = &ds5_csi_metadata_ops;
+#endif
 	ret = camera_common_initialize(&state->mux.sd, "d5xx");
 	if (ret) {
 		dev_err(&c->dev, "Failed to initialize d5xx.\n");

--- a/nvidia-oot/6.0/0013-D5xx-metadata-sidecar-ops.patch
+++ b/nvidia-oot/6.0/0013-D5xx-metadata-sidecar-ops.patch
@@ -1,0 +1,388 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zhou <shengyong.zhou@realsenseai.com>
+Date: Fri, 17 Jul 2026 13:30:00 +0800
+Subject: [PATCH] media: tegra: support sensor metadata ops
+
+Add a small per-sensor metadata ops hook for embedded metadata sidecar
+format negotiation, queue capacity, and runtime bytesused calculation.
+
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
+---
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index a9fadae0..3ee83f5a 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -2668,44 +2668,137 @@ static int tegra_metadata_querycap(struct file *file, void *fh,
+ 	return 0;
+ }
+ 
++static u32 tegra_metadata_native_dataformat(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->dataformat)
++		return chan->embedded.ops->dataformat;
++
++	return V4L2_META_FMT_D4XX;
++}
++
++static u32 tegra_metadata_compat_dataformat(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->compat_dataformat)
++		return chan->embedded.ops->compat_dataformat;
++
++	return tegra_metadata_native_dataformat(chan);
++}
++
++static u32 tegra_metadata_current_dataformat(struct tegra_channel *chan)
++{
++	if (chan->embedded.dataformat)
++		return chan->embedded.dataformat;
++
++	return tegra_metadata_native_dataformat(chan);
++}
++
++static bool tegra_metadata_dataformat_supported(struct tegra_channel *chan,
++						u32 dataformat)
++{
++	u32 native = tegra_metadata_native_dataformat(chan);
++	u32 compat = tegra_metadata_compat_dataformat(chan);
++
++	return dataformat == native || dataformat == compat;
++}
++
++static unsigned int tegra_metadata_buffer_size(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->max_buffer_size)
++		return chan->embedded.ops->max_buffer_size;
++
++	return 255;
++}
++
++static void tegra_metadata_format_description(u32 dataformat, char *description,
++					      size_t size)
++{
++	if (dataformat == V4L2_META_FMT_RSMD)
++		strlcpy(description, "RealSense D5xx CSI metadata", size);
++	else if (dataformat == V4L2_META_FMT_D4XX)
++		strlcpy(description, "D4XX metadata format", size);
++	else
++		strlcpy(description, "Embedded metadata format", size);
++}
++
+ static int tegra_metadata_enum_format(struct file *file, void *fh,
+                                      struct v4l2_fmtdesc *f)
+ {
+-	if (f->index)
++	struct tegra_channel *chan = video_drvdata(file);
++	u32 native = tegra_metadata_native_dataformat(chan);
++	u32 compat = tegra_metadata_compat_dataformat(chan);
++
++	if (f->index > 1 || (f->index == 1 && compat == native))
+ 		return -EINVAL;
+ 
+-	f->pixelformat = V4L2_META_FMT_D4XX;
+-	strlcpy(f->description, "D4XX metadata format", sizeof(f->description));
++	f->pixelformat = f->index ? compat : native;
++	tegra_metadata_format_description(f->pixelformat, f->description,
++					   sizeof(f->description));
+ 
+ 	return 0;
+ }
+ 
+-static int tegra_metadata_get_format(struct file *file, void *fh,
+-                                    struct v4l2_format *format)
++static int tegra_metadata_fill_format(struct tegra_channel *chan,
++				      struct v4l2_format *format,
++				      u32 dataformat)
+ {
+-	struct v4l2_fh *vfh = file->private_data;
+ 	struct v4l2_meta_format *fmt = &format->fmt.meta;
+ 
+-	if (format->type != vfh->vdev->queue->type)
++	if (format->type != V4L2_BUF_TYPE_META_CAPTURE)
+ 		return -EINVAL;
+ 
+ 	memset(fmt, 0, sizeof(*fmt));
+-
+-	fmt->dataformat = V4L2_META_FMT_D4XX;
+-	fmt->buffersize = 255;
++	fmt->dataformat = dataformat;
++	fmt->buffersize = tegra_metadata_buffer_size(chan);
+ 
+ 	return 0;
+ }
++
++static int tegra_metadata_get_format(struct file *file, void *fh,
++                                    struct v4l2_format *format)
++{
++	struct v4l2_fh *vfh = file->private_data;
++	struct tegra_channel *chan = video_drvdata(file);
++
++	if (format->type != vfh->vdev->queue->type)
++		return -EINVAL;
++
++	return tegra_metadata_fill_format(chan, format,
++					  tegra_metadata_current_dataformat(chan));
++}
+ static int tegra_metadata_set_format(struct file *file, void *fh,
+                                     struct v4l2_format *format)
+ {
+-   return 0;
++	struct tegra_channel *chan = video_drvdata(file);
++	u32 dataformat = format->fmt.meta.dataformat;
++
++	if (format->type != V4L2_BUF_TYPE_META_CAPTURE)
++		return -EINVAL;
++
++	if (!dataformat)
++		dataformat = tegra_metadata_native_dataformat(chan);
++	if (!tegra_metadata_dataformat_supported(chan, dataformat))
++		return -EINVAL;
++
++	chan->embedded.dataformat = dataformat;
++
++	return tegra_metadata_fill_format(chan, format, dataformat);
+ }
+ 
+ static int tegra_metadata_try_format(struct file *file, void *fh,
+                                     struct v4l2_format *format)
+ {
+-    return 0;
++	struct tegra_channel *chan = video_drvdata(file);
++	u32 dataformat = format->fmt.meta.dataformat;
++
++	if (format->type != V4L2_BUF_TYPE_META_CAPTURE)
++		return -EINVAL;
++
++	if (!dataformat)
++		dataformat = tegra_metadata_native_dataformat(chan);
++	if (!tegra_metadata_dataformat_supported(chan, dataformat))
++		return -EINVAL;
++
++	return tegra_metadata_fill_format(chan, format, dataformat);
+ }
+ static const struct v4l2_ioctl_ops tegra_metadata_ioctl_ops = {
+ 	.vidioc_querycap                = tegra_metadata_querycap,
+@@ -2728,19 +2821,20 @@ static int tegra_metadata_queue_setup(struct vb2_queue *vq,
+                     unsigned int sizes[], struct device *alloc_devs[])
+ {
+ 	struct tegra_channel *chan = vb2_get_drv_priv(vq);
++	unsigned int size = tegra_metadata_buffer_size(chan);
+ 
+ 	if (*nplanes) {
+ 		if (*nplanes != 1)
+ 			return -EINVAL;
+ 
+-		if (sizes[0] < 255)
++		if (sizes[0] < size)
+ 			return -EINVAL;
+ 
+ 		return 0;
+ 	}
+ 
+ 	*nplanes = 1;
+-	sizes[0] = 255;
++	sizes[0] = size;
+ 	alloc_devs[0] = chan->vi->dev;
+ 
+ 
+@@ -2749,10 +2843,12 @@ static int tegra_metadata_queue_setup(struct vb2_queue *vq,
+ 
+ static int tegra_metadata_buffer_prepare(struct vb2_buffer *vb)
+ {
++	struct tegra_channel *chan = vb2_get_drv_priv(vb->vb2_queue);
++
+ 	if (vb->num_planes != 1)
+ 		return -EINVAL;
+ 
+-	if (vb2_plane_size(vb, 0) < 255)
++	if (vb2_plane_size(vb, 0) < tegra_metadata_buffer_size(chan))
+ 		return -EINVAL;
+ 
+ 	return 0;
+@@ -2761,6 +2857,7 @@ static int tegra_metadata_buffer_prepare(struct vb2_buffer *vb)
+ static void tegra_metadata_buffer_queue(struct vb2_buffer *vb)
+ {
+ 	struct tegra_channel *chan = vb2_get_drv_priv(vb->vb2_queue);
++	bool queued = false;
+ 
+ 	spin_lock(&chan->embedded.spin_lock);
+ 	if (chan->embedded.num_buffers < 16) {
+@@ -2769,8 +2866,12 @@ static void tegra_metadata_buffer_queue(struct vb2_buffer *vb)
+ 		if (chan->embedded.head > 15)
+ 			chan->embedded.head = chan->embedded.head - 16;
+ 		chan->embedded.num_buffers++;
++		queued = true;
+ 	}
+ 	spin_unlock(&chan->embedded.spin_lock);
++
++	if (!queued)
++		vb2_buffer_done(vb, VB2_BUF_STATE_ERROR);
+ }
+ 
+ static int tegra_metadata_start_streaming(struct vb2_queue *vq, unsigned int count)
+diff --git a/drivers/media/platform/tegra/camera/vi/graph.c b/drivers/media/platform/tegra/camera/vi/graph.c
+index 5e25cf6a..10956580 100644
+--- a/drivers/media/platform/tegra/camera/vi/graph.c
++++ b/drivers/media/platform/tegra/camera/vi/graph.c
+@@ -341,6 +341,8 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
+ 
+ 	if (sensor_mode &&
+ 		sensor_mode->image_properties.embedded_metadata_height > 0) {
++		chan->embedded.ops = s_data ? s_data->embedded_metadata_ops : NULL;
++		chan->embedded.dataformat = 0;
+ 		ret = tegra_channel_init_video_embedded(chan);
+ 		if (ret < 0) {
+ 			dev_err(chan->vi->dev,
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index 7f0cd1df..abb1df43 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -445,12 +445,49 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 		chan->capture_descr_sequence += 1;
+ }
+ 
++#define VI5_METADATA_LEGACY_D4XX_BYTESUSED 68
++
++/*
++ * No sensor ops means the pre-existing Tegra sidecar path: D4XX format,
++ * 255-byte queue capacity, and 68-byte payload. Sensors that register ops
++ * own their bytesused policy; invalid runtime sizes become error buffers.
++ */
++static unsigned int vi5_metadata_buffer_size(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->max_buffer_size)
++		return chan->embedded.ops->max_buffer_size;
++
++	return 255;
++}
++
++static unsigned int vi5_metadata_bytesused(struct tegra_channel *chan,
++	unsigned int captured_size)
++{
++	const struct tegra_embedded_metadata_ops *ops = chan->embedded.ops;
++	size_t bytesused;
++
++	if (!ops)
++		return min_t(unsigned int, captured_size,
++			     VI5_METADATA_LEGACY_D4XX_BYTESUSED);
++
++	if (!ops->get_bytesused)
++		return captured_size;
++
++	bytesused = ops->get_bytesused(chan->emb_buf_addr, captured_size);
++	if (bytesused && bytesused <= captured_size)
++		return bytesused;
++
++	return 0;
++}
++
+ static void vi5_release_metadata_buffer(struct tegra_channel *chan,
+ 	struct vb2_v4l2_buffer *vbuf)
+ {
+ 	struct vb2_buffer *evb = NULL;
+ 	struct vb2_v4l2_buffer *evbuf;
+ 	void* frm_buffer;
++	unsigned int copy_size;
++	unsigned int bytesused;
+ 
+ 	spin_lock(&chan->embedded.spin_lock);
+ 	if (0 < chan->embedded.num_buffers) {
+@@ -468,14 +505,37 @@ static void vi5_release_metadata_buffer(struct tegra_channel *chan,
+ 
+ 	frm_buffer = vb2_plane_vaddr(evb, 0);
+ 	if (!frm_buffer)
+-		return;
+-
+-	memcpy(frm_buffer, chan->emb_buf_addr, 255);
++		goto error;
++
++	copy_size = min_t(unsigned int, vi5_metadata_buffer_size(chan),
++		vb2_plane_size(evb, 0));
++	if (chan->embedded_data_width && chan->embedded_data_height)
++		copy_size = min_t(unsigned int, copy_size,
++			chan->embedded_data_width * chan->embedded_data_height *
++			BPP_MEM);
++	if (chan->emb_buf_size)
++		copy_size = min_t(unsigned int, copy_size, chan->emb_buf_size);
++	if (!copy_size)
++		goto error;
++
++	bytesused = vi5_metadata_bytesused(chan, copy_size);
++	if (!bytesused || bytesused > copy_size)
++		goto error;
++
++	memcpy(frm_buffer, chan->emb_buf_addr, bytesused);
+ 	evbuf = to_vb2_v4l2_buffer(evb);
+ 	evbuf->sequence = vbuf->sequence;
+-	vb2_set_plane_payload(evb, 0, 68);
++	vb2_set_plane_payload(evb, 0, bytesused);
+ 	evb->timestamp = vbuf->vb2_buf.timestamp;
+ 	vb2_buffer_done(evb, VB2_BUF_STATE_DONE);
++	return;
++
++error:
++	evbuf = to_vb2_v4l2_buffer(evb);
++	evbuf->sequence = vbuf->sequence;
++	vb2_set_plane_payload(evb, 0, 0);
++	evb->timestamp = vbuf->vb2_buf.timestamp;
++	vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
+ }
+ 
+ static void vi5_release_buffer(struct tegra_channel *chan,
+diff --git a/include/media/camera_common.h b/include/media/camera_common.h
+index 6b5ae91d..45cdff1f 100644
+--- a/include/media/camera_common.h
++++ b/include/media/camera_common.h
+@@ -30,6 +30,19 @@
+ #include <media/v4l2-ctrls.h>
+ #include <media/tegracam_core.h>
+ 
++#ifndef V4L2_META_FMT_RSMD
++#define V4L2_META_FMT_RSMD v4l2_fourcc('R', 'S', 'M', 'D') /* RealSense D5xx CSI metadata */
++#endif
++
++#define CONFIG_TEGRA_EMBEDDED_METADATA_OPS 1
++
++struct tegra_embedded_metadata_ops {
++	u32 dataformat;
++	u32 compat_dataformat;
++	u32 max_buffer_size;
++	size_t (*get_bytesused)(const u8 *data, size_t captured_size);
++};
++
+ /*
+  * Scaling factor for converting a Q10.22 fixed point value
+  * back to its original floating point value
+@@ -244,6 +257,7 @@ struct camera_common_data {
+ 	int	sensor_mode_id;
+ 	bool	use_sensor_mode_id;
+ 	bool	override_enable;
++	const struct tegra_embedded_metadata_ops *embedded_metadata_ops;
+ 	u32	version;
+ };
+ 
+diff --git a/include/media/mc_common.h b/include/media/mc_common.h
+index b87f527e..3e2f7eaf 100644
+--- a/include/media/mc_common.h
++++ b/include/media/mc_common.h
+@@ -70,6 +70,8 @@ enum interlaced_type {
+ 	Interleaved,
+ };
+ 
++struct tegra_embedded_metadata_ops;
++
+ /**
+  * struct tegra_channel_buffer - video channel buffer
+  * @buf: vb2 buffer base object
+@@ -253,6 +255,8 @@ struct tegra_channel {
+ 		void *alloc_ctx;
+ 		struct media_pad pad;
+ 		struct v4l2_ctrl_handler ctrl_handler;
++		const struct tegra_embedded_metadata_ops *ops;
++		u32 dataformat;
+ 	} embedded;
+ 
+ 	DECLARE_BITMAP(fmts_bitmap, MAX_FORMAT_NUM);
+
+-- 
+2.34.1

--- a/nvidia-oot/6.1/0013-D5xx-metadata-sidecar-ops.patch
+++ b/nvidia-oot/6.1/0013-D5xx-metadata-sidecar-ops.patch
@@ -1,0 +1,1 @@
+../6.0/0013-D5xx-metadata-sidecar-ops.patch

--- a/nvidia-oot/6.2/0013-D5xx-metadata-sidecar-ops.patch
+++ b/nvidia-oot/6.2/0013-D5xx-metadata-sidecar-ops.patch
@@ -1,0 +1,388 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zhou <shengyong.zhou@realsenseai.com>
+Date: Fri, 17 Jul 2026 13:30:00 +0800
+Subject: [PATCH] media: tegra: support sensor metadata ops
+
+Add a small per-sensor metadata ops hook for embedded metadata sidecar
+format negotiation, queue capacity, and runtime bytesused calculation.
+
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
+---
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index a9fadae0..3ee83f5a 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -2668,44 +2668,137 @@ static int tegra_metadata_querycap(struct file *file, void *fh,
+ 	return 0;
+ }
+ 
++static u32 tegra_metadata_native_dataformat(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->dataformat)
++		return chan->embedded.ops->dataformat;
++
++	return V4L2_META_FMT_D4XX;
++}
++
++static u32 tegra_metadata_compat_dataformat(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->compat_dataformat)
++		return chan->embedded.ops->compat_dataformat;
++
++	return tegra_metadata_native_dataformat(chan);
++}
++
++static u32 tegra_metadata_current_dataformat(struct tegra_channel *chan)
++{
++	if (chan->embedded.dataformat)
++		return chan->embedded.dataformat;
++
++	return tegra_metadata_native_dataformat(chan);
++}
++
++static bool tegra_metadata_dataformat_supported(struct tegra_channel *chan,
++						u32 dataformat)
++{
++	u32 native = tegra_metadata_native_dataformat(chan);
++	u32 compat = tegra_metadata_compat_dataformat(chan);
++
++	return dataformat == native || dataformat == compat;
++}
++
++static unsigned int tegra_metadata_buffer_size(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->max_buffer_size)
++		return chan->embedded.ops->max_buffer_size;
++
++	return 255;
++}
++
++static void tegra_metadata_format_description(u32 dataformat, char *description,
++					      size_t size)
++{
++	if (dataformat == V4L2_META_FMT_RSMD)
++		strlcpy(description, "RealSense D5xx CSI metadata", size);
++	else if (dataformat == V4L2_META_FMT_D4XX)
++		strlcpy(description, "D4XX metadata format", size);
++	else
++		strlcpy(description, "Embedded metadata format", size);
++}
++
+ static int tegra_metadata_enum_format(struct file *file, void *fh,
+                                      struct v4l2_fmtdesc *f)
+ {
+-	if (f->index)
++	struct tegra_channel *chan = video_drvdata(file);
++	u32 native = tegra_metadata_native_dataformat(chan);
++	u32 compat = tegra_metadata_compat_dataformat(chan);
++
++	if (f->index > 1 || (f->index == 1 && compat == native))
+ 		return -EINVAL;
+ 
+-	f->pixelformat = V4L2_META_FMT_D4XX;
+-	strlcpy(f->description, "D4XX metadata format", sizeof(f->description));
++	f->pixelformat = f->index ? compat : native;
++	tegra_metadata_format_description(f->pixelformat, f->description,
++					   sizeof(f->description));
+ 
+ 	return 0;
+ }
+ 
+-static int tegra_metadata_get_format(struct file *file, void *fh,
+-                                    struct v4l2_format *format)
++static int tegra_metadata_fill_format(struct tegra_channel *chan,
++				      struct v4l2_format *format,
++				      u32 dataformat)
+ {
+-	struct v4l2_fh *vfh = file->private_data;
+ 	struct v4l2_meta_format *fmt = &format->fmt.meta;
+ 
+-	if (format->type != vfh->vdev->queue->type)
++	if (format->type != V4L2_BUF_TYPE_META_CAPTURE)
+ 		return -EINVAL;
+ 
+ 	memset(fmt, 0, sizeof(*fmt));
+-
+-	fmt->dataformat = V4L2_META_FMT_D4XX;
+-	fmt->buffersize = 255;
++	fmt->dataformat = dataformat;
++	fmt->buffersize = tegra_metadata_buffer_size(chan);
+ 
+ 	return 0;
+ }
++
++static int tegra_metadata_get_format(struct file *file, void *fh,
++                                    struct v4l2_format *format)
++{
++	struct v4l2_fh *vfh = file->private_data;
++	struct tegra_channel *chan = video_drvdata(file);
++
++	if (format->type != vfh->vdev->queue->type)
++		return -EINVAL;
++
++	return tegra_metadata_fill_format(chan, format,
++					  tegra_metadata_current_dataformat(chan));
++}
+ static int tegra_metadata_set_format(struct file *file, void *fh,
+                                     struct v4l2_format *format)
+ {
+-   return 0;
++	struct tegra_channel *chan = video_drvdata(file);
++	u32 dataformat = format->fmt.meta.dataformat;
++
++	if (format->type != V4L2_BUF_TYPE_META_CAPTURE)
++		return -EINVAL;
++
++	if (!dataformat)
++		dataformat = tegra_metadata_native_dataformat(chan);
++	if (!tegra_metadata_dataformat_supported(chan, dataformat))
++		return -EINVAL;
++
++	chan->embedded.dataformat = dataformat;
++
++	return tegra_metadata_fill_format(chan, format, dataformat);
+ }
+ 
+ static int tegra_metadata_try_format(struct file *file, void *fh,
+                                     struct v4l2_format *format)
+ {
+-    return 0;
++	struct tegra_channel *chan = video_drvdata(file);
++	u32 dataformat = format->fmt.meta.dataformat;
++
++	if (format->type != V4L2_BUF_TYPE_META_CAPTURE)
++		return -EINVAL;
++
++	if (!dataformat)
++		dataformat = tegra_metadata_native_dataformat(chan);
++	if (!tegra_metadata_dataformat_supported(chan, dataformat))
++		return -EINVAL;
++
++	return tegra_metadata_fill_format(chan, format, dataformat);
+ }
+ static const struct v4l2_ioctl_ops tegra_metadata_ioctl_ops = {
+ 	.vidioc_querycap                = tegra_metadata_querycap,
+@@ -2728,19 +2821,20 @@ static int tegra_metadata_queue_setup(struct vb2_queue *vq,
+                     unsigned int sizes[], struct device *alloc_devs[])
+ {
+ 	struct tegra_channel *chan = vb2_get_drv_priv(vq);
++	unsigned int size = tegra_metadata_buffer_size(chan);
+ 
+ 	if (*nplanes) {
+ 		if (*nplanes != 1)
+ 			return -EINVAL;
+ 
+-		if (sizes[0] < 255)
++		if (sizes[0] < size)
+ 			return -EINVAL;
+ 
+ 		return 0;
+ 	}
+ 
+ 	*nplanes = 1;
+-	sizes[0] = 255;
++	sizes[0] = size;
+ 	alloc_devs[0] = chan->vi->dev;
+ 
+ 
+@@ -2749,10 +2843,12 @@ static int tegra_metadata_queue_setup(struct vb2_queue *vq,
+ 
+ static int tegra_metadata_buffer_prepare(struct vb2_buffer *vb)
+ {
++	struct tegra_channel *chan = vb2_get_drv_priv(vb->vb2_queue);
++
+ 	if (vb->num_planes != 1)
+ 		return -EINVAL;
+ 
+-	if (vb2_plane_size(vb, 0) < 255)
++	if (vb2_plane_size(vb, 0) < tegra_metadata_buffer_size(chan))
+ 		return -EINVAL;
+ 
+ 	return 0;
+@@ -2761,6 +2857,7 @@ static int tegra_metadata_buffer_prepare(struct vb2_buffer *vb)
+ static void tegra_metadata_buffer_queue(struct vb2_buffer *vb)
+ {
+ 	struct tegra_channel *chan = vb2_get_drv_priv(vb->vb2_queue);
++	bool queued = false;
+ 
+ 	spin_lock(&chan->embedded.spin_lock);
+ 	if (chan->embedded.num_buffers < 16) {
+@@ -2769,8 +2866,12 @@ static void tegra_metadata_buffer_queue(struct vb2_buffer *vb)
+ 		if (chan->embedded.head > 15)
+ 			chan->embedded.head = chan->embedded.head - 16;
+ 		chan->embedded.num_buffers++;
++		queued = true;
+ 	}
+ 	spin_unlock(&chan->embedded.spin_lock);
++
++	if (!queued)
++		vb2_buffer_done(vb, VB2_BUF_STATE_ERROR);
+ }
+ 
+ static int tegra_metadata_start_streaming(struct vb2_queue *vq, unsigned int count)
+diff --git a/drivers/media/platform/tegra/camera/vi/graph.c b/drivers/media/platform/tegra/camera/vi/graph.c
+index 5e25cf6a..10956580 100644
+--- a/drivers/media/platform/tegra/camera/vi/graph.c
++++ b/drivers/media/platform/tegra/camera/vi/graph.c
+@@ -341,6 +341,8 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
+ 
+ 	if (sensor_mode &&
+ 		sensor_mode->image_properties.embedded_metadata_height > 0) {
++		chan->embedded.ops = s_data ? s_data->embedded_metadata_ops : NULL;
++		chan->embedded.dataformat = 0;
+ 		ret = tegra_channel_init_video_embedded(chan);
+ 		if (ret < 0) {
+ 			dev_err(chan->vi->dev,
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index 7f0cd1df..abb1df43 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -445,12 +445,49 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 		chan->capture_descr_sequence += 1;
+ }
+ 
++#define VI5_METADATA_LEGACY_D4XX_BYTESUSED 68
++
++/*
++ * No sensor ops means the pre-existing Tegra sidecar path: D4XX format,
++ * 255-byte queue capacity, and 68-byte payload. Sensors that register ops
++ * own their bytesused policy; invalid runtime sizes become error buffers.
++ */
++static unsigned int vi5_metadata_buffer_size(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->max_buffer_size)
++		return chan->embedded.ops->max_buffer_size;
++
++	return 255;
++}
++
++static unsigned int vi5_metadata_bytesused(struct tegra_channel *chan,
++	unsigned int captured_size)
++{
++	const struct tegra_embedded_metadata_ops *ops = chan->embedded.ops;
++	size_t bytesused;
++
++	if (!ops)
++		return min_t(unsigned int, captured_size,
++			     VI5_METADATA_LEGACY_D4XX_BYTESUSED);
++
++	if (!ops->get_bytesused)
++		return captured_size;
++
++	bytesused = ops->get_bytesused(chan->emb_buf_addr, captured_size);
++	if (bytesused && bytesused <= captured_size)
++		return bytesused;
++
++	return 0;
++}
++
+ static void vi5_release_metadata_buffer(struct tegra_channel *chan,
+ 	struct vb2_v4l2_buffer *vbuf)
+ {
+ 	struct vb2_buffer *evb = NULL;
+ 	struct vb2_v4l2_buffer *evbuf;
+ 	void* frm_buffer;
++	unsigned int copy_size;
++	unsigned int bytesused;
+ 
+ 	spin_lock(&chan->embedded.spin_lock);
+ 	if (0 < chan->embedded.num_buffers) {
+@@ -468,14 +505,37 @@ static void vi5_release_metadata_buffer(struct tegra_channel *chan,
+ 
+ 	frm_buffer = vb2_plane_vaddr(evb, 0);
+ 	if (!frm_buffer)
+-		return;
+-
+-	memcpy(frm_buffer, chan->emb_buf_addr, 255);
++		goto error;
++
++	copy_size = min_t(unsigned int, vi5_metadata_buffer_size(chan),
++		vb2_plane_size(evb, 0));
++	if (chan->embedded_data_width && chan->embedded_data_height)
++		copy_size = min_t(unsigned int, copy_size,
++			chan->embedded_data_width * chan->embedded_data_height *
++			BPP_MEM);
++	if (chan->emb_buf_size)
++		copy_size = min_t(unsigned int, copy_size, chan->emb_buf_size);
++	if (!copy_size)
++		goto error;
++
++	bytesused = vi5_metadata_bytesused(chan, copy_size);
++	if (!bytesused || bytesused > copy_size)
++		goto error;
++
++	memcpy(frm_buffer, chan->emb_buf_addr, bytesused);
+ 	evbuf = to_vb2_v4l2_buffer(evb);
+ 	evbuf->sequence = vbuf->sequence;
+-	vb2_set_plane_payload(evb, 0, 68);
++	vb2_set_plane_payload(evb, 0, bytesused);
+ 	evb->timestamp = vbuf->vb2_buf.timestamp;
+ 	vb2_buffer_done(evb, VB2_BUF_STATE_DONE);
++	return;
++
++error:
++	evbuf = to_vb2_v4l2_buffer(evb);
++	evbuf->sequence = vbuf->sequence;
++	vb2_set_plane_payload(evb, 0, 0);
++	evb->timestamp = vbuf->vb2_buf.timestamp;
++	vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
+ }
+ 
+ static void vi5_release_buffer(struct tegra_channel *chan,
+diff --git a/include/media/camera_common.h b/include/media/camera_common.h
+index 6b5ae91d..45cdff1f 100644
+--- a/include/media/camera_common.h
++++ b/include/media/camera_common.h
+@@ -30,6 +30,19 @@
+ #include <media/v4l2-ctrls.h>
+ #include <media/tegracam_core.h>
+ 
++#ifndef V4L2_META_FMT_RSMD
++#define V4L2_META_FMT_RSMD v4l2_fourcc('R', 'S', 'M', 'D') /* RealSense D5xx CSI metadata */
++#endif
++
++#define CONFIG_TEGRA_EMBEDDED_METADATA_OPS 1
++
++struct tegra_embedded_metadata_ops {
++	u32 dataformat;
++	u32 compat_dataformat;
++	u32 max_buffer_size;
++	size_t (*get_bytesused)(const u8 *data, size_t captured_size);
++};
++
+ /*
+  * Scaling factor for converting a Q10.22 fixed point value
+  * back to its original floating point value
+@@ -244,6 +257,7 @@ struct camera_common_data {
+ 	int	sensor_mode_id;
+ 	bool	use_sensor_mode_id;
+ 	bool	override_enable;
++	const struct tegra_embedded_metadata_ops *embedded_metadata_ops;
+ 	u32	version;
+ };
+ 
+diff --git a/include/media/mc_common.h b/include/media/mc_common.h
+index b87f527e..3e2f7eaf 100644
+--- a/include/media/mc_common.h
++++ b/include/media/mc_common.h
+@@ -70,6 +70,8 @@ enum interlaced_type {
+ 	Interleaved,
+ };
+ 
++struct tegra_embedded_metadata_ops;
++
+ /**
+  * struct tegra_channel_buffer - video channel buffer
+  * @buf: vb2 buffer base object
+@@ -253,6 +255,8 @@ struct tegra_channel {
+ 		void *alloc_ctx;
+ 		struct media_pad pad;
+ 		struct v4l2_ctrl_handler ctrl_handler;
++		const struct tegra_embedded_metadata_ops *ops;
++		u32 dataformat;
+ 	} embedded;
+ 
+ 	DECLARE_BITMAP(fmts_bitmap, MAX_FORMAT_NUM);
+
+-- 
+2.34.1

--- a/nvidia-oot/7.0/0013-D5xx-metadata-sidecar-ops.patch
+++ b/nvidia-oot/7.0/0013-D5xx-metadata-sidecar-ops.patch
@@ -1,0 +1,388 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zhou <shengyong.zhou@realsenseai.com>
+Date: Fri, 17 Jul 2026 13:30:00 +0800
+Subject: [PATCH] media: tegra: support sensor metadata ops
+
+Add a small per-sensor metadata ops hook for embedded metadata sidecar
+format negotiation, queue capacity, and runtime bytesused calculation.
+
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
+---
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index a9fadae0..3ee83f5a 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -2668,44 +2668,137 @@ static int tegra_metadata_querycap(struct file *file, void *fh,
+ 	return 0;
+ }
+ 
++static u32 tegra_metadata_native_dataformat(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->dataformat)
++		return chan->embedded.ops->dataformat;
++
++	return V4L2_META_FMT_D4XX;
++}
++
++static u32 tegra_metadata_compat_dataformat(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->compat_dataformat)
++		return chan->embedded.ops->compat_dataformat;
++
++	return tegra_metadata_native_dataformat(chan);
++}
++
++static u32 tegra_metadata_current_dataformat(struct tegra_channel *chan)
++{
++	if (chan->embedded.dataformat)
++		return chan->embedded.dataformat;
++
++	return tegra_metadata_native_dataformat(chan);
++}
++
++static bool tegra_metadata_dataformat_supported(struct tegra_channel *chan,
++						u32 dataformat)
++{
++	u32 native = tegra_metadata_native_dataformat(chan);
++	u32 compat = tegra_metadata_compat_dataformat(chan);
++
++	return dataformat == native || dataformat == compat;
++}
++
++static unsigned int tegra_metadata_buffer_size(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->max_buffer_size)
++		return chan->embedded.ops->max_buffer_size;
++
++	return 255;
++}
++
++static void tegra_metadata_format_description(u32 dataformat, char *description,
++					      size_t size)
++{
++	if (dataformat == V4L2_META_FMT_RSMD)
++		strscpy(description, "RealSense D5xx CSI metadata", size);
++	else if (dataformat == V4L2_META_FMT_D4XX)
++		strscpy(description, "D4XX metadata format", size);
++	else
++		strscpy(description, "Embedded metadata format", size);
++}
++
+ static int tegra_metadata_enum_format(struct file *file, void *fh,
+                                      struct v4l2_fmtdesc *f)
+ {
+-	if (f->index)
++	struct tegra_channel *chan = video_drvdata(file);
++	u32 native = tegra_metadata_native_dataformat(chan);
++	u32 compat = tegra_metadata_compat_dataformat(chan);
++
++	if (f->index > 1 || (f->index == 1 && compat == native))
+ 		return -EINVAL;
+ 
+-	f->pixelformat = V4L2_META_FMT_D4XX;
+-	strscpy(f->description, "D4XX metadata format", sizeof(f->description));
++	f->pixelformat = f->index ? compat : native;
++	tegra_metadata_format_description(f->pixelformat, f->description,
++					   sizeof(f->description));
+ 
+ 	return 0;
+ }
+ 
+-static int tegra_metadata_get_format(struct file *file, void *fh,
+-                                    struct v4l2_format *format)
++static int tegra_metadata_fill_format(struct tegra_channel *chan,
++				      struct v4l2_format *format,
++				      u32 dataformat)
+ {
+-	struct v4l2_fh *vfh = file->private_data;
+ 	struct v4l2_meta_format *fmt = &format->fmt.meta;
+ 
+-	if (format->type != vfh->vdev->queue->type)
++	if (format->type != V4L2_BUF_TYPE_META_CAPTURE)
+ 		return -EINVAL;
+ 
+ 	memset(fmt, 0, sizeof(*fmt));
+-
+-	fmt->dataformat = V4L2_META_FMT_D4XX;
+-	fmt->buffersize = 255;
++	fmt->dataformat = dataformat;
++	fmt->buffersize = tegra_metadata_buffer_size(chan);
+ 
+ 	return 0;
+ }
++
++static int tegra_metadata_get_format(struct file *file, void *fh,
++                                    struct v4l2_format *format)
++{
++	struct v4l2_fh *vfh = file->private_data;
++	struct tegra_channel *chan = video_drvdata(file);
++
++	if (format->type != vfh->vdev->queue->type)
++		return -EINVAL;
++
++	return tegra_metadata_fill_format(chan, format,
++					  tegra_metadata_current_dataformat(chan));
++}
+ static int tegra_metadata_set_format(struct file *file, void *fh,
+                                     struct v4l2_format *format)
+ {
+-   return 0;
++	struct tegra_channel *chan = video_drvdata(file);
++	u32 dataformat = format->fmt.meta.dataformat;
++
++	if (format->type != V4L2_BUF_TYPE_META_CAPTURE)
++		return -EINVAL;
++
++	if (!dataformat)
++		dataformat = tegra_metadata_native_dataformat(chan);
++	if (!tegra_metadata_dataformat_supported(chan, dataformat))
++		return -EINVAL;
++
++	chan->embedded.dataformat = dataformat;
++
++	return tegra_metadata_fill_format(chan, format, dataformat);
+ }
+ 
+ static int tegra_metadata_try_format(struct file *file, void *fh,
+                                     struct v4l2_format *format)
+ {
+-    return 0;
++	struct tegra_channel *chan = video_drvdata(file);
++	u32 dataformat = format->fmt.meta.dataformat;
++
++	if (format->type != V4L2_BUF_TYPE_META_CAPTURE)
++		return -EINVAL;
++
++	if (!dataformat)
++		dataformat = tegra_metadata_native_dataformat(chan);
++	if (!tegra_metadata_dataformat_supported(chan, dataformat))
++		return -EINVAL;
++
++	return tegra_metadata_fill_format(chan, format, dataformat);
+ }
+ static const struct v4l2_ioctl_ops tegra_metadata_ioctl_ops = {
+ 	.vidioc_querycap                = tegra_metadata_querycap,
+@@ -2728,19 +2821,20 @@ static int tegra_metadata_queue_setup(struct vb2_queue *vq,
+                     unsigned int sizes[], struct device *alloc_devs[])
+ {
+ 	struct tegra_channel *chan = vb2_get_drv_priv(vq);
++	unsigned int size = tegra_metadata_buffer_size(chan);
+ 
+ 	if (*nplanes) {
+ 		if (*nplanes != 1)
+ 			return -EINVAL;
+ 
+-		if (sizes[0] < 255)
++		if (sizes[0] < size)
+ 			return -EINVAL;
+ 
+ 		return 0;
+ 	}
+ 
+ 	*nplanes = 1;
+-	sizes[0] = 255;
++	sizes[0] = size;
+ 	alloc_devs[0] = chan->vi->dev;
+ 
+ 
+@@ -2749,10 +2843,12 @@ static int tegra_metadata_queue_setup(struct vb2_queue *vq,
+ 
+ static int tegra_metadata_buffer_prepare(struct vb2_buffer *vb)
+ {
++	struct tegra_channel *chan = vb2_get_drv_priv(vb->vb2_queue);
++
+ 	if (vb->num_planes != 1)
+ 		return -EINVAL;
+ 
+-	if (vb2_plane_size(vb, 0) < 255)
++	if (vb2_plane_size(vb, 0) < tegra_metadata_buffer_size(chan))
+ 		return -EINVAL;
+ 
+ 	return 0;
+@@ -2761,6 +2857,7 @@ static int tegra_metadata_buffer_prepare(struct vb2_buffer *vb)
+ static void tegra_metadata_buffer_queue(struct vb2_buffer *vb)
+ {
+ 	struct tegra_channel *chan = vb2_get_drv_priv(vb->vb2_queue);
++	bool queued = false;
+ 
+ 	spin_lock(&chan->embedded.spin_lock);
+ 	if (chan->embedded.num_buffers < 16) {
+@@ -2769,8 +2866,12 @@ static void tegra_metadata_buffer_queue(struct vb2_buffer *vb)
+ 		if (chan->embedded.head > 15)
+ 			chan->embedded.head = chan->embedded.head - 16;
+ 		chan->embedded.num_buffers++;
++		queued = true;
+ 	}
+ 	spin_unlock(&chan->embedded.spin_lock);
++
++	if (!queued)
++		vb2_buffer_done(vb, VB2_BUF_STATE_ERROR);
+ }
+ 
+ static int tegra_metadata_start_streaming(struct vb2_queue *vq, unsigned int count)
+diff --git a/drivers/media/platform/tegra/camera/vi/graph.c b/drivers/media/platform/tegra/camera/vi/graph.c
+index 5e25cf6a..10956580 100644
+--- a/drivers/media/platform/tegra/camera/vi/graph.c
++++ b/drivers/media/platform/tegra/camera/vi/graph.c
+@@ -341,6 +341,8 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
+ 
+ 	if (sensor_mode &&
+ 		sensor_mode->image_properties.embedded_metadata_height > 0) {
++		chan->embedded.ops = s_data ? s_data->embedded_metadata_ops : NULL;
++		chan->embedded.dataformat = 0;
+ 		ret = tegra_channel_init_video_embedded(chan);
+ 		if (ret < 0) {
+ 			dev_err(chan->vi->dev,
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index 7f0cd1df..abb1df43 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -445,12 +445,49 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 		chan->capture_descr_sequence += 1;
+ }
+ 
++#define VI5_METADATA_LEGACY_D4XX_BYTESUSED 68
++
++/*
++ * No sensor ops means the pre-existing Tegra sidecar path: D4XX format,
++ * 255-byte queue capacity, and 68-byte payload. Sensors that register ops
++ * own their bytesused policy; invalid runtime sizes become error buffers.
++ */
++static unsigned int vi5_metadata_buffer_size(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->max_buffer_size)
++		return chan->embedded.ops->max_buffer_size;
++
++	return 255;
++}
++
++static unsigned int vi5_metadata_bytesused(struct tegra_channel *chan,
++	unsigned int captured_size)
++{
++	const struct tegra_embedded_metadata_ops *ops = chan->embedded.ops;
++	size_t bytesused;
++
++	if (!ops)
++		return min_t(unsigned int, captured_size,
++			     VI5_METADATA_LEGACY_D4XX_BYTESUSED);
++
++	if (!ops->get_bytesused)
++		return captured_size;
++
++	bytesused = ops->get_bytesused(chan->emb_buf_addr, captured_size);
++	if (bytesused && bytesused <= captured_size)
++		return bytesused;
++
++	return 0;
++}
++
+ static void vi5_release_metadata_buffer(struct tegra_channel *chan,
+ 	struct vb2_v4l2_buffer *vbuf)
+ {
+ 	struct vb2_buffer *evb = NULL;
+ 	struct vb2_v4l2_buffer *evbuf;
+ 	void* frm_buffer;
++	unsigned int copy_size;
++	unsigned int bytesused;
+ 
+ 	spin_lock(&chan->embedded.spin_lock);
+ 	if (0 < chan->embedded.num_buffers) {
+@@ -468,14 +505,37 @@ static void vi5_release_metadata_buffer(struct tegra_channel *chan,
+ 
+ 	frm_buffer = vb2_plane_vaddr(evb, 0);
+ 	if (!frm_buffer)
+-		return;
+-
+-	memcpy(frm_buffer, chan->emb_buf_addr, 255);
++		goto error;
++
++	copy_size = min_t(unsigned int, vi5_metadata_buffer_size(chan),
++		vb2_plane_size(evb, 0));
++	if (chan->embedded_data_width && chan->embedded_data_height)
++		copy_size = min_t(unsigned int, copy_size,
++			chan->embedded_data_width * chan->embedded_data_height *
++			BPP_MEM);
++	if (chan->emb_buf_size)
++		copy_size = min_t(unsigned int, copy_size, chan->emb_buf_size);
++	if (!copy_size)
++		goto error;
++
++	bytesused = vi5_metadata_bytesused(chan, copy_size);
++	if (!bytesused || bytesused > copy_size)
++		goto error;
++
++	memcpy(frm_buffer, chan->emb_buf_addr, bytesused);
+ 	evbuf = to_vb2_v4l2_buffer(evb);
+ 	evbuf->sequence = vbuf->sequence;
+-	vb2_set_plane_payload(evb, 0, 68);
++	vb2_set_plane_payload(evb, 0, bytesused);
+ 	evb->timestamp = vbuf->vb2_buf.timestamp;
+ 	vb2_buffer_done(evb, VB2_BUF_STATE_DONE);
++	return;
++
++error:
++	evbuf = to_vb2_v4l2_buffer(evb);
++	evbuf->sequence = vbuf->sequence;
++	vb2_set_plane_payload(evb, 0, 0);
++	evb->timestamp = vbuf->vb2_buf.timestamp;
++	vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
+ }
+ 
+ static void vi5_release_buffer(struct tegra_channel *chan,
+diff --git a/include/media/camera_common.h b/include/media/camera_common.h
+index 6b5ae91d..45cdff1f 100644
+--- a/include/media/camera_common.h
++++ b/include/media/camera_common.h
+@@ -30,6 +30,19 @@
+ #include <media/v4l2-ctrls.h>
+ #include <media/tegracam_core.h>
+ 
++#ifndef V4L2_META_FMT_RSMD
++#define V4L2_META_FMT_RSMD v4l2_fourcc('R', 'S', 'M', 'D') /* RealSense D5xx CSI metadata */
++#endif
++
++#define CONFIG_TEGRA_EMBEDDED_METADATA_OPS 1
++
++struct tegra_embedded_metadata_ops {
++	u32 dataformat;
++	u32 compat_dataformat;
++	u32 max_buffer_size;
++	size_t (*get_bytesused)(const u8 *data, size_t captured_size);
++};
++
+ /*
+  * Scaling factor for converting a Q10.22 fixed point value
+  * back to its original floating point value
+@@ -244,6 +257,7 @@ struct camera_common_data {
+ 	int	sensor_mode_id;
+ 	bool	use_sensor_mode_id;
+ 	bool	override_enable;
++	const struct tegra_embedded_metadata_ops *embedded_metadata_ops;
+ 	u32	version;
+ };
+ 
+diff --git a/include/media/mc_common.h b/include/media/mc_common.h
+index b87f527e..3e2f7eaf 100644
+--- a/include/media/mc_common.h
++++ b/include/media/mc_common.h
+@@ -70,6 +70,8 @@ enum interlaced_type {
+ 	Interleaved,
+ };
+ 
++struct tegra_embedded_metadata_ops;
++
+ /**
+  * struct tegra_channel_buffer - video channel buffer
+  * @buf: vb2 buffer base object
+@@ -253,6 +255,8 @@ struct tegra_channel {
+ 		void *alloc_ctx;
+ 		struct media_pad pad;
+ 		struct v4l2_ctrl_handler ctrl_handler;
++		const struct tegra_embedded_metadata_ops *ops;
++		u32 dataformat;
+ 	} embedded;
+ 
+ 	DECLARE_BITMAP(fmts_bitmap, MAX_FORMAT_NUM);
+
+-- 
+2.34.1

--- a/nvidia-oot/7.1/0013-D5xx-metadata-sidecar-ops.patch
+++ b/nvidia-oot/7.1/0013-D5xx-metadata-sidecar-ops.patch
@@ -1,0 +1,388 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zhou <shengyong.zhou@realsenseai.com>
+Date: Fri, 17 Jul 2026 13:30:00 +0800
+Subject: [PATCH] media: tegra: support sensor metadata ops
+
+Add a small per-sensor metadata ops hook for embedded metadata sidecar
+format negotiation, queue capacity, and runtime bytesused calculation.
+
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
+---
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index a9fadae0..3ee83f5a 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -2668,44 +2668,137 @@ static int tegra_metadata_querycap(struct file *file, void *fh,
+ 	return 0;
+ }
+ 
++static u32 tegra_metadata_native_dataformat(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->dataformat)
++		return chan->embedded.ops->dataformat;
++
++	return V4L2_META_FMT_D4XX;
++}
++
++static u32 tegra_metadata_compat_dataformat(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->compat_dataformat)
++		return chan->embedded.ops->compat_dataformat;
++
++	return tegra_metadata_native_dataformat(chan);
++}
++
++static u32 tegra_metadata_current_dataformat(struct tegra_channel *chan)
++{
++	if (chan->embedded.dataformat)
++		return chan->embedded.dataformat;
++
++	return tegra_metadata_native_dataformat(chan);
++}
++
++static bool tegra_metadata_dataformat_supported(struct tegra_channel *chan,
++						u32 dataformat)
++{
++	u32 native = tegra_metadata_native_dataformat(chan);
++	u32 compat = tegra_metadata_compat_dataformat(chan);
++
++	return dataformat == native || dataformat == compat;
++}
++
++static unsigned int tegra_metadata_buffer_size(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->max_buffer_size)
++		return chan->embedded.ops->max_buffer_size;
++
++	return 255;
++}
++
++static void tegra_metadata_format_description(u32 dataformat, char *description,
++					      size_t size)
++{
++	if (dataformat == V4L2_META_FMT_RSMD)
++		strscpy(description, "RealSense D5xx CSI metadata", size);
++	else if (dataformat == V4L2_META_FMT_D4XX)
++		strscpy(description, "D4XX metadata format", size);
++	else
++		strscpy(description, "Embedded metadata format", size);
++}
++
+ static int tegra_metadata_enum_format(struct file *file, void *fh,
+                                      struct v4l2_fmtdesc *f)
+ {
+-	if (f->index)
++	struct tegra_channel *chan = video_drvdata(file);
++	u32 native = tegra_metadata_native_dataformat(chan);
++	u32 compat = tegra_metadata_compat_dataformat(chan);
++
++	if (f->index > 1 || (f->index == 1 && compat == native))
+ 		return -EINVAL;
+ 
+-	f->pixelformat = V4L2_META_FMT_D4XX;
+-	strscpy(f->description, "D4XX metadata format", sizeof(f->description));
++	f->pixelformat = f->index ? compat : native;
++	tegra_metadata_format_description(f->pixelformat, f->description,
++					   sizeof(f->description));
+ 
+ 	return 0;
+ }
+ 
+-static int tegra_metadata_get_format(struct file *file, void *fh,
+-                                    struct v4l2_format *format)
++static int tegra_metadata_fill_format(struct tegra_channel *chan,
++				      struct v4l2_format *format,
++				      u32 dataformat)
+ {
+-	struct v4l2_fh *vfh = file->private_data;
+ 	struct v4l2_meta_format *fmt = &format->fmt.meta;
+ 
+-	if (format->type != vfh->vdev->queue->type)
++	if (format->type != V4L2_BUF_TYPE_META_CAPTURE)
+ 		return -EINVAL;
+ 
+ 	memset(fmt, 0, sizeof(*fmt));
+-
+-	fmt->dataformat = V4L2_META_FMT_D4XX;
+-	fmt->buffersize = 255;
++	fmt->dataformat = dataformat;
++	fmt->buffersize = tegra_metadata_buffer_size(chan);
+ 
+ 	return 0;
+ }
++
++static int tegra_metadata_get_format(struct file *file, void *fh,
++                                    struct v4l2_format *format)
++{
++	struct v4l2_fh *vfh = file->private_data;
++	struct tegra_channel *chan = video_drvdata(file);
++
++	if (format->type != vfh->vdev->queue->type)
++		return -EINVAL;
++
++	return tegra_metadata_fill_format(chan, format,
++					  tegra_metadata_current_dataformat(chan));
++}
+ static int tegra_metadata_set_format(struct file *file, void *fh,
+                                     struct v4l2_format *format)
+ {
+-   return 0;
++	struct tegra_channel *chan = video_drvdata(file);
++	u32 dataformat = format->fmt.meta.dataformat;
++
++	if (format->type != V4L2_BUF_TYPE_META_CAPTURE)
++		return -EINVAL;
++
++	if (!dataformat)
++		dataformat = tegra_metadata_native_dataformat(chan);
++	if (!tegra_metadata_dataformat_supported(chan, dataformat))
++		return -EINVAL;
++
++	chan->embedded.dataformat = dataformat;
++
++	return tegra_metadata_fill_format(chan, format, dataformat);
+ }
+ 
+ static int tegra_metadata_try_format(struct file *file, void *fh,
+                                     struct v4l2_format *format)
+ {
+-    return 0;
++	struct tegra_channel *chan = video_drvdata(file);
++	u32 dataformat = format->fmt.meta.dataformat;
++
++	if (format->type != V4L2_BUF_TYPE_META_CAPTURE)
++		return -EINVAL;
++
++	if (!dataformat)
++		dataformat = tegra_metadata_native_dataformat(chan);
++	if (!tegra_metadata_dataformat_supported(chan, dataformat))
++		return -EINVAL;
++
++	return tegra_metadata_fill_format(chan, format, dataformat);
+ }
+ static const struct v4l2_ioctl_ops tegra_metadata_ioctl_ops = {
+ 	.vidioc_querycap                = tegra_metadata_querycap,
+@@ -2728,19 +2821,20 @@ static int tegra_metadata_queue_setup(struct vb2_queue *vq,
+                     unsigned int sizes[], struct device *alloc_devs[])
+ {
+ 	struct tegra_channel *chan = vb2_get_drv_priv(vq);
++	unsigned int size = tegra_metadata_buffer_size(chan);
+ 
+ 	if (*nplanes) {
+ 		if (*nplanes != 1)
+ 			return -EINVAL;
+ 
+-		if (sizes[0] < 255)
++		if (sizes[0] < size)
+ 			return -EINVAL;
+ 
+ 		return 0;
+ 	}
+ 
+ 	*nplanes = 1;
+-	sizes[0] = 255;
++	sizes[0] = size;
+ 	alloc_devs[0] = chan->vi->dev;
+ 
+ 
+@@ -2749,10 +2843,12 @@ static int tegra_metadata_queue_setup(struct vb2_queue *vq,
+ 
+ static int tegra_metadata_buffer_prepare(struct vb2_buffer *vb)
+ {
++	struct tegra_channel *chan = vb2_get_drv_priv(vb->vb2_queue);
++
+ 	if (vb->num_planes != 1)
+ 		return -EINVAL;
+ 
+-	if (vb2_plane_size(vb, 0) < 255)
++	if (vb2_plane_size(vb, 0) < tegra_metadata_buffer_size(chan))
+ 		return -EINVAL;
+ 
+ 	return 0;
+@@ -2761,6 +2857,7 @@ static int tegra_metadata_buffer_prepare(struct vb2_buffer *vb)
+ static void tegra_metadata_buffer_queue(struct vb2_buffer *vb)
+ {
+ 	struct tegra_channel *chan = vb2_get_drv_priv(vb->vb2_queue);
++	bool queued = false;
+ 
+ 	spin_lock(&chan->embedded.spin_lock);
+ 	if (chan->embedded.num_buffers < 16) {
+@@ -2769,8 +2866,12 @@ static void tegra_metadata_buffer_queue(struct vb2_buffer *vb)
+ 		if (chan->embedded.head > 15)
+ 			chan->embedded.head = chan->embedded.head - 16;
+ 		chan->embedded.num_buffers++;
++		queued = true;
+ 	}
+ 	spin_unlock(&chan->embedded.spin_lock);
++
++	if (!queued)
++		vb2_buffer_done(vb, VB2_BUF_STATE_ERROR);
+ }
+ 
+ static int tegra_metadata_start_streaming(struct vb2_queue *vq, unsigned int count)
+diff --git a/drivers/media/platform/tegra/camera/vi/graph.c b/drivers/media/platform/tegra/camera/vi/graph.c
+index 5e25cf6a..10956580 100644
+--- a/drivers/media/platform/tegra/camera/vi/graph.c
++++ b/drivers/media/platform/tegra/camera/vi/graph.c
+@@ -341,6 +341,8 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
+ 
+ 	if (sensor_mode &&
+ 		sensor_mode->image_properties.embedded_metadata_height > 0) {
++		chan->embedded.ops = s_data ? s_data->embedded_metadata_ops : NULL;
++		chan->embedded.dataformat = 0;
+ 		ret = tegra_channel_init_video_embedded(chan);
+ 		if (ret < 0) {
+ 			dev_err(chan->vi->dev,
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index 7f0cd1df..abb1df43 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -445,12 +445,49 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 		chan->capture_descr_sequence += 1;
+ }
+ 
++#define VI5_METADATA_LEGACY_D4XX_BYTESUSED 68
++
++/*
++ * No sensor ops means the pre-existing Tegra sidecar path: D4XX format,
++ * 255-byte queue capacity, and 68-byte payload. Sensors that register ops
++ * own their bytesused policy; invalid runtime sizes become error buffers.
++ */
++static unsigned int vi5_metadata_buffer_size(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->max_buffer_size)
++		return chan->embedded.ops->max_buffer_size;
++
++	return 255;
++}
++
++static unsigned int vi5_metadata_bytesused(struct tegra_channel *chan,
++	unsigned int captured_size)
++{
++	const struct tegra_embedded_metadata_ops *ops = chan->embedded.ops;
++	size_t bytesused;
++
++	if (!ops)
++		return min_t(unsigned int, captured_size,
++			     VI5_METADATA_LEGACY_D4XX_BYTESUSED);
++
++	if (!ops->get_bytesused)
++		return captured_size;
++
++	bytesused = ops->get_bytesused(chan->emb_buf_addr, captured_size);
++	if (bytesused && bytesused <= captured_size)
++		return bytesused;
++
++	return 0;
++}
++
+ static void vi5_release_metadata_buffer(struct tegra_channel *chan,
+ 	struct vb2_v4l2_buffer *vbuf)
+ {
+ 	struct vb2_buffer *evb = NULL;
+ 	struct vb2_v4l2_buffer *evbuf;
+ 	void* frm_buffer;
++	unsigned int copy_size;
++	unsigned int bytesused;
+ 
+ 	spin_lock(&chan->embedded.spin_lock);
+ 	if (0 < chan->embedded.num_buffers) {
+@@ -468,14 +505,37 @@ static void vi5_release_metadata_buffer(struct tegra_channel *chan,
+ 
+ 	frm_buffer = vb2_plane_vaddr(evb, 0);
+ 	if (!frm_buffer)
+-		return;
+-
+-	memcpy(frm_buffer, chan->emb_buf_addr, 255);
++		goto error;
++
++	copy_size = min_t(unsigned int, vi5_metadata_buffer_size(chan),
++		vb2_plane_size(evb, 0));
++	if (chan->embedded_data_width && chan->embedded_data_height)
++		copy_size = min_t(unsigned int, copy_size,
++			chan->embedded_data_width * chan->embedded_data_height *
++			BPP_MEM);
++	if (chan->emb_buf_size)
++		copy_size = min_t(unsigned int, copy_size, chan->emb_buf_size);
++	if (!copy_size)
++		goto error;
++
++	bytesused = vi5_metadata_bytesused(chan, copy_size);
++	if (!bytesused || bytesused > copy_size)
++		goto error;
++
++	memcpy(frm_buffer, chan->emb_buf_addr, bytesused);
+ 	evbuf = to_vb2_v4l2_buffer(evb);
+ 	evbuf->sequence = vbuf->sequence;
+-	vb2_set_plane_payload(evb, 0, 68);
++	vb2_set_plane_payload(evb, 0, bytesused);
+ 	evb->timestamp = vbuf->vb2_buf.timestamp;
+ 	vb2_buffer_done(evb, VB2_BUF_STATE_DONE);
++	return;
++
++error:
++	evbuf = to_vb2_v4l2_buffer(evb);
++	evbuf->sequence = vbuf->sequence;
++	vb2_set_plane_payload(evb, 0, 0);
++	evb->timestamp = vbuf->vb2_buf.timestamp;
++	vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
+ }
+ 
+ static void vi5_release_buffer(struct tegra_channel *chan,
+diff --git a/include/media/camera_common.h b/include/media/camera_common.h
+index 6b5ae91d..45cdff1f 100644
+--- a/include/media/camera_common.h
++++ b/include/media/camera_common.h
+@@ -30,6 +30,19 @@
+ #include <media/v4l2-ctrls.h>
+ #include <media/tegracam_core.h>
+ 
++#ifndef V4L2_META_FMT_RSMD
++#define V4L2_META_FMT_RSMD v4l2_fourcc('R', 'S', 'M', 'D') /* RealSense D5xx CSI metadata */
++#endif
++
++#define CONFIG_TEGRA_EMBEDDED_METADATA_OPS 1
++
++struct tegra_embedded_metadata_ops {
++	u32 dataformat;
++	u32 compat_dataformat;
++	u32 max_buffer_size;
++	size_t (*get_bytesused)(const u8 *data, size_t captured_size);
++};
++
+ /*
+  * Scaling factor for converting a Q10.22 fixed point value
+  * back to its original floating point value
+@@ -244,6 +257,7 @@ struct camera_common_data {
+ 	int	sensor_mode_id;
+ 	bool	use_sensor_mode_id;
+ 	bool	override_enable;
++	const struct tegra_embedded_metadata_ops *embedded_metadata_ops;
+ 	u32	version;
+ };
+ 
+diff --git a/include/media/mc_common.h b/include/media/mc_common.h
+index b87f527e..3e2f7eaf 100644
+--- a/include/media/mc_common.h
++++ b/include/media/mc_common.h
+@@ -70,6 +70,8 @@ enum interlaced_type {
+ 	Interleaved,
+ };
+ 
++struct tegra_embedded_metadata_ops;
++
+ /**
+  * struct tegra_channel_buffer - video channel buffer
+  * @buf: vb2 buffer base object
+@@ -253,6 +255,8 @@ struct tegra_channel {
+ 		void *alloc_ctx;
+ 		struct media_pad pad;
+ 		struct v4l2_ctrl_handler ctrl_handler;
++		const struct tegra_embedded_metadata_ops *ops;
++		u32 dataformat;
+ 	} embedded;
+ 
+ 	DECLARE_BITMAP(fmts_bitmap, MAX_FORMAT_NUM);
+
+-- 
+2.34.1

--- a/nvidia-oot/files/6.2/drivers/media/i2c/max96717.c
+++ b/nvidia-oot/files/6.2/drivers/media/i2c/max96717.c
@@ -19,6 +19,7 @@
 #include <media/camera_common.h>
 #include <linux/of.h>
 #include <linux/module.h>
+#include <linux/version.h>
 #include <media/max96717.h>
 
 /* ===== Register Addresses ===== */
@@ -918,8 +919,11 @@ static struct regmap_config max96717_regmap_config = {
 	.cache_type = REGCACHE_RBTREE,
 };
 
-static int max96717_probe(struct i2c_client *client,
-			   const struct i2c_device_id *id)
+static int max96717_probe(struct i2c_client *client
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
+			   , const struct i2c_device_id *id
+#endif
+			   )
 {
 	struct max96717 *priv;
 	int err = 0;
@@ -966,7 +970,11 @@ static int max96717_probe(struct i2c_client *client,
 	return err;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 12)
 static int max96717_remove(struct i2c_client *client)
+#else
+static void max96717_remove(struct i2c_client *client)
+#endif
 {
 	struct max96717 *priv = dev_get_drvdata(&client->dev);
 
@@ -974,7 +982,9 @@ static int max96717_remove(struct i2c_client *client)
 		prim_priv__ = NULL;
 	mutex_destroy(&priv->lock);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 12)
 	return 0;
+#endif
 }
 
 static const struct i2c_device_id max96717_id[] = {

--- a/nvidia-oot/files/6.2/drivers/media/i2c/max96724.c
+++ b/nvidia-oot/files/6.2/drivers/media/i2c/max96724.c
@@ -23,6 +23,7 @@
 #include <linux/of.h>
 #include <linux/of_device.h>
 #include <linux/of_gpio.h>
+#include <linux/version.h>
 #include <media/camera_common.h>
 #include <linux/module.h>
 #include <media/max96724.h>
@@ -2378,8 +2379,11 @@ static struct regmap_config max96724_regmap_config = {
 	.cache_type = REGCACHE_NONE,
 };
 
-static int max96724_probe(struct i2c_client *client,
-			   const struct i2c_device_id *id)
+static int max96724_probe(struct i2c_client *client
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
+			   , const struct i2c_device_id *id
+#endif
+			   )
 {
 	struct max96724 *priv;
 	int err = 0;
@@ -2424,13 +2428,19 @@ static int max96724_probe(struct i2c_client *client,
 	return err;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 12)
 static int max96724_remove(struct i2c_client *client)
+#else
+static void max96724_remove(struct i2c_client *client)
+#endif
 {
 	struct max96724 *priv = dev_get_drvdata(&client->dev);
 
 	mutex_destroy(&priv->lock);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 12)
 	return 0;
+#endif
 }
 
 static const struct i2c_device_id max96724_id[] = {


### PR DESCRIPTION
## Summary

Replaces #508.

This change adds per-sensor embedded metadata sidecar ops for Tegra VI capture and keeps the D5xx metadata sidecar behavior consistent across the JP5.x, JP6.x, and JP7.x patch series.

- D5xx advertises native `RSMD` metadata and keeps `D4XX` as a compatibility format for existing host apps.
- D5xx metadata bytesused is derived from runtime HKRM framing only, using the transport magic and payload length. The kernel does not assume Depth/IR/RGB metadata body sizes and does not parse semantic metadata fields.
- D4xx keeps an explicit legacy `D4XX` sidecar ABI in the D4xx sensor ops: 255-byte sidecar capacity and 68-byte bytesused, matching the previous VI behavior while moving the policy out of generic VI code.
- Generic VI metadata handling is guarded for missing or invalid ops. Sensors without registered ops keep the legacy D4xx fallback; sensors with registered ops return an error metadata buffer when runtime sizing is invalid instead of silently truncating to the legacy 68-byte path.
- JP5.x, JP6.0, JP6.1, JP6.2.x, and JP7.x patch sets define `CONFIG_TEGRA_EMBEDDED_METADATA_OPS`, add `camera_common_data::embedded_metadata_ops`, and extend the embedded metadata node with per-sensor format/capacity/bytesused policy.
- Sensor-side metadata ops remain guarded by `CONFIG_TEGRA_EMBEDDED_METADATA_OPS` as build-time protection for any unpatched source tree.
- JP7.x uses a dedicated sidecar patch variant for the `strscpy` metadata-node source context while keeping the same RSMD/D4XX ops semantics as JP6.2.x.
- The shared MAX96717/MAX96724 source overlay keeps JP6.x and JP7.x reuse intact and uses kernel-version guards only for the I2C driver callback ABI difference.

## CI investigation

- Compared with already-merged #500: #500 changes D5xx stream recovery and MAX96717/MAX96724 code, but does not add camera-common metadata ops or touch D4xx metadata policy.
- JP5.x and JP6.1 need the same metadata ops framework as JP6.2.x; the patch sets now carry the framework consistently instead of removing older JetPack support.
- JP7.0/JP7.1 need the same metadata ops semantics as JP6.2.x, with only source-context and kernel API adaptation where the noble kernel differs.

## Validation

Target: Jetson 67 with D5x over GMSL, JP6.2.2.

- Patch apply: `apply_patches.sh reset 6.2.2` and `apply_patches.sh 6.2.2` passed.
- Generated JP6.2.2 source contains `CONFIG_TEGRA_EMBEDDED_METADATA_OPS`, `camera_common_data::embedded_metadata_ops`, D4xx/D5xx guarded sensor ops, and VI metadata ops dispatch.
- Build/deploy: `orin-gmsl --target 6.2.2 --package-tag pr510-rsmd all --reboot` completed. The helper auto-promoted to full build, deployed the package, rebooted Jetson 67, verified kernel `5.15.185-tegra`, verified d5xx/max96717/max96724 module vermagic/loading, verified deployed artifact sha256, and reported GMSL Link A/B locked.
- Metadata node formats: `/dev/video2`, `/dev/video4`, and `/dev/video6` expose `RSMD` and compatible `D4XX`; default metadata format is `RSMD` with 4096-byte buffer size.
- Frame-only headless preview: passed with metadata sidecar disabled. Depth/IR/RGB video sequences had no drops, backwards frames, or duplicates.
- Metadata sidecar without overlay: repeated 300-frame headless run passed. Depth/IR/RGB metadata buffers were parsed and valid with no missing metadata, parse errors, warnings, truncation, stream mismatch, meta-sequence drops/backwards, HKR frame-counter gaps/backwards, or HKR timestamp backwards.
- Metadata sidecar with overlay: 300-frame headless run passed at 10 fps overlay refresh. Depth/IR/RGB metadata buffers were parsed and valid with no missing metadata, parse errors, warnings, truncation, stream mismatch, meta-sequence drops/backwards, HKR frame-counter gaps/backwards, HKR timestamp backwards, or overlay out-of-order skips.
- Device logs: D5x serial log showed normal DPHY init and pipe done/stop flow during final runs, with no ASSERT, exception, panic, or timeout markers. Jetson dmesg showed no Oops, call trace, kernel panic, null pointer, or hung task markers.
- GitHub Actions matrix passed for JP5.0.2, JP5.1.2, JP5.1.6, JP6.0, JP6.1, JP6.2, JP6.2.2, JP7.0, and JP7.1.
