### PR TITLE
Fix D5xx GMSL probe reload cleanup

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,6 +18,7 @@ Linux kernel driver and userspace utilities for Intel RealSense D4XX series 3D d
 - **Function naming**: prefix all functions with `ds5_`. Mux-related functions use `ds5_mux_`. Examples: `ds5_read()`, `ds5_write()`, `ds5_probe()`, `ds5_mux_s_stream()`.
 - **Struct naming**: prefix with `ds5_`. Examples: `struct ds5`, `struct ds5_sensor`, `struct ds5_ctrls`, `struct ds5_format`.
 - **Macro naming**: prefix with `DS5_`. Register addresses: `DS5_FW_VERSION`, `DS5_START_STOP_STREAM`, `DS5_DEPTH_STREAM_DT`.
+- **D5xx naming**: the rules above apply to `d4xx.c`; use `d5x_*` and `D5X_*` in `d5xx.c`, including D5xx diagnostic sysfs attributes. Keep shared ABI names required by existing character devices, media graph discovery, and DT matching unchanged unless an ABI migration is explicitly required.
 - **Driver name**: `DS5_DRIVER_NAME` = `"d4xx"`, with variants `-awg`, `-asr`, `-class`, `-dfu`.
 - **I2C access**: use `ds5_read()` / `ds5_write()` wrappers around `regmap_raw_read()` / `regmap_raw_write()` with built-in retry logic (`DS5_I2C_RETRY_COUNT=5`, `DS5_I2C_RETRY_DELAY_US=5000`).
 - **Polling vs. normal I2C semantics**: for transient-failure-expected polling loops (HWMC status checks, reset readiness polls, DFU timeout checks), use `ds5_read_poll()` instead of `ds5_read()`. `ds5_read_poll()` performs a single direct `regmap_raw_read()` call without retry or logging, preventing false warnings and excessive log spam on expected transients. Reserve `ds5_read()` for normal I2C operations where retry logic and verbose failure logging are desired.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ RealSense D4XX camera module
 ### Key directories
 
 - **`kernel/realsense/d4xx.c`** — The main driver. Single-file V4L2 subdevice driver handling I2C communication, MIPI CSI-2 stream config, firmware control (DFU), calibration data, metadata capture, and V4L2 controls (exposure, laser power, AE ROI, etc.). Registers four sensor subdevices per camera: Depth, RGB, IR (Y8/Y8I/Y12I), and IMU.
+- **D4xx/D5xx naming** — Keep `ds5_*`/`DS5_*` for `d4xx.c` and use `d5x_*`/`D5X_*` for `d5xx.c`, including D5xx diagnostic sysfs attributes. Preserve shared ABI names required by existing character devices, media graph discovery, and DT matching unless an ABI migration is explicitly required.
 - **`kernel/kernel-4.9/`, `kernel/kernel-5.10/`, `kernel/kernel-jammy-src/`** — Kernel patches organized by JetPack generation: 4.6.1 uses kernel 4.9, 5.x uses kernel 5.10, 6.x uses kernel-jammy-src.
 - **`kernel/nvidia/`** — NVIDIA driver patches (max9295/max9296 SerDes, VI capture engine) organized by JetPack version.
 - **`nvidia-oot/`** — Out-of-tree NVIDIA module patches for JetPack 6.x/7.x. New SERDES source overlays live under `nvidia-oot/files/<version>/...`; non-6.2 selectors currently link to the shared 6.2 overlay.

--- a/kernel/realsense/d5xx.c
+++ b/kernel/realsense/d5xx.c
@@ -531,6 +531,8 @@ struct d5x {
 	struct i2c_client *dser_i2c;
 	const struct dser_interface *dser_ops;
 	bool serdes_primary; /* true for the instance that ran SERDES setup */
+	bool ser_control_setup;
+	bool dser_control_setup;
 #endif
 	struct d5x_dev *d5x_dev; /* D5xx device state */
 };
@@ -4241,6 +4243,7 @@ static int d5x_gmsl_serdes_setup(struct d5x *state)
 		dev_err(dev, "gmsl serializer setup failed\n");
 		goto error;
 	}
+	state->ser_control_setup = true;
 
 	/*
 	 * Configure serializer registers (PIPE_EN,
@@ -4261,6 +4264,8 @@ static int d5x_gmsl_serdes_setup(struct d5x *state)
 	if (des_err) {
 		dev_err(dev, "gmsl deserializer setup failed\n");
 		err = des_err;
+	} else {
+		state->dser_control_setup = true;
 	}
 
 error:
@@ -4268,10 +4273,11 @@ error:
 	return err;
 }
 
-static void d5x_serdes_cleanup(struct d5x *state, bool reset_control)
+static void d5x_serdes_cleanup(struct d5x *state)
 {
 	int ret;
 	bool do_cleanup = false;
+	bool power_off = false;
 	struct device *dev;
 
 	if (!state || !state->serdes_primary)
@@ -4290,18 +4296,23 @@ static void d5x_serdes_cleanup(struct d5x *state, bool reset_control)
 	}
 
 	if (do_cleanup) {
-		if (reset_control && state->ser_dev) {
+		if (state->ser_control_setup && state->ser_dev) {
+			power_off = true;
 			ret = max96717_reset_control(state->ser_dev);
 			if (ret)
 				dev_warn(dev, "failed in 96717 reset control\n");
+			state->ser_control_setup = false;
 		}
 
-		if (reset_control && state->dser_ops && state->dser_dev) {
+		if (state->dser_control_setup &&
+		    state->dser_ops && state->dser_dev) {
+			power_off = true;
 			ret = state->dser_ops->reset_control(state->dser_dev,
 							    state->g_ctx.s_dev);
 			if (ret)
 				dev_warn(dev, "failed in %s reset control\n",
 					 state->dser_ops->name);
+			state->dser_control_setup = false;
 		}
 
 		if (state->ser_dev) {
@@ -4319,7 +4330,7 @@ static void d5x_serdes_cleanup(struct d5x *state, bool reset_control)
 					 state->dser_ops->name);
 		}
 
-		if (reset_control && state->dser_ops && state->dser_dev)
+		if (power_off && state->dser_ops && state->dser_dev)
 			state->dser_ops->power_off(state->dser_dev);
 	}
 	mutex_unlock(&serdes_lock__);
@@ -4331,7 +4342,6 @@ static int d5x_serdes_setup(struct d5x *state)
 {
 	int ret = 0;
 	struct i2c_client *c = state->client;
-	bool control_setup_done = false;
 
 	ret = d5x_board_setup(state);
 	if (ret) {
@@ -4369,8 +4379,6 @@ static int d5x_serdes_setup(struct d5x *state)
 		dev_err(&c->dev, "%s gmsl serdes setup failed\n", __func__);
 		goto serdes_setup_end;
 	}
-	control_setup_done = true;
-
 	/*
 	 * max96717_init_settings is now called inside d5x_gmsl_serdes_setup,
 	 * after setup_control(ser) but before setup_control(dser) to avoid
@@ -4427,7 +4435,7 @@ static int d5x_serdes_setup(struct d5x *state)
 
 serdes_setup_end:
 	if (ret)
-		d5x_serdes_cleanup(state, control_setup_done);
+		d5x_serdes_cleanup(state);
 
 	return ret;
 }
@@ -6724,9 +6732,6 @@ static int d5x_probe(struct i2c_client *c
 	uint32_t override_addr = 0;
 	struct device_node *mode0_node;
 #endif
-#ifdef CONFIG_VIDEO_D5XX_SERDES
-	bool serdes_setup_done = false;
-#endif
 	if (!state)
 		return -ENOMEM;
 
@@ -6771,7 +6776,6 @@ static int d5x_probe(struct i2c_client *c
 	ret = d5x_serdes_setup(state);
 	if (ret < 0)
 		goto e_regulator;
-	serdes_setup_done = true;
 	state->reset_ref_dser = atomic_read(dser_get_reset_gen(state));
 #else
 	d5x_init_global_slots_once();
@@ -6925,7 +6929,7 @@ e_chardev:
 		d5x_chrdev_remove(state);
 e_regulator:
 #ifdef CONFIG_VIDEO_D5XX_SERDES
-	d5x_serdes_cleanup(state, serdes_setup_done);
+	d5x_serdes_cleanup(state);
 #endif
 	if (state->vcc)
 		regulator_disable(state->vcc);
@@ -6952,7 +6956,7 @@ static void d5x_remove(struct i2c_client *c)
 	}
 
 #ifdef CONFIG_VIDEO_D5XX_SERDES
-	d5x_serdes_cleanup(state, true);
+	d5x_serdes_cleanup(state);
 #ifndef CONFIG_OF
 	if (state->ser_i2c)
 		i2c_unregister_device(state->ser_i2c);

--- a/kernel/realsense/d5xx.c
+++ b/kernel/realsense/d5xx.c
@@ -87,150 +87,150 @@ struct dser_interface {
 #endif
 
 /*
- * DS5_BYPASS_CAMERA_I2C: Bypass all I2C communication to the D5XX camera
+ * D5X_BYPASS_CAMERA_I2C: Bypass all I2C communication to the D5XX camera
  * sensor while keeping GMSL SERDES (MAX96717/MAX96724) fully operational.
  * Use this when the camera is already streaming MIPI data independently
  * and only the SERDES link + V4L2 registration is needed on the Orin side.
  */
-#define DS5_BYPASS_CAMERA_I2C 0
+#define D5X_BYPASS_CAMERA_I2C 0
 
-//#define DS5_DRIVER_NAME "DS5 RealSense camera driver"
-#define DS5_DRIVER_NAME "d5xx"
-#define DS5_DRIVER_NAME_AWG "d5xx-awg"
-#define DS5_DRIVER_NAME_ASR "d5xx-asr"
+//#define D5X_DRIVER_NAME "DS5 RealSense camera driver"
+#define D5X_DRIVER_NAME "d5xx"
+#define D5X_DRIVER_NAME_AWG "d5xx-awg"
+#define D5X_DRIVER_NAME_ASR "d5xx-asr"
 /* Keep legacy d4xx sysfs names so librealsense can discover the correct node. */
-#define DS5_DRIVER_NAME_CLASS "d4xx-class"
-#define DS5_DRIVER_NAME_DFU "d4xx-dfu"
+#define D5X_DRIVER_NAME_CLASS "d4xx-class"
+#define D5X_DRIVER_NAME_DFU "d4xx-dfu"
 /* Keep legacy DS5 mux naming so the installed rs-enum/udev rules still match. */
-#define DS5_DRIVER_NAME_MUX "DS5 mux"
+#define D5X_DRIVER_NAME_MUX "DS5 mux"
 /* Keep legacy D4XX sensor entity naming so rs-enum media graph parsing still matches. */
-#define DS5_DRIVER_NAME_SENSOR "D4XX"
+#define D5X_DRIVER_NAME_SENSOR "D4XX"
 
-#define DS5_MIPI_SUPPORT_LINES		0x0300
-#define DS5_MIPI_SUPPORT_PHY		0x0304
-#define DS5_MIPI_DATARATE_MIN		0x0308
-#define DS5_MIPI_DATARATE_MAX		0x030A
-#define DS5_FW_VERSION				0x030C
-#define DS5_FW_BUILD				0x030E
-#define DS5_DEVICE_TYPE				0x0310
-#define DS5_DEVICE_TYPE_D58X		9
-#define DS5_DEVICE_TYPE_UNKNOWN		0
+#define D5X_MIPI_SUPPORT_LINES		0x0300
+#define D5X_MIPI_SUPPORT_PHY		0x0304
+#define D5X_MIPI_DATARATE_MIN		0x0308
+#define D5X_MIPI_DATARATE_MAX		0x030A
+#define D5X_FW_VERSION				0x030C
+#define D5X_FW_BUILD				0x030E
+#define D5X_DEVICE_TYPE				0x0310
+#define D5X_DEVICE_TYPE_D58X		9
+#define D5X_DEVICE_TYPE_UNKNOWN		0
 
-#define DS5_MIPI_LANE_NUMS			0x0400
-#define DS5_MIPI_LANE_DATARATE		0x0402
-#define DS5_MIPI_CONF_STATUS		0x0500
+#define D5X_MIPI_LANE_NUMS			0x0400
+#define D5X_MIPI_LANE_DATARATE		0x0402
+#define D5X_MIPI_CONF_STATUS		0x0500
 
-#define DS5_START_STOP_STREAM		0x1000
-#define DS5_DEPTH_STREAM_STATUS		0x1004
-#define DS5_RGB_STREAM_STATUS		0x1008
-#define DS5_IMU_STREAM_STATUS		0x100C
-#define DS5_IR_STREAM_STATUS		0x1014
+#define D5X_START_STOP_STREAM		0x1000
+#define D5X_DEPTH_STREAM_STATUS		0x1004
+#define D5X_RGB_STREAM_STATUS		0x1008
+#define D5X_IMU_STREAM_STATUS		0x100C
+#define D5X_IR_STREAM_STATUS		0x1014
 
-#define DS5_STREAM_DEPTH			0x0
-#define DS5_STREAM_RGB				0x1
-#define DS5_STREAM_IMU				0x2
-#define DS5_STREAM_IR				0x4
-#define DS5_STREAM_STOP				0x100
-#define DS5_STREAM_START			0x200
-#define DS5_STREAM_IDLE				0x1
-#define DS5_STREAM_STREAMING		0x2
+#define D5X_STREAM_DEPTH			0x0
+#define D5X_STREAM_RGB				0x1
+#define D5X_STREAM_IMU				0x2
+#define D5X_STREAM_IR				0x4
+#define D5X_STREAM_STOP				0x100
+#define D5X_STREAM_START			0x200
+#define D5X_STREAM_IDLE				0x1
+#define D5X_STREAM_STREAMING		0x2
 
-#define DS5_DEPTH_STREAM_DT		 	0x4000
-#define DS5_DEPTH_STREAM_MD		 	0x4002
-#define DS5_DEPTH_RES_WIDTH		 	0x4004
-#define DS5_DEPTH_RES_HEIGHT	 	0x4008
-#define DS5_DEPTH_FPS			 	0x400C
-#define DS5_DEPTH_OVERRIDE		 	0x401C
-#define DS5_DEPTH_CONTROL_STATUS 	0x401E
+#define D5X_DEPTH_STREAM_DT		 	0x4000
+#define D5X_DEPTH_STREAM_MD		 	0x4002
+#define D5X_DEPTH_RES_WIDTH		 	0x4004
+#define D5X_DEPTH_RES_HEIGHT	 	0x4008
+#define D5X_DEPTH_FPS			 	0x400C
+#define D5X_DEPTH_OVERRIDE		 	0x401C
+#define D5X_DEPTH_CONTROL_STATUS 	0x401E
 
-#define DS5_RGB_STREAM_DT			0x4020
-#define DS5_RGB_STREAM_MD			0x4022
-#define DS5_RGB_RES_WIDTH			0x4024
-#define DS5_RGB_RES_HEIGHT			0x4028
-#define DS5_RGB_FPS					0x402C
-#define DS5_RGB_CONTROL_STATUS 		0x402E
+#define D5X_RGB_STREAM_DT			0x4020
+#define D5X_RGB_STREAM_MD			0x4022
+#define D5X_RGB_RES_WIDTH			0x4024
+#define D5X_RGB_RES_HEIGHT			0x4028
+#define D5X_RGB_FPS					0x402C
+#define D5X_RGB_CONTROL_STATUS 		0x402E
 
-#define DS5_IMU_STREAM_DT			0x4040
-#define DS5_IMU_STREAM_MD			0x4042
-#define DS5_IMU_RES_WIDTH			0x4044
-#define DS5_IMU_RES_HEIGHT			0x4048
-#define DS5_IMU_FPS					0x404C
-#define DS5_IMU_CONTROL_STATUS 		0x404E
+#define D5X_IMU_STREAM_DT			0x4040
+#define D5X_IMU_STREAM_MD			0x4042
+#define D5X_IMU_RES_WIDTH			0x4044
+#define D5X_IMU_RES_HEIGHT			0x4048
+#define D5X_IMU_FPS					0x404C
+#define D5X_IMU_CONTROL_STATUS 		0x404E
 
-#define DS5_IR_STREAM_DT			0x4080
-#define DS5_IR_STREAM_MD			0x4082
-#define DS5_IR_RES_WIDTH			0x4084
-#define DS5_IR_RES_HEIGHT			0x4088
-#define DS5_IR_FPS					0x408C
-#define DS5_IR_OVERRIDE				0x409C
-#define DS5_IR_CONTROL_STATUS 		0x409E
+#define D5X_IR_STREAM_DT			0x4080
+#define D5X_IR_STREAM_MD			0x4082
+#define D5X_IR_RES_WIDTH			0x4084
+#define D5X_IR_RES_HEIGHT			0x4088
+#define D5X_IR_FPS					0x408C
+#define D5X_IR_OVERRIDE				0x409C
+#define D5X_IR_CONTROL_STATUS 		0x409E
 
-#define DS5_DEPTH_CONTROL_BASE		0x4100
-#define DS5_RGB_CONTROL_BASE		0x4200
-#define DS5_MANUAL_EXPOSURE_LSB		0x0000
-#define DS5_MANUAL_EXPOSURE_MSB		0x0002
-#define DS5_MANUAL_GAIN				0x0004
-#define DS5_LASER_POWER				0x0008
-#define DS5_AUTO_EXPOSURE_MODE		0x000C
-#define DS5_EXPOSURE_ROI_TOP		0x0010
-#define DS5_EXPOSURE_ROI_LEFT		0x0014
-#define DS5_EXPOSURE_ROI_BOTTOM		0x0018
-#define DS5_EXPOSURE_ROI_RIGHT		0x001C
-#define DS5_MANUAL_LASER_POWER		0x0024
-#define DS5_PWM_FREQUENCY			0x0028
-#define DS5_CAMERA_SYNC_MODE		0x002C
+#define D5X_DEPTH_CONTROL_BASE		0x4100
+#define D5X_RGB_CONTROL_BASE		0x4200
+#define D5X_MANUAL_EXPOSURE_LSB		0x0000
+#define D5X_MANUAL_EXPOSURE_MSB		0x0002
+#define D5X_MANUAL_GAIN				0x0004
+#define D5X_LASER_POWER				0x0008
+#define D5X_AUTO_EXPOSURE_MODE		0x000C
+#define D5X_EXPOSURE_ROI_TOP		0x0010
+#define D5X_EXPOSURE_ROI_LEFT		0x0014
+#define D5X_EXPOSURE_ROI_BOTTOM		0x0018
+#define D5X_EXPOSURE_ROI_RIGHT		0x001C
+#define D5X_MANUAL_LASER_POWER		0x0024
+#define D5X_PWM_FREQUENCY			0x0028
+#define D5X_CAMERA_SYNC_MODE		0x002C
 
-#define DS5_DEPTH_CONFIG_STATUS		0x4800
-#define DS5_RGB_CONFIG_STATUS		0x4802
-#define DS5_IMU_CONFIG_STATUS		0x4804
-#define DS5_IR_CONFIG_STATUS		0x4808
+#define D5X_DEPTH_CONFIG_STATUS		0x4800
+#define D5X_RGB_CONFIG_STATUS		0x4802
+#define D5X_IMU_CONFIG_STATUS		0x4804
+#define D5X_IR_CONFIG_STATUS		0x4808
 
-#define DS5_STATUS_STREAMING		0x1
-#define DS5_STATUS_INVALID_DT		0x2
-#define DS5_STATUS_INVALID_RES		0x4
-#define DS5_STATUS_INVALID_FPS		0x8
-#define DS5_STATUS_VALID_MASK		0xf
-#define DS5_STATUS_UNAVAILABLE		0xffff
+#define D5X_STATUS_STREAMING		0x1
+#define D5X_STATUS_INVALID_DT		0x2
+#define D5X_STATUS_INVALID_RES		0x4
+#define D5X_STATUS_INVALID_FPS		0x8
+#define D5X_STATUS_VALID_MASK		0xf
+#define D5X_STATUS_UNAVAILABLE		0xffff
 
 #define MIPI_LANE_RATE				1300
-#define DS5_CSI_METADATA_MAGIC		0x484B524D
-#define DS5_CSI_METADATA_HEADER_SIZE	20
-#define DS5_CSI_METADATA_PAYLOAD_OFFSET	8
-#define DS5_CSI_METADATA_MAX_WC		4096
+#define D5X_CSI_METADATA_MAGIC		0x484B524D
+#define D5X_CSI_METADATA_HEADER_SIZE	20
+#define D5X_CSI_METADATA_PAYLOAD_OFFSET	8
+#define D5X_CSI_METADATA_MAX_WC		4096
 
 #define MAX_DEPTH_EXP				200000
 #define MAX_RGB_EXP					10000
 #define DEF_DEPTH_EXP				33000
 #define DEF_RGB_EXP					1660
 
-enum ds5_mux_pad {
-	DS5_MUX_PAD_EXTERNAL,
-	DS5_MUX_PAD_DEPTH,
-	DS5_MUX_PAD_RGB,
-	DS5_MUX_PAD_IR,
-	DS5_MUX_PAD_IMU,
-	DS5_MUX_PAD_COUNT,
+enum d5x_mux_pad {
+	D5X_MUX_PAD_EXTERNAL,
+	D5X_MUX_PAD_DEPTH,
+	D5X_MUX_PAD_RGB,
+	D5X_MUX_PAD_IR,
+	D5X_MUX_PAD_IMU,
+	D5X_MUX_PAD_COUNT,
 };
 
-#define DS5_N_CONTROLS		 		8
+#define D5X_N_CONTROLS		 		8
 
-#define DS5_MAX_STREAMS				4
+#define D5X_MAX_STREAMS				4
 
 #define PIPE_NOT_CONFIGURED			-1
 
 #define DFU_WAIT_RET_LEN 			6
 
-#define DS5_START_POLL_TIME			10
-#define DS5_START_POLL_MAX_TIME			40
-#define DS5_START_MAX_TIME			2000
-#define DS5_STOP_MAX_TIME			7000
-#define DS5_START_MAX_COUNT	(DS5_START_MAX_TIME / DS5_START_POLL_TIME)
-#define DS5_DSER_REARM_COOLDOWN_MS		1800
-#define MAX_DS5_CONFIG_RETRIES		5
+#define D5X_START_POLL_TIME			10
+#define D5X_START_POLL_MAX_TIME			40
+#define D5X_START_MAX_TIME			2000
+#define D5X_STOP_MAX_TIME			7000
+#define D5X_START_MAX_COUNT	(D5X_START_MAX_TIME / D5X_START_POLL_TIME)
+#define D5X_DSER_REARM_COOLDOWN_MS		1800
+#define MAX_D5X_CONFIG_RETRIES		5
 
 /* I2C retry configuration */
-#define DS5_I2C_RETRY_COUNT			5
-#define DS5_I2C_RETRY_DELAY_US		5000
+#define D5X_I2C_RETRY_COUNT			5
+#define D5X_I2C_RETRY_DELAY_US		5000
 
 /* DFU definition section */
 #define DFU_MAGIC_NUMBER "/0x01/0x02/0x03/0x04"
@@ -240,17 +240,17 @@ enum ds5_mux_pad {
 #define DFU_I2C_FAST_MODE			400000
 #define DFU_I2C_BUS_CLK_RATE		DFU_I2C_FAST_MODE
 #endif
-#define ds5_read_with_check(state, addr, val) {\
-	if (ds5_read(state, addr, val))	\
+#define d5x_read_with_check(state, addr, val) {\
+	if (d5x_read(state, addr, val))	\
 		return -EINVAL; }
-#define ds5_raw_read_with_check(state, addr, buf, size)	{\
-	if (ds5_raw_read(state, addr, buf, size))	\
+#define d5x_raw_read_with_check(state, addr, buf, size)	{\
+	if (d5x_raw_read(state, addr, buf, size))	\
 		return -EINVAL; }
-#define ds5_write_with_check(state, addr, val) {\
-	if (ds5_write(state, addr, val))	\
+#define d5x_write_with_check(state, addr, val) {\
+	if (d5x_write(state, addr, val))	\
 		return -EINVAL; }
-#define ds5_raw_write_with_check(state, addr, buf, size) {\
-	if (ds5_raw_write(state, addr, buf, size)) \
+#define d5x_raw_write_with_check(state, addr, buf, size) {\
+	if (d5x_raw_write(state, addr, buf, size)) \
 		return -EINVAL; }
 
 enum dfu_fw_state {
@@ -268,13 +268,13 @@ enum dfu_fw_state {
 };
 
 enum dfu_state {
-	DS5_DFU_IDLE = 0,
-	DS5_DFU_RECOVERY,
-	DS5_DFU_OPEN,
-	DS5_DFU_IN_PROGRESS,
-	DS5_DFU_DONE,
-	DS5_DFU_ERROR
-} dfu_state_t;
+	D5X_DFU_IDLE = 0,
+	D5X_DFU_RECOVERY,
+	D5X_DFU_OPEN,
+	D5X_DFU_IN_PROGRESS,
+	D5X_DFU_DONE,
+	D5X_DFU_ERROR
+} d5x_dfu_state_t;
 
 struct hwm_cmd {
 	u16 header;
@@ -299,7 +299,7 @@ enum table_id {
 	DEPTH_CALIBRATION_ID = 0x1f,
 	RGB_CALIBRATION_ID = 0x20,
 	IMU_CALIBRATION_ID = 0x22
-} table_id_t;
+} d5x_table_id_t;
 
 static const struct hwm_cmd get_calib_data = {
 	.header = 0x14,
@@ -374,7 +374,7 @@ static const struct hwm_cmd log_prepare = {
 	.param1 = 0x400, .param2 = 0, .param3 = 0, .param4 = 0,
 };
 
-#define DS5_HWMC_OPCODE_UAMG		0x30
+#define D5X_HWMC_OPCODE_UAMG		0x30
 
 struct __fw_status {
 	uint32_t	spare1;
@@ -389,7 +389,7 @@ struct __fw_status {
 
 /*************************/
 
-struct ds5_ctrls {
+struct d5x_ctrls {
 	struct v4l2_ctrl_handler handler;
 	struct v4l2_ctrl_handler handler_depth;
 	struct v4l2_ctrl_handler handler_rgb;
@@ -416,7 +416,7 @@ struct ds5_ctrls {
 		struct v4l2_ctrl *manual_laser_power;
 		struct v4l2_ctrl *auto_exp;
 		struct v4l2_ctrl *exposure;
-		/* in DS5 manual gain only works with manual exposure */
+		/* In D5xx, manual gain only works with manual exposure. */
 		struct v4l2_ctrl *gain;
 		struct v4l2_ctrl *link_freq;
 		struct v4l2_ctrl *query_sub_stream;
@@ -425,32 +425,32 @@ struct ds5_ctrls {
 	};
 };
 
-struct ds5_resolution {
+struct d5x_resolution {
 	u16 width;
 	u16 height;
 	u8 n_framerates;
 	const u16 *framerates;
 };
 
-struct ds5_format {
+struct d5x_format {
 	unsigned int n_resolutions;
-	const struct ds5_resolution *resolutions;
+	const struct d5x_resolution *resolutions;
 	u32 mbus_code;
 	u8 data_type;
 };
 
-struct ds5_sensor {
+struct d5x_sensor {
 	struct v4l2_subdev sd;
 	struct media_pad pad;
 	struct v4l2_mbus_framefmt format;
 	u16 mux_pad;
 	struct {
-		const struct ds5_format *format;
-		const struct ds5_resolution *resolution;
+		const struct d5x_format *format;
+		const struct d5x_resolution *resolution;
 		u16 framerate;
 	} config;
 	bool streaming;
-	const struct ds5_format *formats;
+	const struct d5x_format *formats;
 	unsigned int n_formats;
 	int pipe_id;
 	u16 pipe_data_type1;
@@ -467,21 +467,21 @@ struct ds5_sensor {
 
 #ifdef CONFIG_TEGRA_CAMERA_PLATFORM
 #include <media/camera_common.h>
-#define ds5_mux_subdev camera_common_data
+#define d5x_mux_subdev camera_common_data
 #else
-struct ds5_mux_subdev {
+struct d5x_mux_subdev {
 	struct v4l2_subdev subdev;
 };
 #endif
 
-struct ds5_variant {
-	const struct ds5_format *formats;
+struct d5x_variant {
+	const struct d5x_format *formats;
 	unsigned int n_formats;
 };
 
-struct ds5_dfu_dev {
-	struct cdev ds5_cdev;
-	struct class *ds5_class;
+struct d5x_dfu_dev {
+	struct cdev d5x_cdev;
+	struct class *d5x_class;
 	int device_open_count;
 	enum dfu_state dfu_state_flag;
 	unsigned char *dfu_msg;
@@ -490,34 +490,34 @@ struct ds5_dfu_dev {
 };
 
 enum {
-	DS5_DS5U,
-	DS5_ASR,
-	DS5_AWG,
+	D5X_DS5U,
+	D5X_ASR,
+	D5X_AWG,
 };
 
-struct ds5 {
-	struct { struct ds5_sensor sensor; } depth;
-	struct { struct ds5_sensor sensor; } ir;
-	struct { struct ds5_sensor sensor; } rgb;
-	struct { struct ds5_sensor sensor; } imu;
+struct d5x {
+	struct { struct d5x_sensor sensor; } depth;
+	struct { struct d5x_sensor sensor; } ir;
+	struct { struct d5x_sensor sensor; } rgb;
+	struct { struct d5x_sensor sensor; } imu;
 	struct {
-		struct ds5_mux_subdev sd;
-		struct media_pad pads[DS5_MUX_PAD_COUNT];
-		struct ds5_sensor *last_set;
+		struct d5x_mux_subdev sd;
+		struct media_pad pads[D5X_MUX_PAD_COUNT];
+		struct d5x_sensor *last_set;
 	} mux;
-	struct ds5_ctrls ctrls;
-	struct ds5_dfu_dev dfu_dev;
+	struct d5x_ctrls ctrls;
+	struct d5x_dfu_dev dfu_dev;
 	bool power;
 	struct i2c_client *client;
 	/* All below pointers are used for writing, cannot be const */
 	struct mutex lock;
 	struct regmap *regmap;
 	struct regulator *vcc;
-	const struct ds5_variant *variant;
+	const struct d5x_variant *variant;
 	int is_depth, is_y8, is_rgb, is_imu;
 	bool metadata_enabled;
 	int aggregated;
-	int reset_ref_ds5;
+	int reset_ref_d5x;
 	int reset_ref_dser;
 	u16 fw_version;
 	u16 fw_build;
@@ -532,10 +532,10 @@ struct ds5 {
 	const struct dser_interface *dser_ops;
 	bool serdes_primary; /* true for the instance that ran SERDES setup */
 #endif
-	struct ds5_dev *ds5_dev; /* pointer to DS5 device struct */
+	struct d5x_dev *d5x_dev; /* D5xx device state */
 };
 
-struct ds5_dev {
+struct d5x_dev {
 	struct mutex lock;
 	struct mutex stream_ctrl_lock;
 
@@ -551,7 +551,7 @@ struct ds5_dev {
 
 	/* 
 	* Cached device type from post-reset device-type polling.
-	* During probe the first instance resets the camera, causing DS5_DEVICE_TYPE
+	* During probe the first instance resets the camera, causing D5X_DEVICE_TYPE
 	* to temporarily return 0. The reset path polls until the register is valid
 	* and stores the result here so that all four probe instances (and any
 	* post-reset code path) can use the confirmed value even if the register
@@ -561,7 +561,7 @@ struct ds5_dev {
 
 	/* 
 	* Timestamp (jiffies) of last completed HW reset.
-	* Used to enforce DS5_HW_RESET_COOLDOWN_MS between consecutive resets
+	* Used to enforce D5X_HW_RESET_COOLDOWN_MS between consecutive resets
 	* and prevent GMSL link degradation from rapid reset cycles.
 	*/
 	unsigned long last_reset_jiffies;
@@ -571,8 +571,8 @@ struct ds5_dev {
 	struct dser_control *dser_control;
 #endif
 
-	/* Pointer to the primary DS5 struct */
-	struct ds5 *ds5_primary;
+	/* Pointer to the primary D5xx state */
+	struct d5x *d5x_primary;
 
 	int sync_mode;
 	bool depth_streaming;
@@ -583,7 +583,7 @@ struct ds5_dev {
 
 #ifdef CONFIG_VIDEO_D5XX_SERDES
 static DEFINE_MUTEX(serdes_lock__);
-static bool ds5_slots_inited;
+static bool d5x_slots_inited;
 
 #define MAX_DSER_NUM 4
 struct dser_control {
@@ -591,7 +591,7 @@ struct dser_control {
 
 	/*
 	* Per-deserializer reset generation counter.
-	* Replaces the old global ds5_reset_gen for SERDES builds so that
+	* Replaces the old global d5x_reset_gen for SERDES builds so that
 	* resetting camera A does not force camera B (on a different deserializer)
 	* to invalidate its state.  Cameras sharing the same deserializer still
 	* see each other's resets through the shared counter.
@@ -606,42 +606,42 @@ struct dser_control {
 };
 static struct dser_control dser_inited[MAX_DSER_NUM];
 
-#define MAX_DS5_NUM (MAX_DSER_NUM * 4) /* assuming max 4 DS5 cameras per deserializer */
-static struct ds5_dev ds5_inited[MAX_DS5_NUM];
+#define MAX_D5X_NUM (MAX_DSER_NUM * 4) /* Up to four D5xx cameras per deserializer. */
+static struct d5x_dev d5x_inited[MAX_D5X_NUM];
 
-static void ds5_init_global_slots_once(void)
+static void d5x_init_global_slots_once(void)
 {
 	int i;
 
-	if (ds5_slots_inited) {
+	if (d5x_slots_inited) {
 		return;
 	}
 
-	for (i = 0; i < MAX_DS5_NUM; i++)
-		mutex_init(&ds5_inited[i].lock);
-	for (i = 0; i < MAX_DS5_NUM; i++)
-		mutex_init(&ds5_inited[i].stream_ctrl_lock);
+	for (i = 0; i < MAX_D5X_NUM; i++)
+		mutex_init(&d5x_inited[i].lock);
+	for (i = 0; i < MAX_D5X_NUM; i++)
+		mutex_init(&d5x_inited[i].stream_ctrl_lock);
 
 	for (i = 0; i < MAX_DSER_NUM; i++)
 		mutex_init(&dser_inited[i].lock);
 
-	ds5_slots_inited = true;
+	d5x_slots_inited = true;
 }
 
-static inline atomic_t *ds5_get_reset_gen(struct ds5 *state)
+static inline atomic_t *d5x_get_reset_gen(struct d5x *state)
 {
-	return &state->ds5_dev->reset_gen;
+	return &state->d5x_dev->reset_gen;
 }
 
-static inline atomic_t *dser_get_reset_gen(struct ds5 *state)
+static inline atomic_t *dser_get_reset_gen(struct d5x *state)
 {
-	return &state->ds5_dev->dser_control->reset_gen;
+	return &state->d5x_dev->dser_control->reset_gen;
 }
 
-static bool ds5_dser_datapath_armed(struct ds5 *state)
+static bool d5x_dser_datapath_armed(struct d5x *state)
 {
 	bool armed;
-	struct dser_control *ctrl = state->ds5_dev->dser_control;
+	struct dser_control *ctrl = state->d5x_dev->dser_control;
 
 	mutex_lock(&ctrl->lock);
 	armed = ctrl->datapath_armed;
@@ -650,9 +650,9 @@ static bool ds5_dser_datapath_armed(struct ds5 *state)
 	return armed;
 }
 
-static void ds5_set_dser_datapath_armed(struct ds5 *state, bool armed)
+static void d5x_set_dser_datapath_armed(struct d5x *state, bool armed)
 {
-	struct dser_control *ctrl = state->ds5_dev->dser_control;
+	struct dser_control *ctrl = state->d5x_dev->dser_control;
 
 	mutex_lock(&ctrl->lock);
 	ctrl->datapath_armed = armed;
@@ -661,10 +661,10 @@ static void ds5_set_dser_datapath_armed(struct ds5 *state, bool armed)
 	mutex_unlock(&ctrl->lock);
 }
 
-static bool ds5_dser_datapath_matches(struct ds5 *state, u8 pipe_mask)
+static bool d5x_dser_datapath_matches(struct d5x *state, u8 pipe_mask)
 {
 	bool matches;
-	struct dser_control *ctrl = state->ds5_dev->dser_control;
+	struct dser_control *ctrl = state->d5x_dev->dser_control;
 
 	mutex_lock(&ctrl->lock);
 	matches = ctrl->datapath_armed &&
@@ -674,9 +674,9 @@ static bool ds5_dser_datapath_matches(struct ds5 *state, u8 pipe_mask)
 	return matches;
 }
 
-static void ds5_set_dser_datapath_pipe_mask(struct ds5 *state, u8 pipe_mask)
+static void d5x_set_dser_datapath_pipe_mask(struct d5x *state, u8 pipe_mask)
 {
-	struct dser_control *ctrl = state->ds5_dev->dser_control;
+	struct dser_control *ctrl = state->d5x_dev->dser_control;
 
 	mutex_lock(&ctrl->lock);
 	ctrl->datapath_armed = true;
@@ -684,10 +684,10 @@ static void ds5_set_dser_datapath_pipe_mask(struct ds5 *state, u8 pipe_mask)
 	mutex_unlock(&ctrl->lock);
 }
 
-static bool ds5_dser_post_start_kick_pending(struct ds5 *state)
+static bool d5x_dser_post_start_kick_pending(struct d5x *state)
 {
 	bool pending;
-	struct dser_control *ctrl = state->ds5_dev->dser_control;
+	struct dser_control *ctrl = state->d5x_dev->dser_control;
 
 	mutex_lock(&ctrl->lock);
 	pending = ctrl->post_start_kick_pending;
@@ -696,28 +696,28 @@ static bool ds5_dser_post_start_kick_pending(struct ds5 *state)
 	return pending;
 }
 
-static void ds5_set_dser_post_start_kick_pending(struct ds5 *state,
+static void d5x_set_dser_post_start_kick_pending(struct d5x *state,
 						 bool pending)
 {
-	struct dser_control *ctrl = state->ds5_dev->dser_control;
+	struct dser_control *ctrl = state->d5x_dev->dser_control;
 
 	mutex_lock(&ctrl->lock);
 	ctrl->post_start_kick_pending = pending;
 	mutex_unlock(&ctrl->lock);
 }
 
-static void ds5_clear_dser_start_state(struct ds5 *state)
+static void d5x_clear_dser_start_state(struct d5x *state)
 {
-	struct dser_control *ctrl = state->ds5_dev->dser_control;
+	struct dser_control *ctrl = state->d5x_dev->dser_control;
 
 	mutex_lock(&ctrl->lock);
 	ctrl->post_start_kick_pending = false;
 	mutex_unlock(&ctrl->lock);
 }
 
-static void ds5_finish_dser_prestart(struct ds5 *state, bool reset_performed)
+static void d5x_finish_dser_prestart(struct d5x *state, bool reset_performed)
 {
-	struct dser_control *ctrl = state->ds5_dev->dser_control;
+	struct dser_control *ctrl = state->d5x_dev->dser_control;
 
 	mutex_lock(&ctrl->lock);
 	ctrl->datapath_armed = reset_performed;
@@ -726,10 +726,10 @@ static void ds5_finish_dser_prestart(struct ds5 *state, bool reset_performed)
 	mutex_unlock(&ctrl->lock);
 }
 
-static unsigned int ds5_dser_rearm_gen(struct ds5 *state)
+static unsigned int d5x_dser_rearm_gen(struct d5x *state)
 {
 	unsigned int gen;
-	struct dser_control *ctrl = state->ds5_dev->dser_control;
+	struct dser_control *ctrl = state->d5x_dev->dser_control;
 
 	mutex_lock(&ctrl->lock);
 	gen = ctrl->rearm_gen;
@@ -738,43 +738,43 @@ static unsigned int ds5_dser_rearm_gen(struct ds5 *state)
 	return gen;
 }
 
-static unsigned int ds5_started_mipi_streams(struct ds5 *state)
+static unsigned int d5x_started_mipi_streams(struct d5x *state)
 {
 	unsigned int count = 0;
 
-	mutex_lock(&state->ds5_dev->lock);
-	if (state->ds5_dev->depth_streaming)
+	mutex_lock(&state->d5x_dev->lock);
+	if (state->d5x_dev->depth_streaming)
 		count++;
-	if (state->ds5_dev->rgb_streaming)
+	if (state->d5x_dev->rgb_streaming)
 		count++;
-	if (state->ds5_dev->ir_streaming)
+	if (state->d5x_dev->ir_streaming)
 		count++;
-	if (state->ds5_dev->imu_streaming)
+	if (state->d5x_dev->imu_streaming)
 		count++;
-	mutex_unlock(&state->ds5_dev->lock);
+	mutex_unlock(&state->d5x_dev->lock);
 
 	return count;
 }
 
-static u8 ds5_started_mipi_pipe_mask(struct ds5 *state)
+static u8 d5x_started_mipi_pipe_mask(struct d5x *state)
 {
 	u8 mask = 0;
 
-	mutex_lock(&state->ds5_dev->lock);
-	if (state->ds5_dev->depth_streaming)
+	mutex_lock(&state->d5x_dev->lock);
+	if (state->d5x_dev->depth_streaming)
 		mask |= BIT(0);
-	if (state->ds5_dev->rgb_streaming)
+	if (state->d5x_dev->rgb_streaming)
 		mask |= BIT(1);
-	if (state->ds5_dev->ir_streaming)
+	if (state->d5x_dev->ir_streaming)
 		mask |= BIT(2);
-	if (state->ds5_dev->imu_streaming)
+	if (state->d5x_dev->imu_streaming)
 		mask |= BIT(3);
-	mutex_unlock(&state->ds5_dev->lock);
+	mutex_unlock(&state->d5x_dev->lock);
 
 	return mask;
 }
 
-static void ds5_post_start_dser_datapath_kick(struct ds5 *state, u16 stream_id)
+static void d5x_post_start_dser_datapath_kick(struct d5x *state, u16 stream_id)
 {
 	unsigned int started_streams;
 	u8 active_pipe_mask;
@@ -789,8 +789,8 @@ static void ds5_post_start_dser_datapath_kick(struct ds5 *state, u16 stream_id)
 
 	active_pipes = state->dser_ops->get_active_pipe_count ?
 		state->dser_ops->get_active_pipe_count(state->dser_dev) : 1;
-	started_streams = ds5_started_mipi_streams(state);
-	active_pipe_mask = ds5_started_mipi_pipe_mask(state);
+	started_streams = d5x_started_mipi_streams(state);
+	active_pipe_mask = d5x_started_mipi_pipe_mask(state);
 	if (started_streams < active_pipes) {
 		dev_info(&state->client->dev,
 			 "stream %u START ok; locked DES datapath unchanged until remaining streams start (%u/%d)\n",
@@ -798,8 +798,8 @@ static void ds5_post_start_dser_datapath_kick(struct ds5 *state, u16 stream_id)
 		goto out;
 	}
 
-	if (ds5_dser_datapath_matches(state, active_pipe_mask) &&
-	    !ds5_dser_post_start_kick_pending(state)) {
+	if (d5x_dser_datapath_matches(state, active_pipe_mask) &&
+	    !d5x_dser_post_start_kick_pending(state)) {
 		dev_info(&state->client->dev,
 			 "stream %u START ok; keeping locked GMSL Link A unchanged for pipe mask 0x%02x (%u/%d streams started)\n",
 			 stream_id, active_pipe_mask, started_streams, active_pipes);
@@ -814,17 +814,17 @@ static void ds5_post_start_dser_datapath_kick(struct ds5 *state, u16 stream_id)
 	 * frames, while leaving the datapath untouched does not resynchronize
 	 * tunnel detection after the camera starts transmitting. */
 	state->dser_ops->retrigger_datapath(state->dser_dev);
-	ds5_clear_dser_start_state(state);
-	ds5_set_dser_datapath_pipe_mask(state, active_pipe_mask);
-	ds5_set_dser_post_start_kick_pending(state, false);
+	d5x_clear_dser_start_state(state);
+	d5x_set_dser_datapath_pipe_mask(state, active_pipe_mask);
+	d5x_set_dser_post_start_kick_pending(state, false);
 
 out:
 	mutex_unlock(&serdes_lock__);
 }
 
-static void ds5_wait_for_dser_rearm_cooldown(struct ds5 *state, const char *reason)
+static void d5x_wait_for_dser_rearm_cooldown(struct d5x *state, const char *reason)
 {
-	struct dser_control *ctrl = state->ds5_dev->dser_control;
+	struct dser_control *ctrl = state->d5x_dev->dser_control;
 	unsigned long last_idle;
 	unsigned long ready;
 	unsigned int wait_ms;
@@ -836,7 +836,7 @@ static void ds5_wait_for_dser_rearm_cooldown(struct ds5 *state, const char *reas
 	if (!last_idle)
 		return;
 
-	ready = last_idle + msecs_to_jiffies(DS5_DSER_REARM_COOLDOWN_MS);
+	ready = last_idle + msecs_to_jiffies(D5X_DSER_REARM_COOLDOWN_MS);
 	if (!time_before(jiffies, ready))
 		return;
 
@@ -847,7 +847,7 @@ static void ds5_wait_for_dser_rearm_cooldown(struct ds5 *state, const char *reas
 	msleep(wait_ms);
 }
 
-static bool ds5_rearm_dser_datapath_before_start(struct ds5 *state, int pipe_id,
+static bool d5x_rearm_dser_datapath_before_start(struct d5x *state, int pipe_id,
 						 int active_pipes,
 						 int link_locked,
 						 const char *reason)
@@ -862,7 +862,7 @@ static bool ds5_rearm_dser_datapath_before_start(struct ds5 *state, int pipe_id,
 		return false;
 	}
 
-	ds5_wait_for_dser_rearm_cooldown(state, reason);
+	d5x_wait_for_dser_rearm_cooldown(state, reason);
 	dev_info(&state->client->dev,
 		 "pipe %d pre-start resetting GMSL Link A PHY and datapath with ONESHOT (%s, %d pipes active, link %s)\n",
 		 pipe_id, reason, active_pipes,
@@ -871,16 +871,16 @@ static bool ds5_rearm_dser_datapath_before_start(struct ds5 *state, int pipe_id,
 	state->dser_ops->reset_oneshot(state->dser_dev);
 	max96717_retrigger_tx(state->ser_dev);
 	msleep(200);
-	ds5_set_dser_post_start_kick_pending(state, true);
+	d5x_set_dser_post_start_kick_pending(state, true);
 	return true;
 }
 
-static void ds5_disarm_dser_datapath_if_idle(struct ds5 *state)
+static void d5x_disarm_dser_datapath_if_idle(struct d5x *state)
 {
 	int active_pipes;
 	int link_locked;
 	bool armed;
-	struct dser_control *ctrl = state->ds5_dev->dser_control;
+	struct dser_control *ctrl = state->d5x_dev->dser_control;
 
 	if (!state->dser_ops->get_active_pipe_count)
 		return;
@@ -937,54 +937,54 @@ static const struct dser_interface max96724_interface = {
 
 #else /* !CONFIG_VIDEO_D5XX_SERDES */
 
-static atomic_t ds5_reset_gen = ATOMIC_INIT(0);
-static inline atomic_t *ds5_get_reset_gen(struct ds5 *state)
+static atomic_t d5x_reset_gen = ATOMIC_INIT(0);
+static inline atomic_t *d5x_get_reset_gen(struct d5x *state)
 {
-	return &ds5_reset_gen;
+	return &d5x_reset_gen;
 }
 
-#define MAX_DS5_NUM (1)
-static struct ds5_dev ds5_inited[MAX_DS5_NUM];
-static bool ds5_slots_inited;
-static DEFINE_MUTEX(ds5_slots_lock__);
+#define MAX_D5X_NUM (1)
+static struct d5x_dev d5x_inited[MAX_D5X_NUM];
+static bool d5x_slots_inited;
+static DEFINE_MUTEX(d5x_slots_lock__);
 
-static void ds5_init_global_slots_once(void)
+static void d5x_init_global_slots_once(void)
 {
-	mutex_lock(&ds5_slots_lock__);
-	if (!ds5_slots_inited) {
-		mutex_init(&ds5_inited[0].lock);
-		mutex_init(&ds5_inited[0].stream_ctrl_lock);
-		ds5_slots_inited = true;
+	mutex_lock(&d5x_slots_lock__);
+	if (!d5x_slots_inited) {
+		mutex_init(&d5x_inited[0].lock);
+		mutex_init(&d5x_inited[0].stream_ctrl_lock);
+		d5x_slots_inited = true;
 	}
-	mutex_unlock(&ds5_slots_lock__);
+	mutex_unlock(&d5x_slots_lock__);
 }
 
 #endif /* !CONFIG_VIDEO_D5XX_SERDES */
 
-static inline u16 ds5_dev_type(struct ds5 *state, u16 dev_type)
+static inline u16 d5x_dev_type(struct d5x *state, u16 dev_type)
 {
-	if (dev_type == 0 && state->ds5_dev->cached_device_type != 0) {
+	if (dev_type == 0 && state->d5x_dev->cached_device_type != 0) {
 		dev_info(&state->client->dev,
 			"%s(): device type register returned 0, using cached type 0x%x\n",
-			__func__, state->ds5_dev->cached_device_type);
-		dev_type = state->ds5_dev->cached_device_type;
+			__func__, state->d5x_dev->cached_device_type);
+		dev_type = state->d5x_dev->cached_device_type;
 	}
 	return dev_type;
 }
 
-static bool ds5_is_valid_device_type(u16 dev_type)
+static bool d5x_is_valid_device_type(u16 dev_type)
 {
 	switch (dev_type) {
-	case DS5_DEVICE_TYPE_D58X:
+	case D5X_DEVICE_TYPE_D58X:
 		return true;
 	default:
 		return false;
 	}
 }
 
-#define ds5_from_depth_sd(sd) container_of(sd, struct ds5, depth.sd)
-#define ds5_from_ir_sd(sd) container_of(sd, struct ds5, ir.sd)
-#define ds5_from_rgb_sd(sd) container_of(sd, struct ds5, rgb.sd)
+#define d5x_from_depth_sd(sd) container_of(sd, struct d5x, depth.sd)
+#define d5x_from_ir_sd(sd) container_of(sd, struct d5x, ir.sd)
+#define d5x_from_rgb_sd(sd) container_of(sd, struct d5x, rgb.sd)
 #if LINUX_VERSION_CODE > KERNEL_VERSION(5, 15, 136)
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 148)
 static inline void msleep_range(unsigned int delay_base)
@@ -994,16 +994,16 @@ static inline void msleep_range(unsigned int delay_base)
 #endif
 #endif
 
-static unsigned int ds5_stream_poll_delay(bool starting, unsigned int retry)
+static unsigned int d5x_stream_poll_delay(bool starting, unsigned int retry)
 {
-	unsigned int delay = retry * DS5_START_POLL_TIME;
+	unsigned int delay = retry * D5X_START_POLL_TIME;
 
 	if (starting)
-		return min(delay, (unsigned int)DS5_START_POLL_MAX_TIME);
+		return min(delay, (unsigned int)D5X_START_POLL_MAX_TIME);
 	return delay;
 }
 
-static int ds5_write(struct ds5 *state, u16 reg, u16 val)
+static int d5x_write(struct d5x *state, u16 reg, u16 val)
 {
 	int ret;
 	int retry;
@@ -1016,30 +1016,30 @@ static int ds5_write(struct ds5 *state, u16 reg, u16 val)
 			"%s(): writing to register: 0x%04x, value1: 0x%x, value2:0x%x\n",
 			__func__, reg, value[1], value[0]);
 
-	for (retry = 0; retry < DS5_I2C_RETRY_COUNT; retry++) {
+	for (retry = 0; retry < D5X_I2C_RETRY_COUNT; retry++) {
 		ret = regmap_raw_write(state->regmap, reg, value, sizeof(value));
 		if (ret == 0)
 			break;
-		if (retry < DS5_I2C_RETRY_COUNT - 1) {
+		if (retry < D5X_I2C_RETRY_COUNT - 1) {
 			dev_warn(&state->client->dev,
 				"%s(): i2c write retry %d, 0x%04x = 0x%x, err %d\n",
 				__func__, retry + 1, reg, val, ret);
-			usleep_range(DS5_I2C_RETRY_DELAY_US,
-				     DS5_I2C_RETRY_DELAY_US + 500);
+			usleep_range(D5X_I2C_RETRY_DELAY_US,
+				     D5X_I2C_RETRY_DELAY_US + 500);
 		}
 	}
 	if (ret < 0)
 		dev_err(&state->client->dev,
 			"%s(): i2c write failed after %d retries, 0x%04x = 0x%x, err %d\n",
-			__func__, DS5_I2C_RETRY_COUNT, reg, val, ret);
-	else if (state->dfu_dev.dfu_state_flag == DS5_DFU_IDLE)
+			__func__, D5X_I2C_RETRY_COUNT, reg, val, ret);
+	else if (state->dfu_dev.dfu_state_flag == D5X_DFU_IDLE)
 		dev_dbg(&state->client->dev, "%s(): i2c write 0x%04x: 0x%x\n",
 			__func__, reg, val);
 
 	return ret;
 }
 
-static int ds5_write_then_read(struct ds5 *state, u16 write_reg, u16 write_val,
+static int d5x_write_then_read(struct d5x *state, u16 write_reg, u16 write_val,
 			       u16 read_reg, u16 *read_val)
 {
 	struct i2c_client *client = state->client;
@@ -1076,7 +1076,7 @@ static int ds5_write_then_read(struct ds5 *state, u16 write_reg, u16 write_val,
 	/* Keep the command and its first status read in one adapter transaction.
 	 * Repeated STARTs provide an unambiguous boundary to the remote slave even
 	 * when its polling task is scheduled after all address bytes have arrived. */
-	for (retry = 0; retry < DS5_I2C_RETRY_COUNT; retry++) {
+	for (retry = 0; retry < D5X_I2C_RETRY_COUNT; retry++) {
 		ret = i2c_transfer(client->adapter, msgs, ARRAY_SIZE(msgs));
 		if (ret == ARRAY_SIZE(msgs)) {
 			*read_val = read_buf[0] | ((u16)read_buf[1] << 8);
@@ -1084,40 +1084,40 @@ static int ds5_write_then_read(struct ds5 *state, u16 write_reg, u16 write_val,
 		}
 		if (ret >= 0)
 			ret = -EIO;
-		if (retry < DS5_I2C_RETRY_COUNT - 1)
-			usleep_range(DS5_I2C_RETRY_DELAY_US,
-				     DS5_I2C_RETRY_DELAY_US + 500);
+		if (retry < D5X_I2C_RETRY_COUNT - 1)
+			usleep_range(D5X_I2C_RETRY_DELAY_US,
+				     D5X_I2C_RETRY_DELAY_US + 500);
 	}
 
 	dev_err(&client->dev,
 		"%s(): i2c write/read failed after %d retries, 0x%04x = 0x%x -> 0x%04x, err %d\n",
-		__func__, DS5_I2C_RETRY_COUNT, write_reg, write_val, read_reg, ret);
+		__func__, D5X_I2C_RETRY_COUNT, write_reg, write_val, read_reg, ret);
 	return ret;
 }
 
-static int ds5_raw_write(struct ds5 *state, u16 reg,
+static int d5x_raw_write(struct d5x *state, u16 reg,
 			const void *val, size_t val_len)
 {
 	int ret;
 	int retry;
 
-	for (retry = 0; retry < DS5_I2C_RETRY_COUNT; retry++) {
+	for (retry = 0; retry < D5X_I2C_RETRY_COUNT; retry++) {
 		ret = regmap_raw_write(state->regmap, reg, val, val_len);
 		if (ret == 0)
 			break;
-		if (retry < DS5_I2C_RETRY_COUNT - 1) {
+		if (retry < D5X_I2C_RETRY_COUNT - 1) {
 			dev_warn(&state->client->dev,
 				"%s(): i2c raw write retry %d, 0x%04x size(%d), err %d\n",
 				__func__, retry + 1, reg, (int)val_len, ret);
-			usleep_range(DS5_I2C_RETRY_DELAY_US,
-				     DS5_I2C_RETRY_DELAY_US + 500);
+			usleep_range(D5X_I2C_RETRY_DELAY_US,
+				     D5X_I2C_RETRY_DELAY_US + 500);
 		}
 	}
 	if (ret < 0)
 		dev_err(&state->client->dev,
 			"%s(): i2c raw write failed after %d retries, 0x%04x size(%d), err %d\n",
-			__func__, DS5_I2C_RETRY_COUNT, reg, (int)val_len, ret);
-	else if (state->dfu_dev.dfu_state_flag == DS5_DFU_IDLE)
+			__func__, D5X_I2C_RETRY_COUNT, reg, (int)val_len, ret);
+	else if (state->dfu_dev.dfu_state_flag == D5X_DFU_IDLE)
 		dev_dbg(&state->client->dev,
 			"%s(): i2c raw write 0x%04x: %d bytes\n",
 			__func__, reg, (int)val_len);
@@ -1125,151 +1125,151 @@ static int ds5_raw_write(struct ds5 *state, u16 reg,
 	return ret;
 }
 
-static int ds5_read(struct ds5 *state, u16 reg, u16 *val)
+static int d5x_read(struct d5x *state, u16 reg, u16 *val)
 {
 	int ret;
 	int retry;
 
-	for (retry = 0; retry < DS5_I2C_RETRY_COUNT; retry++) {
+	for (retry = 0; retry < D5X_I2C_RETRY_COUNT; retry++) {
 		ret = regmap_raw_read(state->regmap, reg, val, 2);
 		if (ret == 0)
 			break;
-		if (retry < DS5_I2C_RETRY_COUNT - 1) {
+		if (retry < D5X_I2C_RETRY_COUNT - 1) {
 			dev_warn(&state->client->dev,
 				"%s(): i2c read retry %d, 0x%04x, err %d\n",
 				__func__, retry + 1, reg, ret);
-			usleep_range(DS5_I2C_RETRY_DELAY_US,
-				     DS5_I2C_RETRY_DELAY_US + 500);
+			usleep_range(D5X_I2C_RETRY_DELAY_US,
+				     D5X_I2C_RETRY_DELAY_US + 500);
 		}
 	}
 	if (ret < 0)
 		dev_err(&state->client->dev,
 			"%s(): i2c read failed after %d retries, 0x%04x, err %d\n",
-			__func__, DS5_I2C_RETRY_COUNT, reg, ret);
-	else if (state->dfu_dev.dfu_state_flag == DS5_DFU_IDLE)
+			__func__, D5X_I2C_RETRY_COUNT, reg, ret);
+	else if (state->dfu_dev.dfu_state_flag == D5X_DFU_IDLE)
 		dev_dbg(&state->client->dev, "%s(): i2c read 0x%04x: 0x%x\n",
 			__func__, reg, *val);
 
 	return ret;
 }
 
-static int ds5_read_poll(struct ds5 *state, u16 reg, u16 *val)
+static int d5x_read_poll(struct d5x *state, u16 reg, u16 *val)
 {
 	return regmap_raw_read(state->regmap, reg, val, 2);
 }
 
-static int ds5_raw_read(struct ds5 *state, u16 reg, void *val, size_t val_len)
+static int d5x_raw_read(struct d5x *state, u16 reg, void *val, size_t val_len)
 {
 	int ret;
 	int retry;
 
-	for (retry = 0; retry < DS5_I2C_RETRY_COUNT; retry++) {
+	for (retry = 0; retry < D5X_I2C_RETRY_COUNT; retry++) {
 		ret = regmap_raw_read(state->regmap, reg, val, val_len);
 		if (ret == 0)
 			break;
-		if (retry < DS5_I2C_RETRY_COUNT - 1) {
+		if (retry < D5X_I2C_RETRY_COUNT - 1) {
 			dev_warn(&state->client->dev,
 				"%s(): i2c raw read retry %d, 0x%04x size(%d), err %d\n",
 				__func__, retry + 1, reg, (int)val_len, ret);
-			usleep_range(DS5_I2C_RETRY_DELAY_US,
-				     DS5_I2C_RETRY_DELAY_US + 500);
+			usleep_range(D5X_I2C_RETRY_DELAY_US,
+				     D5X_I2C_RETRY_DELAY_US + 500);
 		}
 	}
 	if (ret < 0)
 		dev_err(&state->client->dev,
 			"%s(): i2c raw read failed after %d retries, 0x%04x size(%d), err %d\n",
-			__func__, DS5_I2C_RETRY_COUNT, reg, (int)val_len, ret);
+			__func__, D5X_I2C_RETRY_COUNT, reg, (int)val_len, ret);
 
 	return ret;
 }
 
 /* Pad ops */
 
-static const u16 ds5_default_framerate = 30;
+static const u16 d5x_default_framerate = 30;
 
-#define DS5_FRAMERATE_DEFAULT_IDX 1
+#define D5X_FRAMERATE_DEFAULT_IDX 1
 
-static const u16 ds5_framerate_30 = 30;
-static const u16 ds5_depth_framerate_to_30[] = {5, 15, 30};
-static const u16 ds5_framerate_to_60[] = {5, 15, 30, 60};
-static const u16 ds5_framerate_to_90[] = {5, 15, 30, 60, 90};
-static const u16 ds5_framerate_15_30[] = {15, 30};
-static const u16 ds5_framerate_15_25[] = {15, 25};
-static const u16 ds5_framerate_90[] = {90};
-static const u16 ds5_framerate_9_30[] = {9, 30};
-static const u16 ds5_imu_framerates[] = {100, 200, 400};
+static const u16 d5x_framerate_30 = 30;
+static const u16 d5x_depth_framerate_to_30[] = {5, 15, 30};
+static const u16 d5x_framerate_to_60[] = {5, 15, 30, 60};
+static const u16 d5x_framerate_to_90[] = {5, 15, 30, 60, 90};
+static const u16 d5x_framerate_15_30[] = {15, 30};
+static const u16 d5x_framerate_15_25[] = {15, 25};
+static const u16 d5x_framerate_90[] = {90};
+static const u16 d5x_framerate_9_30[] = {9, 30};
+static const u16 d5x_imu_framerates[] = {100, 200, 400};
 
 /* Helper macro to define resolution entries concisely. */
-#define DS5_RES(w, h, fr) \
+#define D5X_RES(w, h, fr) \
     { .width = (w), .height = (h), .framerates = (fr), .n_framerates = ARRAY_SIZE(fr) },
 
 /* D58x depth resolutions: DEPTH (Z16) + DEPTH_RAW (Z16) */
-static const struct ds5_resolution d58x_depth_sizes[] = {
-	DS5_RES(640, 360, ds5_framerate_to_90)	/* default */
-	DS5_RES(1280, 960, ds5_framerate_to_60)
-	DS5_RES(1280, 720, ds5_framerate_to_60)
-	DS5_RES(896, 504, ds5_framerate_to_60)
-	DS5_RES(848, 480, ds5_framerate_to_60)
-	DS5_RES(640, 480, ds5_framerate_to_90)
-	DS5_RES(480, 270, ds5_framerate_to_90)
-	DS5_RES(424, 240, ds5_framerate_to_90)
+static const struct d5x_resolution d58x_depth_sizes[] = {
+	D5X_RES(640, 360, d5x_framerate_to_90)	/* default */
+	D5X_RES(1280, 960, d5x_framerate_to_60)
+	D5X_RES(1280, 720, d5x_framerate_to_60)
+	D5X_RES(896, 504, d5x_framerate_to_60)
+	D5X_RES(848, 480, d5x_framerate_to_60)
+	D5X_RES(640, 480, d5x_framerate_to_90)
+	D5X_RES(480, 270, d5x_framerate_to_90)
+	D5X_RES(424, 240, d5x_framerate_to_90)
 };
 
 /* D58x IR/Y8 resolutions: IR (Y8/L8R8) + IR_RAW (Y8) */
-static const struct ds5_resolution d58x_y8_sizes[] = {
-	DS5_RES(640, 360, ds5_framerate_to_90)	/* default */
-	DS5_RES(1280, 960, ds5_framerate_to_60)
-	DS5_RES(1280, 720, ds5_framerate_to_60)
-	DS5_RES(896, 504, ds5_framerate_to_60)
-	DS5_RES(848, 480, ds5_framerate_to_60)
-	DS5_RES(640, 480, ds5_framerate_to_90)
-	DS5_RES(480, 270, ds5_framerate_to_90)
-	DS5_RES(424, 240, ds5_framerate_to_90)
+static const struct d5x_resolution d58x_y8_sizes[] = {
+	D5X_RES(640, 360, d5x_framerate_to_90)	/* default */
+	D5X_RES(1280, 960, d5x_framerate_to_60)
+	D5X_RES(1280, 720, d5x_framerate_to_60)
+	D5X_RES(896, 504, d5x_framerate_to_60)
+	D5X_RES(848, 480, d5x_framerate_to_60)
+	D5X_RES(640, 480, d5x_framerate_to_90)
+	D5X_RES(480, 270, d5x_framerate_to_90)
+	D5X_RES(424, 240, d5x_framerate_to_90)
 };
 
 /* D58x calibration resolutions: IR_RAW Y12I (24-bit) + Self-Calibration/Tare */
-static const struct ds5_resolution d58x_calibration_sizes[] = {
-	DS5_RES(1600, 1300, ds5_framerate_15_25)
-	DS5_RES(256, 144, ds5_framerate_90)
+static const struct d5x_resolution d58x_calibration_sizes[] = {
+	D5X_RES(1600, 1300, d5x_framerate_15_25)
+	D5X_RES(256, 144, d5x_framerate_90)
 };
 
 /* D58x RGB resolutions: COLOR (YUY2) */
-static const struct ds5_resolution d58x_rgb_sizes[] = {
-	DS5_RES(640, 360, ds5_framerate_to_90)	/* default */
-	DS5_RES(1280, 960, ds5_framerate_to_60)
-	DS5_RES(1280, 720, ds5_framerate_to_60)
-	DS5_RES(896, 504, ds5_framerate_to_60)
-	DS5_RES(848, 480, ds5_framerate_to_60)
-	DS5_RES(640, 480, ds5_framerate_to_90)
-	DS5_RES(480, 270, ds5_framerate_to_90)
-	DS5_RES(424, 240, ds5_framerate_to_90)
+static const struct d5x_resolution d58x_rgb_sizes[] = {
+	D5X_RES(640, 360, d5x_framerate_to_90)	/* default */
+	D5X_RES(1280, 960, d5x_framerate_to_60)
+	D5X_RES(1280, 720, d5x_framerate_to_60)
+	D5X_RES(896, 504, d5x_framerate_to_60)
+	D5X_RES(848, 480, d5x_framerate_to_60)
+	D5X_RES(640, 480, d5x_framerate_to_90)
+	D5X_RES(480, 270, d5x_framerate_to_90)
+	D5X_RES(424, 240, d5x_framerate_to_90)
 };
 
 /* D58x COLOR_RAW resolutions: RAW16 */
-static const struct ds5_resolution d58x_rgb_raw_sizes[] = {
-	DS5_RES(1600, 1300, ds5_framerate_9_30)
+static const struct d5x_resolution d58x_rgb_raw_sizes[] = {
+	D5X_RES(1600, 1300, d5x_framerate_9_30)
 };
 
-static const struct ds5_resolution ds5_size_imu[] = {
+static const struct d5x_resolution d5x_size_imu[] = {
 	{
 	.width = 32,
 	.height = 1,
-	.framerates = ds5_imu_framerates,
-	.n_framerates = ARRAY_SIZE(ds5_imu_framerates),
+	.framerates = d5x_imu_framerates,
+	.n_framerates = ARRAY_SIZE(d5x_imu_framerates),
 	},
 };
 
 /* 32 bit IMU introduced with IMU sensitivity attribute Firmware */
-static const struct ds5_resolution ds5_size_imu_extended[] = {
+static const struct d5x_resolution d5x_size_imu_extended[] = {
 	{
 	.width = 38,
 	.height = 1,
-	.framerates = ds5_imu_framerates,
-	.n_framerates = ARRAY_SIZE(ds5_imu_framerates),
+	.framerates = d5x_imu_framerates,
+	.n_framerates = ARRAY_SIZE(d5x_imu_framerates),
 	},
 };
 
-static const struct ds5_format ds5_depth_formats_d58x[] = {
+static const struct d5x_format d5x_depth_formats_d58x[] = {
 	{
 		.data_type = GMSL_CSI_DT_YUV422_8,	/* Z16 */
 		.mbus_code = MEDIA_BUS_FMT_UYVY8_1X16,
@@ -1288,9 +1288,9 @@ static const struct ds5_format ds5_depth_formats_d58x[] = {
 	},
 };
 
-#define DS5_DEPTH_N_FORMATS 1
+#define D5X_DEPTH_N_FORMATS 1
 
-static const struct ds5_format ds5_y_formats_d58x[] = {
+static const struct d5x_format d5x_y_formats_d58x[] = {
 	{
 		/* First format: default */
 		.data_type = GMSL_CSI_DT_RAW_8,	/* Y8 */
@@ -1310,42 +1310,42 @@ static const struct ds5_format ds5_y_formats_d58x[] = {
 	},
 };
 
-static const struct ds5_format ds5_d58x_rgb_format = {
+static const struct d5x_format d5x_d58x_rgb_format = {
 	.data_type = GMSL_CSI_DT_YUV422_8,	/* UYVY */
 	.mbus_code = MEDIA_BUS_FMT_YUYV8_1X16,
 	.n_resolutions = ARRAY_SIZE(d58x_rgb_sizes),
 	.resolutions = d58x_rgb_sizes,
 };
-#define DS5_D58X_RGB_N_FORMATS 1
+#define D5X_D58X_RGB_N_FORMATS 1
 
-static const struct ds5_variant ds5_variants[] = {
-	[DS5_DS5U] = {
-		.formats = ds5_y_formats_d58x,
-		.n_formats = ARRAY_SIZE(ds5_y_formats_d58x),
+static const struct d5x_variant d5x_variants[] = {
+	[D5X_DS5U] = {
+		.formats = d5x_y_formats_d58x,
+		.n_formats = ARRAY_SIZE(d5x_y_formats_d58x),
 	},
 };
 
-static const struct ds5_format ds5_imu_formats[] = {
+static const struct d5x_format d5x_imu_formats[] = {
 	{
 		/* First format: default */
 		.data_type = GMSL_CSI_DT_RAW_8,	/* IMU DT */
 		.mbus_code = MEDIA_BUS_FMT_Y8_1X8,
-		.n_resolutions = ARRAY_SIZE(ds5_size_imu),
-		.resolutions = ds5_size_imu,
+		.n_resolutions = ARRAY_SIZE(d5x_size_imu),
+		.resolutions = d5x_size_imu,
 	},
 };
 
-static const struct ds5_format ds5_imu_formats_extended[] = {
+static const struct d5x_format d5x_imu_formats_extended[] = {
 	{
 		/* First format: default */
 		.data_type = GMSL_CSI_DT_RAW_8,	/* IMU DT */
 		.mbus_code = MEDIA_BUS_FMT_Y8_1X8,
-		.n_resolutions = ARRAY_SIZE(ds5_size_imu_extended),
-		.resolutions = ds5_size_imu_extended,
+		.n_resolutions = ARRAY_SIZE(d5x_size_imu_extended),
+		.resolutions = d5x_size_imu_extended,
 	},
 };
 
-static const struct v4l2_mbus_framefmt ds5_mbus_framefmt_template = {
+static const struct v4l2_mbus_framefmt d5x_mbus_framefmt_template = {
 	.width = 0,
 	.height = 0,
 	.code = MEDIA_BUS_FMT_FIXED,
@@ -1357,7 +1357,7 @@ static const struct v4l2_mbus_framefmt ds5_mbus_framefmt_template = {
 };
 
 /* Get readable sensor name */
-static const char *ds5_get_sensor_name(struct ds5 *state)
+static const char *d5x_get_sensor_name(struct d5x *state)
 {
 	static const char *sensor_name[] = {"unknown", "RGB", "DEPTH", "Y8", "IMU"};
 	int sensor_id = state->is_rgb * 1 + state->is_depth * 2 + \
@@ -1368,10 +1368,10 @@ static const char *ds5_get_sensor_name(struct ds5 *state)
 	return sensor_name[sensor_id];
 }
 
-static void ds5_set_state_last_set(struct ds5 *state)
+static void d5x_set_state_last_set(struct d5x *state)
 {
 	 dev_dbg(&state->client->dev, "%s(): %s\n",
-		__func__, ds5_get_sensor_name(state));
+		__func__, d5x_get_sensor_name(state));
 
 	if (state->is_depth)
 		state->mux.last_set = &state->depth.sensor;
@@ -1383,9 +1383,9 @@ static void ds5_set_state_last_set(struct ds5 *state)
 		state->mux.last_set = &state->imu.sensor;
 }
 
-static void ds5_sensor_format_init(struct ds5_sensor *sensor)
+static void d5x_sensor_format_init(struct d5x_sensor *sensor)
 {
-	const struct ds5_format *fmt;
+	const struct d5x_format *fmt;
 	struct v4l2_mbus_framefmt *ffmt;
 	unsigned int i;
 
@@ -1395,7 +1395,7 @@ static void ds5_sensor_format_init(struct ds5_sensor *sensor)
 	dev_dbg(sensor->sd.dev, "%s(): on pad %u\n", __func__, sensor->mux_pad);
 
 	ffmt = &sensor->format;
-	*ffmt = ds5_mbus_framefmt_template;
+	*ffmt = d5x_mbus_framefmt_template;
 	/* Use the first format */
 	fmt = sensor->formats;
 	ffmt->code = fmt->mbus_code;
@@ -1407,8 +1407,8 @@ static void ds5_sensor_format_init(struct ds5_sensor *sensor)
 	sensor->config.resolution = fmt->resolutions;
 	/* Set default framerate to 30, or to 1st one if not supported */
 	for (i = 0; i < fmt->resolutions->n_framerates; i++) {
-		if (fmt->resolutions->framerates[i] == ds5_framerate_30 /* fps */) {
-			sensor->config.framerate = ds5_framerate_30;
+		if (fmt->resolutions->framerates[i] == d5x_framerate_30 /* fps */) {
+			sensor->config.framerate = d5x_framerate_30;
 			return;
 		}
 	}
@@ -1416,7 +1416,7 @@ static void ds5_sensor_format_init(struct ds5_sensor *sensor)
 }
 
 /* No locking needed for enumeration methods */
-static int ds5_sensor_enum_mbus_code(struct v4l2_subdev *sd,
+static int d5x_sensor_enum_mbus_code(struct v4l2_subdev *sd,
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
 				     struct v4l2_subdev_pad_config *cfg,
 #else
@@ -1424,7 +1424,7 @@ static int ds5_sensor_enum_mbus_code(struct v4l2_subdev *sd,
 #endif
 				     struct v4l2_subdev_mbus_code_enum *mce)
 {
-	struct ds5_sensor *sensor = container_of(sd, struct ds5_sensor, sd);
+	struct d5x_sensor *sensor = container_of(sd, struct d5x_sensor, sd);
 
 	dev_dbg(sensor->sd.dev, "%s(): sensor %s pad: %d index: %d\n",
 		__func__, sensor->sd.name, mce->pad, mce->index);
@@ -1439,7 +1439,7 @@ static int ds5_sensor_enum_mbus_code(struct v4l2_subdev *sd,
 	return 0;
 }
 
-static int ds5_sensor_enum_frame_size(struct v4l2_subdev *sd,
+static int d5x_sensor_enum_frame_size(struct v4l2_subdev *sd,
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
 		struct v4l2_subdev_pad_config *cfg,
 #else
@@ -1447,13 +1447,13 @@ static int ds5_sensor_enum_frame_size(struct v4l2_subdev *sd,
 #endif
 		struct v4l2_subdev_frame_size_enum *fse)
 {
-	struct ds5_sensor *sensor = container_of(sd, struct ds5_sensor, sd);
-	struct ds5 *state = v4l2_get_subdevdata(sd);
-	const struct ds5_format *fmt;
+	struct d5x_sensor *sensor = container_of(sd, struct d5x_sensor, sd);
+	struct d5x *state = v4l2_get_subdevdata(sd);
+	const struct d5x_format *fmt;
 	unsigned int i;
 
 	dev_dbg(sensor->sd.dev, "%s(): sensor %s is %s\n",
-		__func__, sensor->sd.name, ds5_get_sensor_name(state));
+		__func__, sensor->sd.name, d5x_get_sensor_name(state));
 
 	for (i = 0, fmt = sensor->formats; i < sensor->n_formats; i++, fmt++)
 		if (fse->code == fmt->mbus_code)
@@ -1471,7 +1471,7 @@ static int ds5_sensor_enum_frame_size(struct v4l2_subdev *sd,
 	return 0;
 }
 
-static int ds5_sensor_enum_frame_interval(struct v4l2_subdev *sd,
+static int d5x_sensor_enum_frame_interval(struct v4l2_subdev *sd,
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
 		struct v4l2_subdev_pad_config *cfg,
 #else
@@ -1479,9 +1479,9 @@ static int ds5_sensor_enum_frame_interval(struct v4l2_subdev *sd,
 #endif
 		struct v4l2_subdev_frame_interval_enum *fie)
 {
-	struct ds5_sensor *sensor = container_of(sd, struct ds5_sensor, sd);
-	const struct ds5_format *fmt;
-	const struct ds5_resolution *res;
+	struct d5x_sensor *sensor = container_of(sd, struct d5x_sensor, sd);
+	const struct d5x_format *fmt;
+	const struct d5x_resolution *res;
 	unsigned int i;
 
 	for (i = 0, fmt = sensor->formats; i < sensor->n_formats; i++, fmt++)
@@ -1507,7 +1507,7 @@ static int ds5_sensor_enum_frame_interval(struct v4l2_subdev *sd,
 	return 0;
 }
 
-static int ds5_sensor_get_fmt(struct v4l2_subdev *sd,
+static int d5x_sensor_get_fmt(struct v4l2_subdev *sd,
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
 		struct v4l2_subdev_pad_config *cfg,
 #else
@@ -1515,8 +1515,8 @@ static int ds5_sensor_get_fmt(struct v4l2_subdev *sd,
 #endif
 		struct v4l2_subdev_format *fmt)
 {
-	struct ds5_sensor *sensor = container_of(sd, struct ds5_sensor, sd);
-	struct ds5 *state = v4l2_get_subdevdata(sd);
+	struct d5x_sensor *sensor = container_of(sd, struct d5x_sensor, sd);
+	struct d5x *state = v4l2_get_subdevdata(sd);
 	int ret = 0;
 
 	if (fmt->pad)
@@ -1552,13 +1552,13 @@ static int ds5_sensor_get_fmt(struct v4l2_subdev *sd,
 }
 
 /* Called with lock held */
-static const struct ds5_format *ds5_sensor_find_format(
-		struct ds5_sensor *sensor,
+static const struct d5x_format *d5x_sensor_find_format(
+		struct d5x_sensor *sensor,
 		struct v4l2_mbus_framefmt *ffmt,
-		const struct ds5_resolution **best)
+		const struct d5x_resolution **best)
 {
-	const struct ds5_resolution *res;
-	const struct ds5_format *fmt;
+	const struct d5x_resolution *res;
+	const struct d5x_format *fmt;
 	unsigned long best_delta = ~0;
 	unsigned int i;
 
@@ -1610,7 +1610,7 @@ static const struct ds5_format *ds5_sensor_find_format(
 /* 1-8 */
 #define MIPI_CSI2_TYPE_USER_DEF(i)	(0x30 + (i) - 1)
 
-static int __ds5_sensor_set_fmt(struct ds5 *state, struct ds5_sensor *sensor,
+static int __d5x_sensor_set_fmt(struct d5x *state, struct d5x_sensor *sensor,
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
 		struct v4l2_subdev_pad_config *cfg,
 #else
@@ -1633,7 +1633,7 @@ static int __ds5_sensor_set_fmt(struct ds5 *state, struct ds5_sensor *sensor,
 
 	mutex_lock(&state->lock);
 
-	sensor->config.format = ds5_sensor_find_format(sensor, mf,
+	sensor->config.format = d5x_sensor_find_format(sensor, mf,
 						&sensor->config.resolution);
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
@@ -1677,7 +1677,7 @@ static int __ds5_sensor_set_fmt(struct ds5 *state, struct ds5_sensor *sensor,
 	return ret;
 }
 
-static int ds5_sensor_set_fmt(struct v4l2_subdev *sd,
+static int d5x_sensor_set_fmt(struct v4l2_subdev *sd,
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
 		struct v4l2_subdev_pad_config *cfg,
 #else
@@ -1685,17 +1685,17 @@ static int ds5_sensor_set_fmt(struct v4l2_subdev *sd,
 #endif
 		struct v4l2_subdev_format *fmt)
 {
-	struct ds5_sensor *sensor = container_of(sd, struct ds5_sensor, sd);
-	struct ds5 *state = v4l2_get_subdevdata(sd);
+	struct d5x_sensor *sensor = container_of(sd, struct d5x_sensor, sd);
+	struct d5x *state = v4l2_get_subdevdata(sd);
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
-	return __ds5_sensor_set_fmt(state, sensor, cfg, fmt);
+	return __d5x_sensor_set_fmt(state, sensor, cfg, fmt);
 #else
-	return __ds5_sensor_set_fmt(state, sensor, v4l2_state, fmt);
+	return __d5x_sensor_set_fmt(state, sensor, v4l2_state, fmt);
 #endif
 }
 
 #ifdef CONFIG_VIDEO_D5XX_SERDES
-static int ds5_setup_pipeline(struct ds5 *state, u8 data_type1, u8 data_type2,
+static int d5x_setup_pipeline(struct d5x *state, u8 data_type1, u8 data_type2,
 			      int pipe_id, u32 vc_id)
 {
 	int ret = 0;
@@ -1705,13 +1705,13 @@ static int ds5_setup_pipeline(struct ds5 *state, u8 data_type1, u8 data_type2,
 	 * to a deserializer will have its vc_id 0 - 3 mapped to outside vc_id 4 - 7 etc.
 	 * The ser_pipe to dser_pipe mapping depends on the deserializer.
 	 */
-	int ser_vc_id = vc_id % DS5_MAX_STREAMS;
+	int ser_vc_id = vc_id % D5X_MAX_STREAMS;
 	int ser_pipe_id = state->dser_ops->get_ser_pipe_id(state->dser_dev, pipe_id, ser_vc_id);
 	int active_pipes = (state->dser_ops->get_active_pipe_count != NULL) ?
 		state->dser_ops->get_active_pipe_count(state->dser_dev) : 1;
 	int link_locked = (state->dser_ops->get_link_locked != NULL) ?
 		state->dser_ops->get_link_locked(state->dser_dev) : -1;
-	bool datapath_armed = ds5_dser_datapath_armed(state);
+	bool datapath_armed = d5x_dser_datapath_armed(state);
 
 	if (link_locked > 0 && !datapath_armed && active_pipes <= 1)
 		dev_info(&state->client->dev,
@@ -1726,7 +1726,7 @@ static int ds5_setup_pipeline(struct ds5 *state, u8 data_type1, u8 data_type2,
 	ret |= state->dser_ops->set_pipe(state->dser_dev, pipe_id,
 				data_type1, data_type2, vc_id);
 	if (ret >= 0 && link_locked > 0 && datapath_armed) {
-		unsigned int started_streams = ds5_started_mipi_streams(state);
+		unsigned int started_streams = d5x_started_mipi_streams(state);
 
 		dev_info(&state->client->dev,
 			 "pipe %d mapping updated while DES datapath armed (%u streams active); keeping datapath armed\n",
@@ -1745,11 +1745,11 @@ static int ds5_setup_pipeline(struct ds5 *state, u8 data_type1, u8 data_type2,
 			 link_locked > 0 ? "locked" :
 			 (link_locked == 0 ? "unlocked" : "unknown"),
 			 active_pipes);
-		reset_performed = ds5_rearm_dser_datapath_before_start(state,
+		reset_performed = d5x_rearm_dser_datapath_before_start(state,
 									 pipe_id, active_pipes,
 									 link_locked,
 									 "first active pipe");
-		ds5_finish_dser_prestart(state, reset_performed);
+		d5x_finish_dser_prestart(state, reset_performed);
 	} else {
 		dev_info(&state->client->dev,
 			 "pipe %d mapping updated w/o link reset (%d pipes active, link %s)\n",
@@ -1766,7 +1766,7 @@ static int ds5_setup_pipeline(struct ds5 *state, u8 data_type1, u8 data_type2,
 }
 #endif
 
-static void ds5_config_cache_clear(struct ds5_sensor *sensor)
+static void d5x_config_cache_clear(struct d5x_sensor *sensor)
 {
 	sensor->cached_dt_value = 0xFFFF;
 	sensor->cached_md_value = 0xFFFF;
@@ -1776,14 +1776,14 @@ static void ds5_config_cache_clear(struct ds5_sensor *sensor)
 	sensor->cached_height_value = 0xFFFF;
 }
 
-static void ds5_invalidate_sensor(struct ds5 *state, struct ds5_sensor *sensor)
+static void d5x_invalidate_sensor(struct d5x *state, struct d5x_sensor *sensor)
 {
-	ds5_config_cache_clear(sensor);
+	d5x_config_cache_clear(sensor);
 	/* 
 	 * Do NOT release SERDES pipes or clear pipe_id here.
-	 * Preserve the existing pipe_id so that ds5_configure() can
+	 * Preserve the existing pipe_id so that d5x_configure() can
 	 * release-then-reallocate the pipe at stream-start time.
-	 * Clearing pipe_data_type forces ds5_configure() to enter the
+	 * Clearing pipe_data_type forces d5x_configure() to enter the
 	 * re-allocation path (data_type mismatch triggers pipe setup).
 	 */
 	sensor->pipe_data_type1 = 0;
@@ -1792,16 +1792,16 @@ static void ds5_invalidate_sensor(struct ds5 *state, struct ds5_sensor *sensor)
 	sensor->pipe_reapply_gen = 0;
 }
 
-static int ds5_configure(struct ds5 *state)
+static int d5x_configure(struct d5x *state)
 {
-	struct ds5_sensor *sensor;
+	struct d5x_sensor *sensor;
 	u16 md_fmt, vc_id;
 #ifdef CONFIG_VIDEO_D5XX_SERDES
 	u16 data_type1, data_type2;
 	bool is_calib = 0;
 	unsigned int pipe_reapply_gen;
 #endif
-#if !DS5_BYPASS_CAMERA_I2C
+#if !D5X_BYPASS_CAMERA_I2C
 	u16 dt_addr, md_addr, override_addr, fps_addr, width_addr, height_addr;
 	u16 dt_value = 0;
 	u16 md_value = 0;
@@ -1813,43 +1813,43 @@ static int ds5_configure(struct ds5 *state)
 
 	if (state->is_depth) {
 		sensor = &state->depth.sensor;
-#if !DS5_BYPASS_CAMERA_I2C
-		dt_addr = DS5_DEPTH_STREAM_DT;
-		md_addr = DS5_DEPTH_STREAM_MD;
-		override_addr = DS5_DEPTH_OVERRIDE;
-		fps_addr = DS5_DEPTH_FPS;
-		width_addr = DS5_DEPTH_RES_WIDTH;
-		height_addr = DS5_DEPTH_RES_HEIGHT;
+#if !D5X_BYPASS_CAMERA_I2C
+		dt_addr = D5X_DEPTH_STREAM_DT;
+		md_addr = D5X_DEPTH_STREAM_MD;
+		override_addr = D5X_DEPTH_OVERRIDE;
+		fps_addr = D5X_DEPTH_FPS;
+		width_addr = D5X_DEPTH_RES_WIDTH;
+		height_addr = D5X_DEPTH_RES_HEIGHT;
 #endif
 	} else if (state->is_rgb) {
 		sensor = &state->rgb.sensor;
-#if !DS5_BYPASS_CAMERA_I2C
-		dt_addr = DS5_RGB_STREAM_DT;
-		md_addr = DS5_RGB_STREAM_MD;
+#if !D5X_BYPASS_CAMERA_I2C
+		dt_addr = D5X_RGB_STREAM_DT;
+		md_addr = D5X_RGB_STREAM_MD;
 		override_addr = 0;
-		fps_addr = DS5_RGB_FPS;
-		width_addr = DS5_RGB_RES_WIDTH;
-		height_addr = DS5_RGB_RES_HEIGHT;
+		fps_addr = D5X_RGB_FPS;
+		width_addr = D5X_RGB_RES_WIDTH;
+		height_addr = D5X_RGB_RES_HEIGHT;
 #endif
 	} else if (state->is_y8) {
 		sensor = &state->ir.sensor;
-#if !DS5_BYPASS_CAMERA_I2C
-		dt_addr = DS5_IR_STREAM_DT;
-		md_addr = DS5_IR_STREAM_MD;
-		override_addr = DS5_IR_OVERRIDE;
-		fps_addr = DS5_IR_FPS;
-		width_addr = DS5_IR_RES_WIDTH;
-		height_addr = DS5_IR_RES_HEIGHT;
+#if !D5X_BYPASS_CAMERA_I2C
+		dt_addr = D5X_IR_STREAM_DT;
+		md_addr = D5X_IR_STREAM_MD;
+		override_addr = D5X_IR_OVERRIDE;
+		fps_addr = D5X_IR_FPS;
+		width_addr = D5X_IR_RES_WIDTH;
+		height_addr = D5X_IR_RES_HEIGHT;
 #endif
 	} else if (state->is_imu) {
 		sensor = &state->imu.sensor;
-#if !DS5_BYPASS_CAMERA_I2C
-		dt_addr = DS5_IMU_STREAM_DT;
-		md_addr = DS5_IMU_STREAM_MD;
+#if !D5X_BYPASS_CAMERA_I2C
+		dt_addr = D5X_IMU_STREAM_DT;
+		md_addr = D5X_IMU_STREAM_MD;
 		override_addr = 0;
-		fps_addr = DS5_IMU_FPS;
-		width_addr = DS5_IMU_RES_WIDTH;
-		height_addr = DS5_IMU_RES_HEIGHT;
+		fps_addr = D5X_IMU_FPS;
+		width_addr = D5X_IMU_RES_WIDTH;
+		height_addr = D5X_IMU_RES_HEIGHT;
 #endif
 	} else {
 		return -EINVAL;
@@ -1864,8 +1864,8 @@ static int ds5_configure(struct ds5 *state)
 
 	vc_id = state->g_ctx.dst_vc;
 	dev_info(&state->client->dev,
-		"ds5_configure: sensor=%s dt1=0x%x dt2=0x%x vc=%u pipe_id=%d\n",
-		ds5_get_sensor_name(state), data_type1, data_type2, vc_id, sensor->pipe_id);
+		"d5x_configure: sensor=%s dt1=0x%x dt2=0x%x vc=%u pipe_id=%d\n",
+		d5x_get_sensor_name(state), data_type1, data_type2, vc_id, sensor->pipe_id);
     if (PIPE_NOT_CONFIGURED == sensor->pipe_id ||
 			sensor->pipe_data_type1 != data_type1 ||
 			sensor->pipe_data_type2 != data_type2 ||
@@ -1874,7 +1874,7 @@ static int ds5_configure(struct ds5 *state)
 			mutex_lock(&serdes_lock__);
 			ret = state->dser_ops->release_pipe(state->dser_dev, sensor->pipe_id);
 			if (ret >= 0)
-				ds5_disarm_dser_datapath_if_idle(state);
+				d5x_disarm_dser_datapath_if_idle(state);
 			mutex_unlock(&serdes_lock__);
 			dev_warn(&state->client->dev, "release pipe %d (%d)\n", sensor->pipe_id, ret);
 			sensor->pipe_reapply_gen = 0;
@@ -1894,10 +1894,10 @@ static int ds5_configure(struct ds5 *state)
 			dev_err(&state->client->dev, "No free pipe in %s\n",state->dser_ops->name);
 			return -ENOSR;
 		}
-		pipe_reapply_gen = ds5_dser_rearm_gen(state);
+		pipe_reapply_gen = d5x_dser_rearm_gen(state);
 		sensor->pipe_reapply_gen = pipe_reapply_gen;
 		mutex_lock(&serdes_lock__);
-		ret = ds5_setup_pipeline(state, data_type1, data_type2,
+		ret = d5x_setup_pipeline(state, data_type1, data_type2,
 					 sensor->pipe_id, vc_id);
 		/* reset data path when switching to Y12I */
 		if (is_calib)
@@ -1921,10 +1921,10 @@ static int ds5_configure(struct ds5 *state)
 				sensor->pipe_id, data_type1, data_type2, vc_id);
 	}
 
-	pipe_reapply_gen = ds5_dser_rearm_gen(state);
+	pipe_reapply_gen = d5x_dser_rearm_gen(state);
 	if (sensor->pipe_reapply_gen != pipe_reapply_gen) {
 		mutex_lock(&serdes_lock__);
-		ret = ds5_setup_pipeline(state, data_type1, data_type2,
+		ret = d5x_setup_pipeline(state, data_type1, data_type2,
 					 sensor->pipe_id, vc_id);
 		mutex_unlock(&serdes_lock__);
 		if (ret < 0) {
@@ -1948,7 +1948,7 @@ static int ds5_configure(struct ds5 *state)
 	vc_id = (state->is_depth) ? 0 : (state->is_rgb) ? 1 : (state->is_y8) ? 2 : 3;
 #endif
 
-#if DS5_BYPASS_CAMERA_I2C
+#if D5X_BYPASS_CAMERA_I2C
 	/* Skip camera I2C config writes - camera is already streaming */
 	return 0;
 #else
@@ -1967,7 +1967,7 @@ static int ds5_configure(struct ds5 *state)
 		sensor, dt_value, sensor->cached_dt_value, sensor->cached_fps_value, sensor->config.framerate);
 
 	if (sensor->cached_dt_value != dt_value) {
-		ret = ds5_write(state, dt_addr, dt_value);
+		ret = d5x_write(state, dt_addr, dt_value);
 		if (ret < 0)
 			return ret;
 		sensor->cached_dt_value = dt_value;
@@ -1975,7 +1975,7 @@ static int ds5_configure(struct ds5 *state)
 
 	md_value = (vc_id << 8) | md_fmt;
 	if (sensor->cached_md_value != md_value) {
-		ret = ds5_write(state, md_addr, md_value);
+		ret = d5x_write(state, md_addr, md_value);
 		if (ret < 0)
 			return ret;
 		sensor->cached_md_value = md_value;
@@ -1984,7 +1984,7 @@ static int ds5_configure(struct ds5 *state)
 	if (override_addr != 0) {
 		dt_value = sensor->config.format->data_type;
 		if (sensor->cached_override_value != dt_value) {
-			ret = ds5_write(state, override_addr, dt_value);
+			ret = d5x_write(state, override_addr, dt_value);
 			if (ret < 0)
 				return ret;
 			sensor->cached_override_value = dt_value;
@@ -1993,7 +1993,7 @@ static int ds5_configure(struct ds5 *state)
 
 	fps_value = sensor->config.framerate;
 	if (sensor->cached_fps_value != fps_value) {
-		ret = ds5_write(state, fps_addr, fps_value);
+		ret = d5x_write(state, fps_addr, fps_value);
 		if (ret < 0)
 			return ret;
 		sensor->cached_fps_value = fps_value;
@@ -2001,7 +2001,7 @@ static int ds5_configure(struct ds5 *state)
 
 	width_value = sensor->config.resolution->width;
 	if (sensor->cached_width_value != width_value) {
-		ret = ds5_write(state, width_addr, width_value);
+		ret = d5x_write(state, width_addr, width_value);
 		if (ret < 0)
 			return ret;
 		sensor->cached_width_value = width_value;
@@ -2009,23 +2009,23 @@ static int ds5_configure(struct ds5 *state)
 
 	height_value = sensor->config.resolution->height;
 	if (sensor->cached_height_value != height_value) {
-		ret = ds5_write(state, height_addr, height_value);
+		ret = d5x_write(state, height_addr, height_value);
 		if (ret < 0)
 			return ret;
 		sensor->cached_height_value = height_value;
 	}
 
 	return 0;
-#endif /* !DS5_BYPASS_CAMERA_I2C */
+#endif /* !D5X_BYPASS_CAMERA_I2C */
 }
 
-static int ds5_sensor_g_frame_interval(struct v4l2_subdev *sd,
+static int d5x_sensor_g_frame_interval(struct v4l2_subdev *sd,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
 		struct v4l2_subdev_state *state,
 #endif
 		struct v4l2_subdev_frame_interval *fi)
 {
-	struct ds5_sensor *sensor = container_of(sd, struct ds5_sensor, sd);
+	struct d5x_sensor *sensor = container_of(sd, struct d5x_sensor, sd);
 
 	if (NULL == sd || NULL == fi)
 		return -EINVAL;
@@ -2038,22 +2038,22 @@ static int ds5_sensor_g_frame_interval(struct v4l2_subdev *sd,
 
 	return 0;
 }
-static u16 __ds5_probe_framerate(const struct ds5_resolution *res, u16 target);
+static u16 __d5x_probe_framerate(const struct d5x_resolution *res, u16 target);
 
-static int ds5_sensor_s_frame_interval(struct v4l2_subdev *sd,
+static int d5x_sensor_s_frame_interval(struct v4l2_subdev *sd,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
 		struct v4l2_subdev_state *state,
 #endif
 		struct v4l2_subdev_frame_interval *fi)
 {
-	struct ds5_sensor *sensor = container_of(sd, struct ds5_sensor, sd);
+	struct d5x_sensor *sensor = container_of(sd, struct d5x_sensor, sd);
 	u16 framerate = 1;
 
 	if (NULL == sd || NULL == fi || fi->interval.numerator == 0)
 		return -EINVAL;
 
 	framerate = fi->interval.denominator / fi->interval.numerator;
-	framerate = __ds5_probe_framerate(sensor->config.resolution, framerate);
+	framerate = __d5x_probe_framerate(sensor->config.resolution, framerate);
 	sensor->config.framerate = framerate;
 	fi->interval.numerator = 1;
 	fi->interval.denominator = framerate;
@@ -2063,9 +2063,9 @@ static int ds5_sensor_s_frame_interval(struct v4l2_subdev *sd,
 	return 0;
 }
 
-static int ds5_sensor_s_stream(struct v4l2_subdev *sd, int on)
+static int d5x_sensor_s_stream(struct v4l2_subdev *sd, int on)
 {
-	struct ds5_sensor *sensor = container_of(sd, struct ds5_sensor, sd);
+	struct d5x_sensor *sensor = container_of(sd, struct d5x_sensor, sd);
 
 	dev_dbg(sensor->sd.dev, "%s(): sensor: name=%s state=%d\n",
 		__func__, sensor->sd.name, on);
@@ -2075,34 +2075,34 @@ static int ds5_sensor_s_stream(struct v4l2_subdev *sd, int on)
 	return 0;
 }
 
-static const struct v4l2_subdev_video_ops ds5_sensor_video_ops = {
+static const struct v4l2_subdev_video_ops d5x_sensor_video_ops = {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
-	.g_frame_interval	= ds5_sensor_g_frame_interval,
-	.s_frame_interval	= ds5_sensor_s_frame_interval,
+	.g_frame_interval	= d5x_sensor_g_frame_interval,
+	.s_frame_interval	= d5x_sensor_s_frame_interval,
 #endif
-	.s_stream		= ds5_sensor_s_stream,
+	.s_stream		= d5x_sensor_s_stream,
 };
 
-static const struct v4l2_subdev_pad_ops ds5_pad_ops = {
+static const struct v4l2_subdev_pad_ops d5x_pad_ops = {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
-	.get_frame_interval	= ds5_sensor_g_frame_interval,
-	.set_frame_interval	= ds5_sensor_s_frame_interval,
+	.get_frame_interval	= d5x_sensor_g_frame_interval,
+	.set_frame_interval	= d5x_sensor_s_frame_interval,
 #endif
-	.enum_mbus_code		= ds5_sensor_enum_mbus_code,
-	.enum_frame_size	= ds5_sensor_enum_frame_size,
-	.enum_frame_interval	= ds5_sensor_enum_frame_interval,
-	.get_fmt		= ds5_sensor_get_fmt,
-	.set_fmt		= ds5_sensor_set_fmt,
+	.enum_mbus_code		= d5x_sensor_enum_mbus_code,
+	.enum_frame_size	= d5x_sensor_enum_frame_size,
+	.enum_frame_interval	= d5x_sensor_enum_frame_interval,
+	.get_fmt		= d5x_sensor_get_fmt,
+	.set_fmt		= d5x_sensor_set_fmt,
 };
 
-static const struct v4l2_subdev_ops ds5_subdev_ops = {
-	.pad = &ds5_pad_ops,
-	.video = &ds5_sensor_video_ops,
+static const struct v4l2_subdev_ops d5x_subdev_ops = {
+	.pad = &d5x_pad_ops,
+	.video = &d5x_sensor_video_ops,
 };
 
 /* InfraRed stream Y8/Y16 */
 
-static int ds5_hw_set_auto_exposure(struct ds5 *state, u32 base, s32 val)
+static int d5x_hw_set_auto_exposure(struct d5x *state, u32 base, s32 val)
 {
 	if (val != V4L2_EXPOSURE_APERTURE_PRIORITY &&
 		val != V4L2_EXPOSURE_MANUAL)
@@ -2125,7 +2125,7 @@ static int ds5_hw_set_auto_exposure(struct ds5 *state, u32 base, s32 val)
 			val = 0;
 	}
 
-	return ds5_write(state, base | DS5_AUTO_EXPOSURE_MODE, (u16)val);
+	return d5x_write(state, base | D5X_AUTO_EXPOSURE_MODE, (u16)val);
 }
 
 /*
@@ -2133,7 +2133,7 @@ static int ds5_hw_set_auto_exposure(struct ds5 *state, u32 base, s32 val)
  * Depth/Y8: between 100 and 200000 (200ms)
  * Color: between 100 and 1000000 (1s)
  */
-static int ds5_hw_set_exposure(struct ds5 *state, u32 base, s32 val)
+static int d5x_hw_set_exposure(struct d5x *state, u32 base, s32 val)
 {
 	int ret = -1;
 
@@ -2150,123 +2150,123 @@ static int ds5_hw_set_exposure(struct ds5 *state, u32 base, s32 val)
 	 *	Depth: 1 is 1 us
 	 */
 
-	ret = ds5_write(state, base | DS5_MANUAL_EXPOSURE_MSB, (u16)(val >> 16));
+	ret = d5x_write(state, base | D5X_MANUAL_EXPOSURE_MSB, (u16)(val >> 16));
 	if (!ret)
-		ret = ds5_write(state, base | DS5_MANUAL_EXPOSURE_LSB,
+		ret = d5x_write(state, base | D5X_MANUAL_EXPOSURE_LSB,
 				(u16)(val & 0xffff));
 
 	return ret;
 }
 
-#define DS5_MAX_LOG_WAIT 200
-#define DS5_MAX_LOG_SLEEP 10
-#define DS5_MAX_LOG_POLL (DS5_MAX_LOG_WAIT / DS5_MAX_LOG_SLEEP)
+#define D5X_MAX_LOG_WAIT 200
+#define D5X_MAX_LOG_SLEEP 10
+#define D5X_MAX_LOG_POLL (D5X_MAX_LOG_WAIT / D5X_MAX_LOG_SLEEP)
 
-#define DS5_CAMERA_CID_BASE	(V4L2_CTRL_CLASS_CAMERA | DS5_DEPTH_STREAM_DT)
+#define D5X_CAMERA_CID_BASE	(V4L2_CTRL_CLASS_CAMERA | D5X_DEPTH_STREAM_DT)
 
-#define DS5_CAMERA_CID_LOG			(DS5_CAMERA_CID_BASE+0)
-#define DS5_CAMERA_CID_LASER_POWER		(DS5_CAMERA_CID_BASE+1)
-#define DS5_CAMERA_CID_MANUAL_LASER_POWER	(DS5_CAMERA_CID_BASE+2)
-#define DS5_CAMERA_DEPTH_CALIBRATION_TABLE_GET	(DS5_CAMERA_CID_BASE+3)
-#define DS5_CAMERA_DEPTH_CALIBRATION_TABLE_SET	(DS5_CAMERA_CID_BASE+4)
-#define DS5_CAMERA_COEFF_CALIBRATION_TABLE_GET	(DS5_CAMERA_CID_BASE+5)
-#define DS5_CAMERA_COEFF_CALIBRATION_TABLE_SET	(DS5_CAMERA_CID_BASE+6)
-#define DS5_CAMERA_CID_FW_VERSION		(DS5_CAMERA_CID_BASE+7)
-#define DS5_CAMERA_CID_GVD			(DS5_CAMERA_CID_BASE+8)
-#define DS5_CAMERA_CID_DEVICE_TYPE		(DS5_CAMERA_CID_BASE+23)
-#define DS5_CAMERA_CID_AE_ROI_GET		(DS5_CAMERA_CID_BASE+9)
-#define DS5_CAMERA_CID_AE_ROI_SET		(DS5_CAMERA_CID_BASE+10)
-#define DS5_CAMERA_CID_AE_SETPOINT_GET		(DS5_CAMERA_CID_BASE+11)
-#define DS5_CAMERA_CID_AE_SETPOINT_SET		(DS5_CAMERA_CID_BASE+12)
-#define DS5_CAMERA_CID_ERB			(DS5_CAMERA_CID_BASE+13)
-#define DS5_CAMERA_CID_EWB			(DS5_CAMERA_CID_BASE+14)
-#define DS5_CAMERA_CID_HWMC			(DS5_CAMERA_CID_BASE+15)
-#define DS5_CAMERA_CID_SYNC_MODE		(DS5_CAMERA_CID_BASE+16)
+#define D5X_CAMERA_CID_LOG			(D5X_CAMERA_CID_BASE+0)
+#define D5X_CAMERA_CID_LASER_POWER		(D5X_CAMERA_CID_BASE+1)
+#define D5X_CAMERA_CID_MANUAL_LASER_POWER	(D5X_CAMERA_CID_BASE+2)
+#define D5X_CAMERA_DEPTH_CALIBRATION_TABLE_GET	(D5X_CAMERA_CID_BASE+3)
+#define D5X_CAMERA_DEPTH_CALIBRATION_TABLE_SET	(D5X_CAMERA_CID_BASE+4)
+#define D5X_CAMERA_COEFF_CALIBRATION_TABLE_GET	(D5X_CAMERA_CID_BASE+5)
+#define D5X_CAMERA_COEFF_CALIBRATION_TABLE_SET	(D5X_CAMERA_CID_BASE+6)
+#define D5X_CAMERA_CID_FW_VERSION		(D5X_CAMERA_CID_BASE+7)
+#define D5X_CAMERA_CID_GVD			(D5X_CAMERA_CID_BASE+8)
+#define D5X_CAMERA_CID_DEVICE_TYPE		(D5X_CAMERA_CID_BASE+23)
+#define D5X_CAMERA_CID_AE_ROI_GET		(D5X_CAMERA_CID_BASE+9)
+#define D5X_CAMERA_CID_AE_ROI_SET		(D5X_CAMERA_CID_BASE+10)
+#define D5X_CAMERA_CID_AE_SETPOINT_GET		(D5X_CAMERA_CID_BASE+11)
+#define D5X_CAMERA_CID_AE_SETPOINT_SET		(D5X_CAMERA_CID_BASE+12)
+#define D5X_CAMERA_CID_ERB			(D5X_CAMERA_CID_BASE+13)
+#define D5X_CAMERA_CID_EWB			(D5X_CAMERA_CID_BASE+14)
+#define D5X_CAMERA_CID_HWMC			(D5X_CAMERA_CID_BASE+15)
+#define D5X_CAMERA_CID_SYNC_MODE		(D5X_CAMERA_CID_BASE+16)
 
 /* Sync mode values — indices into sync_mode_menu_full[] */
-enum ds5_sync_mode {
-	DS5_SYNC_MODE_DEFAULT,
-	DS5_SYNC_MODE_MASTER,
-	DS5_SYNC_MODE_SLAVE,
-	DS5_SYNC_MODE_FULL_SLAVE,
-	DS5_SYNC_MODE_SUB_PREMASTER,
-	DS5_SYNC_MODE_FULL_MASTER,
+enum d5x_sync_mode {
+	D5X_SYNC_MODE_DEFAULT,
+	D5X_SYNC_MODE_MASTER,
+	D5X_SYNC_MODE_SLAVE,
+	D5X_SYNC_MODE_FULL_SLAVE,
+	D5X_SYNC_MODE_SUB_PREMASTER,
+	D5X_SYNC_MODE_FULL_MASTER,
 };
 
-#define DS5_CAMERA_CID_PWM			(DS5_CAMERA_CID_BASE+22)
+#define D5X_CAMERA_CID_PWM			(D5X_CAMERA_CID_BASE+22)
 
 /* 
  * The HWMC will remain for legacy tools compatibility,
  * HWMC_RW used for UVC compatibility
  */
-#define DS5_CAMERA_CID_HWMC_RW		(DS5_CAMERA_CID_BASE+32)
+#define D5X_CAMERA_CID_HWMC_RW		(D5X_CAMERA_CID_BASE+32)
 
 /* HW reset with recovery for GMSL connections */
-#define DS5_CAMERA_CID_HW_RESET		(DS5_CAMERA_CID_BASE+33)
+#define D5X_CAMERA_CID_HW_RESET		(D5X_CAMERA_CID_BASE+33)
 
-#define DS5_HWMC_DATA			0x4900
-#define DS5_HWMC_STATUS			0x4904
-#define DS5_HWMC_RESP_LEN		0x4908
-#define DS5_HWMC_EXEC			0x490C
+#define D5X_HWMC_DATA			0x4900
+#define D5X_HWMC_STATUS			0x4904
+#define D5X_HWMC_RESP_LEN		0x4908
+#define D5X_HWMC_EXEC			0x490C
 
-#define DS5_HWMC_STATUS_OK		0
-#define DS5_HWMC_STATUS_ERR		1
-#define DS5_HWMC_STATUS_WIP		2
-#define DS5_HWMC_BUFFER_SIZE	1024
+#define D5X_HWMC_STATUS_OK		0
+#define D5X_HWMC_STATUS_ERR		1
+#define D5X_HWMC_STATUS_WIP		2
+#define D5X_HWMC_BUFFER_SIZE	1024
 
 #ifdef V4L2_CTRL_FLAG_DYNAMIC_ARRAY
-#define DS5_HWMC_RW_CTRL_FLAGS	(V4L2_CTRL_FLAG_VOLATILE | \
+#define D5X_HWMC_RW_CTRL_FLAGS	(V4L2_CTRL_FLAG_VOLATILE | \
 				 V4L2_CTRL_FLAG_EXECUTE_ON_WRITE | \
 				 V4L2_CTRL_FLAG_DYNAMIC_ARRAY)
 #else
-#define DS5_HWMC_RW_CTRL_FLAGS	(V4L2_CTRL_FLAG_VOLATILE | \
+#define D5X_HWMC_RW_CTRL_FLAGS	(V4L2_CTRL_FLAG_VOLATILE | \
 				 V4L2_CTRL_FLAG_EXECUTE_ON_WRITE)
 #endif
 
-enum DS5_HWMC_ERR {
-	DS5_HWMC_ERR_SUCCESS = 0,
-	DS5_HWMC_ERR_CMD     = -1,
-	DS5_HWMC_ERR_PARAM   = -6,
-	DS5_HWMC_ERR_NODATA  = -21,
-	DS5_HWMC_ERR_UNKNOWN = -64,
-	DS5_HWMC_ERR_LAST,
+enum D5X_HWMC_ERR {
+	D5X_HWMC_ERR_SUCCESS = 0,
+	D5X_HWMC_ERR_CMD     = -1,
+	D5X_HWMC_ERR_PARAM   = -6,
+	D5X_HWMC_ERR_NODATA  = -21,
+	D5X_HWMC_ERR_UNKNOWN = -64,
+	D5X_HWMC_ERR_LAST,
 };
 
-static int ds5_hwmc_wait(struct ds5 *state)
+static int d5x_hwmc_wait(struct d5x *state)
 {
 	int ret = 0;
-	u16 status = DS5_HWMC_STATUS_WIP;
+	u16 status = D5X_HWMC_STATUS_WIP;
 	int retries = 100;
 	int errorCode;
 	do {
 		if (retries != 100)
 			msleep_range(1);
-		ret = ds5_read_poll(state, DS5_HWMC_STATUS, &status);
+		ret = d5x_read_poll(state, D5X_HWMC_STATUS, &status);
 		if (ret) {
 			dev_dbg(&state->client->dev,
 				"%s(): I2C read failed (%d), retries left: %d\n",
 				__func__, ret, retries);
 		}
-	} while (retries-- && (ret || status == DS5_HWMC_STATUS_WIP));
+	} while (retries-- && (ret || status == D5X_HWMC_STATUS_WIP));
 	dev_dbg(&state->client->dev,
 		"%s(): ret: 0x%x, status: 0x%x\n",
 		__func__, ret, status);
 	if (!ret) {
-		if (status == DS5_HWMC_STATUS_ERR) {
-			ds5_raw_read(state, DS5_HWMC_DATA, &errorCode, sizeof(errorCode));
+		if (status == D5X_HWMC_STATUS_ERR) {
+			d5x_raw_read(state, D5X_HWMC_DATA, &errorCode, sizeof(errorCode));
 			ret = errorCode;
-		} else if (status == DS5_HWMC_STATUS_WIP) {
+		} else if (status == D5X_HWMC_STATUS_WIP) {
 			ret = -ETIMEDOUT;
 			dev_warn(&state->client->dev,
 				"%s(): HWMC command timed out\n", __func__);
 		}
 	} else {
-		ret = DS5_HWMC_ERR_LAST;
+		ret = D5X_HWMC_ERR_LAST;
 	}
 	return ret;
 }
 
-static int ds5_get_hwmc(struct ds5 *state, unsigned char *data,
+static int d5x_get_hwmc(struct d5x *state, unsigned char *data,
 		u16 cmdDataLen, u16 *dataLen)
 {
 	int ret = 0;
@@ -2276,12 +2276,12 @@ static int ds5_get_hwmc(struct ds5 *state, unsigned char *data,
 		return -ENOBUFS;
 
 	memset(data, 0, cmdDataLen);
-	ret = ds5_hwmc_wait(state);
+	ret = d5x_hwmc_wait(state);
 	if (ret) {
 		dev_dbg(&state->client->dev,
 			"%s(): HWMC status not clear, ret: %d\n",
 			__func__, ret);
-		if (ret != DS5_HWMC_ERR_LAST) {
+		if (ret != D5X_HWMC_ERR_LAST) {
 			int *p = (int *)data;
 			*p = ret;
 			return 0;
@@ -2290,7 +2290,7 @@ static int ds5_get_hwmc(struct ds5 *state, unsigned char *data,
 		}
 	}
 
-	ret = ds5_raw_read(state, DS5_HWMC_RESP_LEN,
+	ret = d5x_raw_read(state, D5X_HWMC_RESP_LEN,
 			&tmp_len, sizeof(tmp_len)); /* Read response length */
 	if (ret)
 		return -EBADMSG;
@@ -2308,13 +2308,13 @@ static int ds5_get_hwmc(struct ds5 *state, unsigned char *data,
 			"%s(): HWMC read len: %d, lrs_len: %d\n",
 			__func__, tmp_len, tmp_len - 4);
 
-	ds5_raw_read_with_check(state, DS5_HWMC_DATA, data, tmp_len); /* Read response data */
+	d5x_raw_read_with_check(state, D5X_HWMC_DATA, data, tmp_len); /* Read response data */
 	if (dataLen)
 		*dataLen = tmp_len;
 	return ret;
 }
 
-static int ds5_hwmc_send(struct ds5 *state,
+static int d5x_hwmc_send(struct d5x *state,
 			u16 cmdLen,
 			const struct hwm_cmd *cmd)
 {
@@ -2324,15 +2324,15 @@ static int ds5_hwmc_send(struct ds5 *state,
 			__func__, cmd->header, cmd->magic_word, cmd->opcode,
 			cmdLen,	cmd->param1, cmd->param2, cmd->param3, cmd->param4);
 
-	ds5_raw_write_with_check(state, DS5_HWMC_DATA, cmd, cmdLen); /* Write command data */
+	d5x_raw_write_with_check(state, D5X_HWMC_DATA, cmd, cmdLen); /* Write command data */
 
-	ds5_write_with_check(state, DS5_HWMC_EXEC, 0x01); /* execute cmd */
+	d5x_write_with_check(state, D5X_HWMC_EXEC, 0x01); /* execute cmd */
 
 	return 0;
 }
 
 #ifdef V4L2_CTRL_FLAG_DYNAMIC_ARRAY
-static int ds5_prime_hwmc_rw_ctrl(struct v4l2_ctrl *ctrl)
+static int d5x_prime_hwmc_rw_ctrl(struct v4l2_ctrl *ctrl)
 {
 	size_t bytes;
 	void *buffer;
@@ -2340,7 +2340,7 @@ static int ds5_prime_hwmc_rw_ctrl(struct v4l2_ctrl *ctrl)
 	if (!ctrl || !ctrl->is_array || !ctrl->is_dyn_array)
 		return -EINVAL;
 
-	bytes = DS5_HWMC_BUFFER_SIZE * ctrl->elem_size;
+	bytes = D5X_HWMC_BUFFER_SIZE * ctrl->elem_size;
 	buffer = kvzalloc(2 * bytes, GFP_KERNEL);
 	if (!buffer)
 		return -ENOMEM;
@@ -2349,15 +2349,15 @@ static int ds5_prime_hwmc_rw_ctrl(struct v4l2_ctrl *ctrl)
 	ctrl->p_array = buffer;
 	ctrl->p_new.p = buffer;
 	ctrl->p_cur.p = buffer + bytes;
-	ctrl->p_array_alloc_elems = DS5_HWMC_BUFFER_SIZE;
-	ctrl->elems = DS5_HWMC_BUFFER_SIZE;
-	ctrl->new_elems = DS5_HWMC_BUFFER_SIZE;
+	ctrl->p_array_alloc_elems = D5X_HWMC_BUFFER_SIZE;
+	ctrl->elems = D5X_HWMC_BUFFER_SIZE;
+	ctrl->new_elems = D5X_HWMC_BUFFER_SIZE;
 
 	return 0;
 }
 #endif
 
-static u16 ds5_hwmc_rw_buf_len(const struct v4l2_ctrl *ctrl)
+static u16 d5x_hwmc_rw_buf_len(const struct v4l2_ctrl *ctrl)
 {
 #ifdef V4L2_CTRL_FLAG_DYNAMIC_ARRAY
 	if (ctrl->is_dyn_array && ctrl->p_array_alloc_elems)
@@ -2366,13 +2366,13 @@ static u16 ds5_hwmc_rw_buf_len(const struct v4l2_ctrl *ctrl)
 	return ctrl->dims[0];
 }
 
-static void ds5_fix_empty_uamg_response(struct ds5 *state,
+static void d5x_fix_empty_uamg_response(struct d5x *state,
 		unsigned char *data, u16 buf_len, u16 *data_len)
 {
 	if (!data || !data_len || *data_len != 4 || buf_len <= 4)
 		return;
 
-	if (data[0] != DS5_HWMC_OPCODE_UAMG || data[1] || data[2] || data[3])
+	if (data[0] != D5X_HWMC_OPCODE_UAMG || data[1] || data[2] || data[3])
 		return;
 
 	/*
@@ -2387,16 +2387,16 @@ static void ds5_fix_empty_uamg_response(struct ds5 *state,
 		__func__);
 }
 
-static int ds5_set_calibration_data(struct ds5 *state,
+static int d5x_set_calibration_data(struct d5x *state,
 		const struct hwm_cmd *cmd, u16 length)
 {
 	int ret;
 
-	ret = ds5_hwmc_send(state, length, cmd);
+	ret = d5x_hwmc_send(state, length, cmd);
 	if (ret)
 		return ret;
 
-	ret = ds5_hwmc_wait(state);
+	ret = d5x_hwmc_wait(state);
 	if (ret) {
 		dev_err(&state->client->dev,
 				"%s(): Failed to set calibration table %d, error: %d\n",
@@ -2407,50 +2407,50 @@ static int ds5_set_calibration_data(struct ds5 *state,
 }
 
 /* HW reset timeout and polling parameters */
-#define DS5_HW_RESET_INITIAL_DELAY_MS	500
-#define DS5_HW_RESET_POLL_INTERVAL_MS	200
-#define DS5_HW_RESET_TIMEOUT_MS			10000
-#define DS5_HW_RESET_MAX_RETRIES	(DS5_HW_RESET_TIMEOUT_MS / DS5_HW_RESET_POLL_INTERVAL_MS)
+#define D5X_HW_RESET_INITIAL_DELAY_MS	500
+#define D5X_HW_RESET_POLL_INTERVAL_MS	200
+#define D5X_HW_RESET_TIMEOUT_MS			10000
+#define D5X_HW_RESET_MAX_RETRIES	(D5X_HW_RESET_TIMEOUT_MS / D5X_HW_RESET_POLL_INTERVAL_MS)
 
 /* 
  * Minimum interval between consecutive HW resets (ms).
  * Rapid back-to-back resets degrade the GMSL link.
  */
-#define DS5_HW_RESET_COOLDOWN_MS		2000
+#define D5X_HW_RESET_COOLDOWN_MS		2000
 
 /* Reset readiness handshake:
  * 1) write scratch value before reset,
  * 2) wait for FW to restore control-status registers to default 0.
  */
-#define DS5_HW_RESET_READY_SCRATCH_VAL	0x00AD
-#define DS5_HW_RESET_READY_EXPECTED_VAL	0x0000
+#define D5X_HW_RESET_READY_SCRATCH_VAL	0x00AD
+#define D5X_HW_RESET_READY_EXPECTED_VAL	0x0000
 
 /*
  * Register holding DFU magic (0x5020).
  * In non-DFU mode this register is not defined.
  * - 0x04030201: Device in DFU mode (DFU magic bytes, little-endian)
  */
-#define DS5_DFU_MAGIC_REG				0x5020
-#define DS5_DFU_MAGIC_LSW				0x0201
+#define D5X_DFU_MAGIC_REG				0x5020
+#define D5X_DFU_MAGIC_LSW				0x0201
 
-static int ds5_wait_device_type(struct ds5 *state, u16 *dev_type)
+static int d5x_wait_device_type(struct d5x *state, u16 *dev_type)
 {
 	int ret = -ETIMEDOUT;
 	int retry;
 	u16 cached_type;
-	u16 probed_type = DS5_DEVICE_TYPE_UNKNOWN;
+	u16 probed_type = D5X_DEVICE_TYPE_UNKNOWN;
 
-	for (retry = 0; retry < DS5_HW_RESET_MAX_RETRIES;
-	     retry++, msleep(DS5_HW_RESET_POLL_INTERVAL_MS)) {
-		cached_type = READ_ONCE(state->ds5_dev->cached_device_type);
-		if (ds5_is_valid_device_type(cached_type)) {
+	for (retry = 0; retry < D5X_HW_RESET_MAX_RETRIES;
+	     retry++, msleep(D5X_HW_RESET_POLL_INTERVAL_MS)) {
+		cached_type = READ_ONCE(state->d5x_dev->cached_device_type);
+		if (d5x_is_valid_device_type(cached_type)) {
 			*dev_type = cached_type;
 			return 0;
 		}
 
-		ret = ds5_read_poll(state, DS5_DEVICE_TYPE, &probed_type);
-		if (!ret && ds5_is_valid_device_type(probed_type)) {
-			WRITE_ONCE(state->ds5_dev->cached_device_type, probed_type);
+		ret = d5x_read_poll(state, D5X_DEVICE_TYPE, &probed_type);
+		if (!ret && d5x_is_valid_device_type(probed_type)) {
+			WRITE_ONCE(state->d5x_dev->cached_device_type, probed_type);
 			*dev_type = probed_type;
 			return 0;
 		}
@@ -2460,19 +2460,19 @@ static int ds5_wait_device_type(struct ds5 *state, u16 *dev_type)
 	return ret ? ret : -ETIMEDOUT;
 }
 
-static void ds5_reset_streaming_flags(struct ds5_dev *ds5_dev)
+static void d5x_reset_streaming_flags(struct d5x_dev *d5x_dev)
 {
-	mutex_lock(&ds5_dev->lock);
-	ds5_dev->depth_streaming = false;
-	ds5_dev->ir_streaming = false;
-	ds5_dev->rgb_streaming = false;
-	ds5_dev->imu_streaming = false;
-	mutex_unlock(&ds5_dev->lock);
+	mutex_lock(&d5x_dev->lock);
+	d5x_dev->depth_streaming = false;
+	d5x_dev->ir_streaming = false;
+	d5x_dev->rgb_streaming = false;
+	d5x_dev->imu_streaming = false;
+	mutex_unlock(&d5x_dev->lock);
 }
 
 #ifdef CONFIG_VIDEO_D5XX_SERDES
-static void ds5_release_serdes_pipe(struct ds5 *state,
-				    struct ds5_sensor *sensor,
+static void d5x_release_serdes_pipe(struct d5x *state,
+				    struct d5x_sensor *sensor,
 				    const char *reason)
 {
 	int ret;
@@ -2487,7 +2487,7 @@ static void ds5_release_serdes_pipe(struct ds5 *state,
 			 "release pipe %d failed after %s (%d)\n",
 			 sensor->pipe_id, reason, ret);
 	} else {
-		ds5_disarm_dser_datapath_if_idle(state);
+		d5x_disarm_dser_datapath_if_idle(state);
 		sensor->pipe_id = PIPE_NOT_CONFIGURED;
 		sensor->pipe_reapply_gen = 0;
 	}
@@ -2495,16 +2495,16 @@ static void ds5_release_serdes_pipe(struct ds5 *state,
 }
 #endif
 
-static int ds5_set_ser_esync_tunneling(struct ds5 *state, bool enable)
+static int d5x_set_ser_esync_tunneling(struct d5x *state, bool enable)
 {
 #ifdef CONFIG_VIDEO_D5XX_SERDES
-	struct ds5 *owner;
+	struct d5x *owner;
 	int ret;
 
-	if (!state || !state->client || !state->ds5_dev)
+	if (!state || !state->client || !state->d5x_dev)
 		return -EINVAL;
 
-	owner = state->ds5_dev->ds5_primary ? state->ds5_dev->ds5_primary : state;
+	owner = state->d5x_dev->d5x_primary ? state->d5x_dev->d5x_primary : state;
 	if (!owner || !owner->client || !owner->ser_dev || !owner->dser_ops)
 		return -EINVAL;
 	if (owner->dser_ops != &max96724_interface)
@@ -2535,17 +2535,17 @@ static int ds5_set_ser_esync_tunneling(struct ds5 *state, bool enable)
 #endif
 }
 
-static int ds5_set_des_fsync(struct ds5 *state, bool enable)
+static int d5x_set_des_fsync(struct d5x *state, bool enable)
 {
 #ifdef CONFIG_VIDEO_D5XX_SERDES
-	struct ds5 *owner;
+	struct d5x *owner;
 	u32 fps = 0;
 	int ret = 0;
 
-	if (!state || !state->client || !state->ds5_dev)
+	if (!state || !state->client || !state->d5x_dev)
 		return -EINVAL;
 
-	owner = state->ds5_dev->ds5_primary ? state->ds5_dev->ds5_primary : state;
+	owner = state->d5x_dev->d5x_primary ? state->d5x_dev->d5x_primary : state;
 	if (!owner || !owner->client || !owner->dser_dev || !owner->dser_ops)
 		return -EINVAL;
 	if (owner->dser_ops != &max96724_interface)
@@ -2583,24 +2583,24 @@ static int ds5_set_des_fsync(struct ds5 *state, bool enable)
 #endif
 }
 
-static bool ds5_sync_mode_uses_esync(struct ds5 *state)
+static bool d5x_sync_mode_uses_esync(struct d5x *state)
 {
-	int sync_mode = DS5_SYNC_MODE_DEFAULT;
+	int sync_mode = D5X_SYNC_MODE_DEFAULT;
 
 	if (!state)
 		return false;
 
-	if (state->ds5_dev)
-		sync_mode = READ_ONCE(state->ds5_dev->sync_mode);
-	if (sync_mode == DS5_SYNC_MODE_DEFAULT && state->ctrls.sync_mode)
+	if (state->d5x_dev)
+		sync_mode = READ_ONCE(state->d5x_dev->sync_mode);
+	if (sync_mode == D5X_SYNC_MODE_DEFAULT && state->ctrls.sync_mode)
 		sync_mode = state->ctrls.sync_mode->cur.val;
 
-	return sync_mode == DS5_SYNC_MODE_SLAVE ||
-	       sync_mode == DS5_SYNC_MODE_FULL_SLAVE;
+	return sync_mode == D5X_SYNC_MODE_SLAVE ||
+	       sync_mode == D5X_SYNC_MODE_FULL_SLAVE;
 }
 
 /*
- * ds5_hw_reset_with_recovery - Perform hardware reset with readiness polling
+ * d5x_hw_reset_with_recovery - Perform hardware reset with readiness polling
  * @state: Driver state structure
  *
  * Sends a hardware reset command to the D4XX device and waits for it to
@@ -2608,15 +2608,15 @@ static bool ds5_sync_mode_uses_esync(struct ds5 *state)
  * all driver-side sensor state (streaming flags, SERDES pipes, config cache).
  * After the device responds, waits for DEVICE_TYPE to become valid (GMSL
  * link recovery).  Per-pipe SERDES reconfiguration is deferred to
- * ds5_configure() at the next stream start.
+ * d5x_configure() at the next stream start.
  *
  * Returns 0 on success, negative error code on failure.
  */
-static int ds5_hw_reset_with_recovery(struct ds5 *state)
+static int d5x_hw_reset_with_recovery(struct d5x *state)
 {
 	int ret;
 	int retry;
-	u16 dev_type = DS5_DEVICE_TYPE_UNKNOWN;
+	u16 dev_type = D5X_DEVICE_TYPE_UNKNOWN;
 	u16 ready_status = 0;
 	u16 ready_reg = state->control_status_reg;
 	struct hwm_cmd reset_cmd;
@@ -2624,7 +2624,7 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	bool rgb_streaming;
 	bool ir_streaming;
 	bool imu_streaming;
-	unsigned long ds5_last_reset_jiffies = READ_ONCE(state->ds5_dev->last_reset_jiffies);
+	unsigned long d5x_last_reset_jiffies = READ_ONCE(state->d5x_dev->last_reset_jiffies);
 	unsigned long ts, timeout;
 
 	dev_info(&state->client->dev, "%s(): Initiating HW reset with recovery\n",
@@ -2634,13 +2634,13 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	 *    Repeated HW resets without sufficient recovery time
 	 *    progressively degrade the GMSL link.  Enforce a minimum
 	 *    interval between resets.
-	 *    Skip check on the very first reset (ds5_last_reset_jiffies == 0).
+	 *    Skip check on the very first reset (d5x_last_reset_jiffies == 0).
 	 */
-	if (ds5_last_reset_jiffies) {
-		unsigned long elapsed = jiffies - ds5_last_reset_jiffies;
-		unsigned long cooldown = msecs_to_jiffies(DS5_HW_RESET_COOLDOWN_MS);
+	if (d5x_last_reset_jiffies) {
+		unsigned long elapsed = jiffies - d5x_last_reset_jiffies;
+		unsigned long cooldown = msecs_to_jiffies(D5X_HW_RESET_COOLDOWN_MS);
 
-		if (time_before(jiffies, ds5_last_reset_jiffies + cooldown)) {
+		if (time_before(jiffies, d5x_last_reset_jiffies + cooldown)) {
 			unsigned long remaining = cooldown - elapsed;
 
 			dev_info(&state->client->dev,
@@ -2660,26 +2660,26 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	 *    stop and invalidate all peer instances of the same camera.
 	 */
 	dev_info(&state->client->dev, "%s(): stopping streams before reset\n", __func__);
-	mutex_lock(&state->ds5_dev->lock);
-	depth_streaming = state->ds5_dev->depth_streaming;
-	rgb_streaming = state->ds5_dev->rgb_streaming;
-	ir_streaming = state->ds5_dev->ir_streaming;
-	imu_streaming = state->ds5_dev->imu_streaming;
-	mutex_unlock(&state->ds5_dev->lock);
+	mutex_lock(&state->d5x_dev->lock);
+	depth_streaming = state->d5x_dev->depth_streaming;
+	rgb_streaming = state->d5x_dev->rgb_streaming;
+	ir_streaming = state->d5x_dev->ir_streaming;
+	imu_streaming = state->d5x_dev->imu_streaming;
+	mutex_unlock(&state->d5x_dev->lock);
 
 	if (depth_streaming)
-		ds5_write(state, DS5_START_STOP_STREAM,	DS5_STREAM_STOP | DS5_STREAM_DEPTH);
+		d5x_write(state, D5X_START_STOP_STREAM,	D5X_STREAM_STOP | D5X_STREAM_DEPTH);
 	if (rgb_streaming)
-		ds5_write(state, DS5_START_STOP_STREAM,	DS5_STREAM_STOP | DS5_STREAM_RGB);
+		d5x_write(state, D5X_START_STOP_STREAM,	D5X_STREAM_STOP | D5X_STREAM_RGB);
 	if (ir_streaming)
-		ds5_write(state, DS5_START_STOP_STREAM,	DS5_STREAM_STOP | DS5_STREAM_IR);
+		d5x_write(state, D5X_START_STOP_STREAM,	D5X_STREAM_STOP | D5X_STREAM_IR);
 	if (imu_streaming)
-		ds5_write(state, DS5_START_STOP_STREAM,	DS5_STREAM_STOP | DS5_STREAM_IMU);
+		d5x_write(state, D5X_START_STOP_STREAM,	D5X_STREAM_STOP | D5X_STREAM_IMU);
 
-	/* 2. Increment DS5 reset generation.
+	/* 2. Increment D5xx reset generation.
 	 *    After HW reset the device loses all configuration, so driver
 	 *    state must be brought in sync, like clearing streaming flags so that
-	 *    ds5_mux_s_stream() won't silently skip the next stream-start.
+	 *    d5x_mux_s_stream() won't silently skip the next stream-start.
 	 *    Also clear cached device type so post-reset readiness polling
 	 *    cannot be satisfied by stale pre-reset values.
 	 *    Covers this instance AND all peer instances of the same camera.
@@ -2687,25 +2687,25 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	 *    Do NOT release SERDES pipes here — the D5XX FW may still
 	 *    reconfigure MAX96717 while reset completion propagates.
 	 *    Releasing + re-allocating pipes now would race with FW init.
-	 *    Instead, clear pipe_data_type to force ds5_configure() to
+	 *    Instead, clear pipe_data_type to force d5x_configure() to
 	 *    release-then-reallocate at stream-start time, when the FW
 	 *    has long finished its init (matching v1.0.1.33 behavior).
 	 */
-	atomic_inc(ds5_get_reset_gen(state));
-	WRITE_ONCE(state->ds5_dev->cached_device_type, DS5_DEVICE_TYPE_UNKNOWN);
-	ds5_reset_streaming_flags(state->ds5_dev);
+	atomic_inc(d5x_get_reset_gen(state));
+	WRITE_ONCE(state->d5x_dev->cached_device_type, D5X_DEVICE_TYPE_UNKNOWN);
+	d5x_reset_streaming_flags(state->d5x_dev);
 #ifdef CONFIG_VIDEO_D5XX_SERDES
-	ds5_set_dser_datapath_armed(state, false);
-	ds5_clear_dser_start_state(state);
+	d5x_set_dser_datapath_armed(state, false);
+	d5x_clear_dser_start_state(state);
 #endif
 
 	/* 3. Scratch one control-status register before reset.
 	 *    FW restores them to default 0x0000 only after reset completes.
 	 */
 	if (!ready_reg)
-		ready_reg = DS5_DEPTH_CONTROL_STATUS;
+		ready_reg = D5X_DEPTH_CONTROL_STATUS;
 
-	ret = ds5_write(state, ready_reg, DS5_HW_RESET_READY_SCRATCH_VAL);
+	ret = d5x_write(state, ready_reg, D5X_HW_RESET_READY_SCRATCH_VAL);
 	if (ret) {
 		dev_err(&state->client->dev,
 			"%s(): scratch write failed reg 0x%04x (%d)\n",
@@ -2715,7 +2715,7 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 
 	/* 4. Send HW reset command */
 	memcpy(&reset_cmd, &cmd_hw_reset, sizeof(reset_cmd));
-	ret = ds5_hwmc_send(state, sizeof(reset_cmd), &reset_cmd);
+	ret = d5x_hwmc_send(state, sizeof(reset_cmd), &reset_cmd);
 	if (ret < 0) {
 		dev_err(&state->client->dev,
 			"%s(): Failed to send HW reset command: %d\n",
@@ -2728,11 +2728,11 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 
 	/* 5. Delay to allow reset to complete */
 	ts = jiffies;
-	msleep(DS5_HW_RESET_INITIAL_DELAY_MS);
+	msleep(D5X_HW_RESET_INITIAL_DELAY_MS);
 
 	/* 6. Poll for control-status defaults to confirm reset completion. */
-	for (retry = 0, timeout = ts + msecs_to_jiffies(DS5_HW_RESET_TIMEOUT_MS);
-			; retry++, msleep_range(DS5_HW_RESET_POLL_INTERVAL_MS)) {
+	for (retry = 0, timeout = ts + msecs_to_jiffies(D5X_HW_RESET_TIMEOUT_MS);
+			; retry++, msleep_range(D5X_HW_RESET_POLL_INTERVAL_MS)) {
 		if (!time_before(jiffies, timeout)) {
 			dev_err(&state->client->dev,
 				"%s(): Device isn't ready after %d ms (last control-status: 0x%04x, i2c ret: %d)\n",
@@ -2741,25 +2741,25 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 			return -ETIMEDOUT;
 		}
 
-		ret = ds5_read_poll(state, ready_reg, &ready_status);
+		ret = d5x_read_poll(state, ready_reg, &ready_status);
 		if (ret < 0) {
 			dev_dbg(&state->client->dev,
 				"%s(): Device not responding (resetting), retry %d\n",
 				__func__, retry);
 			continue;
 		}
-		if (ready_status == DS5_HW_RESET_READY_EXPECTED_VAL) {
+		if (ready_status == D5X_HW_RESET_READY_EXPECTED_VAL) {
 			dev_info(&state->client->dev,
 				"%s(): Device ready after %d ms (control-status default restored)\n",
 				__func__, jiffies_to_msecs(jiffies - ts));
 			break;
 		}
 
-		ret = ds5_read_poll(state, DS5_DFU_MAGIC_REG, &ready_status);
-		if (!ret && ready_status == DS5_DFU_MAGIC_LSW) {
+		ret = d5x_read_poll(state, D5X_DFU_MAGIC_REG, &ready_status);
+		if (!ret && ready_status == D5X_DFU_MAGIC_LSW) {
 			dev_warn(&state->client->dev,
 				"%s(): Device in DFU/recovery mode after reset\n", __func__);
-			state->dfu_dev.dfu_state_flag = DS5_DFU_RECOVERY;
+			state->dfu_dev.dfu_state_flag = D5X_DFU_RECOVERY;
 			return 0;
 		}
 	}
@@ -2774,10 +2774,10 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	 *    Do NOT call max96717_init_settings() here.  That function writes
 	 *    global serializer registers (0x02, 0x308, 0x311, 0x331) that
 	 *    disrupt the active GMSL link.  Per-pipe reconfiguration is
-	 *    handled by ds5_configure()->ds5_setup_pipeline()
+	 *    handled by d5x_configure()->d5x_setup_pipeline()
 	 *    at the next STREAMON for each stream.
 	 */
-	ret = ds5_wait_device_type(state, &dev_type);
+	ret = d5x_wait_device_type(state, &dev_type);
 	if (ret < 0) {
 		dev_err(&state->client->dev,
 			"%s(): device type not ready after reset (ret=%d, val=0x%x)\n",
@@ -2789,14 +2789,14 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 		__func__, dev_type);
 
 	/* 8. Verify device is operational by reading firmware version */
-	ret = ds5_read(state, DS5_FW_VERSION, &state->fw_version);
+	ret = d5x_read(state, D5X_FW_VERSION, &state->fw_version);
 	if (ret < 0) {
 		dev_err(&state->client->dev,
 			"%s(): Failed to read firmware version: %d\n", __func__, ret);
 		return ret;
 	}
 
-	ret = ds5_read(state, DS5_FW_BUILD, &state->fw_build);
+	ret = d5x_read(state, D5X_FW_BUILD, &state->fw_build);
 	if (ret < 0) {
 		dev_err(&state->client->dev,
 			"%s(): Failed to read firmware build: %d\n", __func__, ret);
@@ -2814,15 +2814,15 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	 * ESYNC / FSYNC hardware is NOT re-applied here after a HW
 	 * reset.  The cached sync_mode control is a pure policy flag;
 	 * the actual SERDES programming happens at the next
-	 * stream-on boundary (ds5_mux_s_stream).
+	 * stream-on boundary (d5x_mux_s_stream).
 	 */
 
-	WRITE_ONCE(state->ds5_dev->last_reset_jiffies, jiffies);
+	WRITE_ONCE(state->d5x_dev->last_reset_jiffies, jiffies);
 
 	return 0;
 }
 
-static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on);
+static int d5x_mux_s_stream(struct v4l2_subdev *sd, int on);
 
 #if defined(CONFIG_TEGRA_CAMERA_PLATFORM) && defined(CONFIG_TEGRA_EMBEDDED_METADATA_OPS)
 /*
@@ -2830,55 +2830,55 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on);
  * validates the framing needed to publish the actual sidecar bytesused;
  * semantic metadata parsing stays in userspace.
  */
-static size_t ds5_csi_metadata_bytesused(const u8 *data, size_t captured_size)
+static size_t d5x_csi_metadata_bytesused(const u8 *data, size_t captured_size)
 {
 	u16 payload_size;
 	size_t bytesused;
 
-	if (!data || captured_size < DS5_CSI_METADATA_HEADER_SIZE)
+	if (!data || captured_size < D5X_CSI_METADATA_HEADER_SIZE)
 		return 0;
 
-	if (get_unaligned_le32(data) != DS5_CSI_METADATA_MAGIC)
+	if (get_unaligned_le32(data) != D5X_CSI_METADATA_MAGIC)
 		return 0;
 
-	payload_size = get_unaligned_le16(data + DS5_CSI_METADATA_PAYLOAD_OFFSET);
-	bytesused = DS5_CSI_METADATA_HEADER_SIZE + payload_size;
+	payload_size = get_unaligned_le16(data + D5X_CSI_METADATA_PAYLOAD_OFFSET);
+	bytesused = D5X_CSI_METADATA_HEADER_SIZE + payload_size;
 	if (!payload_size || bytesused > captured_size)
 		return 0;
 
 	return bytesused;
 }
 
-static const struct tegra_embedded_metadata_ops ds5_csi_metadata_ops = {
+static const struct tegra_embedded_metadata_ops d5x_csi_metadata_ops = {
 	.dataformat = V4L2_META_FMT_RSMD,
 	.compat_dataformat = V4L2_META_FMT_D4XX,
-	.max_buffer_size = DS5_CSI_METADATA_MAX_WC,
-	.get_bytesused = ds5_csi_metadata_bytesused,
+	.max_buffer_size = D5X_CSI_METADATA_MAX_WC,
+	.get_bytesused = d5x_csi_metadata_bytesused,
 };
 #endif
 
-static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
+static int d5x_s_ctrl(struct v4l2_ctrl *ctrl)
 {
-	struct ds5 *state = container_of(ctrl->handler, struct ds5,
+	struct d5x *state = container_of(ctrl->handler, struct d5x,
 					 ctrls.handler);
 	struct v4l2_subdev *sd = &state->mux.sd.subdev;
-	struct ds5_sensor *sensor = (struct ds5_sensor *)ctrl->priv;
+	struct d5x_sensor *sensor = (struct d5x_sensor *)ctrl->priv;
 	int ret = -EINVAL;
 	u16 base;
 
 	if (sensor) {
 		switch (sensor->mux_pad) {
-		case DS5_MUX_PAD_DEPTH:
-			state = container_of(ctrl->handler, struct ds5, ctrls.handler_depth);
+		case D5X_MUX_PAD_DEPTH:
+			state = container_of(ctrl->handler, struct d5x, ctrls.handler_depth);
 			break;
-		case DS5_MUX_PAD_RGB:
-			state = container_of(ctrl->handler, struct ds5, ctrls.handler_rgb);
+		case D5X_MUX_PAD_RGB:
+			state = container_of(ctrl->handler, struct d5x, ctrls.handler_rgb);
 			break;
-		case DS5_MUX_PAD_IR:
-			state = container_of(ctrl->handler, struct ds5, ctrls.handler_y8);
+		case D5X_MUX_PAD_IR:
+			state = container_of(ctrl->handler, struct d5x, ctrls.handler_y8);
 			break;
-		case DS5_MUX_PAD_IMU:
-			state = container_of(ctrl->handler, struct ds5, ctrls.handler_imu);
+		case D5X_MUX_PAD_IMU:
+			state = container_of(ctrl->handler, struct d5x, ctrls.handler_imu);
 			break;
 		default:
 			break;
@@ -2888,35 +2888,35 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 	base = state->control_base;
 	v4l2_dbg(3, 1, sd, "ctrl: %s, value: %d\n", ctrl->name, ctrl->val);
 	dev_dbg(&state->client->dev, "%s(): %s - ctrl: %s, value: %d\n",
-		__func__, ds5_get_sensor_name(state), ctrl->name, ctrl->val);
+		__func__, d5x_get_sensor_name(state), ctrl->name, ctrl->val);
 
 	mutex_lock(&state->lock);
 
 	switch (ctrl->id) {
 	case V4L2_CID_ANALOGUE_GAIN:
-		ret = ds5_write(state, base | DS5_MANUAL_GAIN, ctrl->val);
+		ret = d5x_write(state, base | D5X_MANUAL_GAIN, ctrl->val);
 		break;
 
 	case V4L2_CID_EXPOSURE_AUTO:
-		ret = ds5_hw_set_auto_exposure(state, base, ctrl->val);
+		ret = d5x_hw_set_auto_exposure(state, base, ctrl->val);
 		break;
 
 	case V4L2_CID_EXPOSURE_ABSOLUTE:
-		ret = ds5_hw_set_exposure(state, base, ctrl->val);
+		ret = d5x_hw_set_exposure(state, base, ctrl->val);
 		break;
-	case DS5_CAMERA_CID_LASER_POWER:
+	case D5X_CAMERA_CID_LASER_POWER:
 		if (!state->is_rgb)
-			ret = ds5_write(state, base | DS5_LASER_POWER,
+			ret = d5x_write(state, base | D5X_LASER_POWER,
 					ctrl->val);
 		break;
-	case DS5_CAMERA_CID_MANUAL_LASER_POWER:
+	case D5X_CAMERA_CID_MANUAL_LASER_POWER:
 		if (!state->is_rgb)
-			ret = ds5_write(state, base | DS5_MANUAL_LASER_POWER,
+			ret = d5x_write(state, base | D5X_MANUAL_LASER_POWER,
 					ctrl->val);
 		break;
-	case DS5_CAMERA_DEPTH_CALIBRATION_TABLE_SET:
+	case D5X_CAMERA_DEPTH_CALIBRATION_TABLE_SET:
 		dev_dbg(&state->client->dev,
-			"%s(): DS5_CAMERA_DEPTH_CALIBRATION_TABLE_SET \n",	__func__);
+			"%s(): D5X_CAMERA_DEPTH_CALIBRATION_TABLE_SET \n",	__func__);
 		if (ctrl->p_new.p) {
 			struct hwm_cmd *calib_cmd;
 			dev_dbg(&state->client->dev,
@@ -2936,15 +2936,15 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 				calib_cmd->header = 276;
 				calib_cmd->param1 = DEPTH_CALIBRATION_ID;
 				memcpy(calib_cmd->Data, (u8 *)ctrl->p_new.p, 256);
-				ret = ds5_set_calibration_data(state, calib_cmd,
+				ret = d5x_set_calibration_data(state, calib_cmd,
 					sizeof(struct hwm_cmd) + 256);
 				devm_kfree(&state->client->dev, calib_cmd);
 			}
 		}
 		break;
-	case DS5_CAMERA_COEFF_CALIBRATION_TABLE_SET:
+	case D5X_CAMERA_COEFF_CALIBRATION_TABLE_SET:
 			dev_dbg(&state->client->dev,
-				"%s(): DS5_CAMERA_COEFF_CALIBRATION_TABLE_SET \n",
+				"%s(): D5X_CAMERA_COEFF_CALIBRATION_TABLE_SET \n",
 				__func__);
 			if (ctrl->p_new.p) {
 				struct hwm_cmd *calib_cmd;
@@ -2965,13 +2965,13 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 				calib_cmd->header = 532;
 				calib_cmd->param1 = COEF_CALIBRATION_ID;
 				memcpy(calib_cmd->Data, (u8 *)ctrl->p_new.p, 512);
-				ret = ds5_set_calibration_data(state, calib_cmd,
+				ret = d5x_set_calibration_data(state, calib_cmd,
 						sizeof(struct hwm_cmd) + 512);
 				devm_kfree(&state->client->dev, calib_cmd);
 			}
 		}
 		break;
-	case DS5_CAMERA_CID_AE_ROI_SET: 
+	case D5X_CAMERA_CID_AE_ROI_SET:
 		if (ctrl->p_new.p_u16) {
 			struct hwm_cmd ae_roi_cmd;
 			memcpy(&ae_roi_cmd, &set_ae_roi, sizeof(ae_roi_cmd));
@@ -2979,13 +2979,13 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 			ae_roi_cmd.param2 = *((u16 *)ctrl->p_new.p_u16 + 1);
 			ae_roi_cmd.param3 = *((u16 *)ctrl->p_new.p_u16 + 2);
 			ae_roi_cmd.param4 = *((u16 *)ctrl->p_new.p_u16 + 3);
-			ret = ds5_hwmc_send(state, sizeof(struct hwm_cmd),
+			ret = d5x_hwmc_send(state, sizeof(struct hwm_cmd),
 				&ae_roi_cmd);
 			if (!ret)
-				ret = ds5_hwmc_wait(state);
+				ret = d5x_hwmc_wait(state);
 		}
 		break;
-	case DS5_CAMERA_CID_AE_SETPOINT_SET:
+	case D5X_CAMERA_CID_AE_SETPOINT_SET:
 		if (ctrl->p_new.p_s32) {
 			struct hwm_cmd *ae_setpoint_cmd;
 			dev_dbg(&state->client->dev, "%s():0x%x \n",
@@ -3001,14 +3001,14 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 			}
 			memcpy(ae_setpoint_cmd, &set_ae_setpoint, sizeof (set_ae_setpoint));
 			memcpy(ae_setpoint_cmd->Data, (u8 *)ctrl->p_new.p_s32, 4);
-			ret = ds5_hwmc_send(state, sizeof(struct hwm_cmd) + 4,
+			ret = d5x_hwmc_send(state, sizeof(struct hwm_cmd) + 4,
 					ae_setpoint_cmd);
 			if (!ret)
-				ret = ds5_hwmc_wait(state);
+				ret = d5x_hwmc_wait(state);
 			devm_kfree(&state->client->dev, ae_setpoint_cmd);
 		}
 		break;
-	case DS5_CAMERA_CID_ERB:
+	case D5X_CAMERA_CID_ERB:
 		if (ctrl->p_new.p_u8) {
 			u16 offset = 0;
 			u16 size = 0;
@@ -3034,9 +3034,9 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 			memcpy(erb_cmd, &erb, sizeof(struct hwm_cmd));
 			erb_cmd->param1 = offset;
 			erb_cmd->param2 = size;
-			ret = ds5_hwmc_send(state, sizeof(struct hwm_cmd), erb_cmd);
+			ret = d5x_hwmc_send(state, sizeof(struct hwm_cmd), erb_cmd);
 			if (!ret)
-				ret = ds5_get_hwmc(state, erb_cmd->Data, len, &size);
+				ret = d5x_get_hwmc(state, erb_cmd->Data, len, &size);
 			if (ret) {
 				dev_err(&state->client->dev,
 					"%s(): ERB cmd failed, ret: %d,"
@@ -3060,7 +3060,7 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 			devm_kfree(&state->client->dev, erb_cmd);
 		}
 		break;
-	case DS5_CAMERA_CID_EWB:
+	case D5X_CAMERA_CID_EWB:
 		if (ctrl->p_new.p_u8) {
 			u16 offset = 0;
 			u16 size = 0;
@@ -3093,9 +3093,9 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 			ewb_cmd->param1 = offset; // start index
 			ewb_cmd->param2 = size; // size
 			memcpy(ewb_cmd->Data, (u8 *)ctrl->p_new.p_u8 + 4, size);
-			ret = ds5_hwmc_send(state, sizeof(struct hwm_cmd) + size, ewb_cmd);
+			ret = d5x_hwmc_send(state, sizeof(struct hwm_cmd) + size, ewb_cmd);
 			if (!ret)
-				ret = ds5_hwmc_wait(state);
+				ret = d5x_hwmc_wait(state);
 			if (ret) {
 				dev_err(&state->client->dev,
 					"%s(): EWB cmd failed, ret: %d,"
@@ -3108,15 +3108,15 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 			devm_kfree(&state->client->dev, ewb_cmd);
 		}
 		break;
-	case DS5_CAMERA_CID_HWMC:
+	case D5X_CAMERA_CID_HWMC:
 		if (ctrl->p_new.p_u8) {
 			u16 size = 0;
 			struct hwm_cmd *cmd = (struct hwm_cmd *)ctrl->p_new.p_u8;
 			size = *((u8 *)ctrl->p_new.p_u8 + 1) << 8;
 			size |= *((u8 *)ctrl->p_new.p_u8 + 0);
-			ret = ds5_hwmc_send(state, size + 4, cmd);
-			ret = ds5_get_hwmc(state, cmd->Data, ctrl->dims[0], &size);
-			if (ctrl->dims[0] < DS5_HWMC_BUFFER_SIZE) {
+			ret = d5x_hwmc_send(state, size + 4, cmd);
+			ret = d5x_get_hwmc(state, cmd->Data, ctrl->dims[0], &size);
+			if (ctrl->dims[0] < D5X_HWMC_BUFFER_SIZE) {
 				ret = -ENODATA;
 				break;
 			}
@@ -3126,11 +3126,11 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 			cmd->Data[1001] = (unsigned char)(((size) & 0xFF00) >> 8);
 		}
 		break;
-	case DS5_CAMERA_CID_HWMC_RW:
+	case D5X_CAMERA_CID_HWMC_RW:
 		if (ctrl->p_new.p_u8) {
 			struct hwm_cmd *cmd = (struct hwm_cmd *)ctrl->p_new.p_u8;
 			u16 size = *((u8 *)ctrl->p_new.p_u8 + 1) << 8;
-			u16 buf_len = ds5_hwmc_rw_buf_len(ctrl);
+			u16 buf_len = d5x_hwmc_rw_buf_len(ctrl);
 			size |= *((u8 *)ctrl->p_new.p_u8 + 0);
 
 			dev_info(&state->client->dev,
@@ -3161,9 +3161,9 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 				dev_info(&state->client->dev,
 					"%s(): HW reset detected via HWMC_RW, using recovery path\n",
 					__func__);
-				ret = ds5_hw_reset_with_recovery(state);
+				ret = d5x_hw_reset_with_recovery(state);
 			} else {
-				ret = ds5_hwmc_send(state, size + 4, cmd);
+				ret = d5x_hwmc_send(state, size + 4, cmd);
 			}
 
 #ifdef V4L2_CTRL_FLAG_DYNAMIC_ARRAY
@@ -3172,24 +3172,24 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 #endif
 		}
 		break;
-	case DS5_CAMERA_CID_HW_RESET:
+	case D5X_CAMERA_CID_HW_RESET:
 		dev_info(&state->client->dev, "%s(): HW reset requested via V4L2 control\n",
 			__func__);
-		ret = ds5_hw_reset_with_recovery(state);
+		ret = d5x_hw_reset_with_recovery(state);
 		break;
-	case DS5_CAMERA_CID_SYNC_MODE:
+	case D5X_CAMERA_CID_SYNC_MODE:
 		dev_info(&state->client->dev, "%s(): XU SYNC_MODE control received, value: %d\n",
 			__func__, ctrl->val);
 		if (state->is_depth) {
-			ret = ds5_write(state, base | DS5_CAMERA_SYNC_MODE, ctrl->val);
+			ret = d5x_write(state, base | D5X_CAMERA_SYNC_MODE, ctrl->val);
 			dev_info(&state->client->dev, "%s(): SYNC_MODE command passed to FW, addr: 0x%x, value: %d, ret: %d\n",
-				__func__, base | DS5_CAMERA_SYNC_MODE, ctrl->val, ret);
+				__func__, base | D5X_CAMERA_SYNC_MODE, ctrl->val, ret);
 			if (!ret) {
-				bool need_esync = (ctrl->val == DS5_SYNC_MODE_SLAVE ||
-						   ctrl->val == DS5_SYNC_MODE_FULL_SLAVE);
+				bool need_esync = (ctrl->val == D5X_SYNC_MODE_SLAVE ||
+						   ctrl->val == D5X_SYNC_MODE_FULL_SLAVE);
 
-				if (state->ds5_dev)
-					WRITE_ONCE(state->ds5_dev->sync_mode, ctrl->val);
+				if (state->d5x_dev)
+					WRITE_ONCE(state->d5x_dev->sync_mode, ctrl->val);
 
 				/*
 				 * Match D4xx behavior for the serializer side:
@@ -3198,15 +3198,15 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 				 * FSYNC generator still starts at stream-on so it
 				 * can use the negotiated FPS.
 				 */
-				ret = ds5_set_ser_esync_tunneling(state, need_esync);
+				ret = d5x_set_ser_esync_tunneling(state, need_esync);
 				if (!ret && !need_esync)
-					ret = ds5_set_des_fsync(state, false);
+					ret = d5x_set_des_fsync(state, false);
 			}
 		}
 		break;
-	case DS5_CAMERA_CID_PWM:
+	case D5X_CAMERA_CID_PWM:
 		if (state->is_depth)
-			ret = ds5_write(state, base | DS5_PWM_FREQUENCY, ctrl->val);
+			ret = d5x_write(state, base | D5X_PWM_FREQUENCY, ctrl->val);
 		break;
 	}
 
@@ -3215,7 +3215,7 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 	return ret;
 }
 
-static int ds5_get_calibration_data(struct ds5 *state, enum table_id id,
+static int d5x_get_calibration_data(struct d5x *state, enum table_id id,
 		unsigned char *table, unsigned int length)
 {
 	struct hwm_cmd *cmd;
@@ -3231,13 +3231,13 @@ static int ds5_get_calibration_data(struct ds5 *state, enum table_id id,
 
 	memcpy(cmd, &get_calib_data, sizeof(get_calib_data));
 	cmd->param1 = id;
-	ret = ds5_hwmc_send(state, sizeof(struct hwm_cmd), cmd);
+	ret = d5x_hwmc_send(state, sizeof(struct hwm_cmd), cmd);
 	if (ret) {
 		devm_kfree(&state->client->dev, cmd);
 		return ret;
 	}
 
-	ret = ds5_hwmc_wait(state);
+	ret = d5x_hwmc_wait(state);
 
 	if (ret) {
 		dev_err(&state->client->dev,
@@ -3248,11 +3248,11 @@ static int ds5_get_calibration_data(struct ds5 *state, enum table_id id,
 	}
 
 	/* get table length from fw */
-	ret = ds5_raw_read(state, DS5_HWMC_RESP_LEN,
+	ret = d5x_raw_read(state, D5X_HWMC_RESP_LEN,
 			&table_length, sizeof(table_length));
 
 	/* read table */
-	ds5_raw_read_with_check(state, DS5_HWMC_DATA, cmd->Data, table_length);
+	d5x_raw_read_with_check(state, D5X_HWMC_DATA, cmd->Data, table_length);
 
 	/* first 4 bytes are opcode HWM, not part of calibration table */
 	memcpy(table, cmd->Data + 4, length);
@@ -3260,18 +3260,18 @@ static int ds5_get_calibration_data(struct ds5 *state, enum table_id id,
 	return 0;
 }
 
-static int ds5_gvd(struct ds5 *state, unsigned char *data)
+static int d5x_gvd(struct d5x *state, unsigned char *data)
 {
 	struct hwm_cmd cmd;
 	int ret;
 	u16 length = 0;
 
 	memcpy(&cmd, &gvd, sizeof(gvd));
-	ret = ds5_hwmc_send(state, sizeof(cmd), &cmd);
+	ret = d5x_hwmc_send(state, sizeof(cmd), &cmd);
 	if (ret)
 		return ret;
 
-	ret = ds5_hwmc_wait(state);
+	ret = d5x_hwmc_wait(state);
 	if (ret) {
 		dev_err(&state->client->dev,
 			"%s(): Failed to read GVD, error: %d\n",
@@ -3279,37 +3279,37 @@ static int ds5_gvd(struct ds5 *state, unsigned char *data)
 		return -EIO;
 	}
 	/* Read response length */
-	ret = ds5_raw_read(state, DS5_HWMC_RESP_LEN, &length, sizeof(length));
+	ret = d5x_raw_read(state, D5X_HWMC_RESP_LEN, &length, sizeof(length));
 	/* Read response data */
-	ds5_raw_read_with_check(state, DS5_HWMC_DATA, data, length);
+	d5x_raw_read_with_check(state, D5X_HWMC_DATA, data, length);
 
 	return ret;
 }
 
-static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
+static int d5x_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 {
-	struct ds5 *state = container_of(ctrl->handler, struct ds5,
+	struct d5x *state = container_of(ctrl->handler, struct d5x,
 			ctrls.handler);
 			
 	u32 data;
 	int ret = 0;
-	struct ds5_sensor *sensor = (struct ds5_sensor *)ctrl->priv;
+	struct d5x_sensor *sensor = (struct d5x_sensor *)ctrl->priv;
 	u16 base;
 	u16 reg;
 
 	if (sensor) {
 		switch (sensor->mux_pad) {
-		case DS5_MUX_PAD_DEPTH:
-			state = container_of(ctrl->handler, struct ds5, ctrls.handler_depth);
+		case D5X_MUX_PAD_DEPTH:
+			state = container_of(ctrl->handler, struct d5x, ctrls.handler_depth);
 			break;
-		case DS5_MUX_PAD_RGB:
-			state = container_of(ctrl->handler, struct ds5, ctrls.handler_rgb);
+		case D5X_MUX_PAD_RGB:
+			state = container_of(ctrl->handler, struct d5x, ctrls.handler_rgb);
 			break;
-		case DS5_MUX_PAD_IR:
-			state = container_of(ctrl->handler, struct ds5, ctrls.handler_y8);
+		case D5X_MUX_PAD_IR:
+			state = container_of(ctrl->handler, struct d5x, ctrls.handler_y8);
 			break;
-		case DS5_MUX_PAD_IMU:
-			state = container_of(ctrl->handler, struct ds5, ctrls.handler_imu);
+		case D5X_MUX_PAD_IMU:
+			state = container_of(ctrl->handler, struct d5x, ctrls.handler_imu);
 			break;
 		default:
 			break;
@@ -3318,22 +3318,22 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 	base = state->control_base;
 
 	dev_dbg(&state->client->dev, "%s(): %s - ctrl: %s \n",
-		__func__, ds5_get_sensor_name(state), ctrl->name);
+		__func__, d5x_get_sensor_name(state), ctrl->name);
 
 	switch (ctrl->id) {
 
 	case V4L2_CID_ANALOGUE_GAIN:
 		if (state->is_imu)
 			return -EINVAL;
-		ret = ds5_read(state, base | DS5_MANUAL_GAIN, ctrl->p_new.p_u16);
+		ret = d5x_read(state, base | D5X_MANUAL_GAIN, ctrl->p_new.p_u16);
 		break;
 
 	case V4L2_CID_EXPOSURE_AUTO:
 		if (state->is_imu)
 			return -EINVAL;
-		ds5_read(state, base | DS5_AUTO_EXPOSURE_MODE, &reg);
+		d5x_read(state, base | D5X_AUTO_EXPOSURE_MODE, &reg);
 		*ctrl->p_new.p_u16 = reg;
-		/* see ds5_hw_set_auto_exposure */
+		/* see d5x_hw_set_auto_exposure */
 		if (!state->is_rgb) {
 			if (reg == 1)
 				*ctrl->p_new.p_u16 = V4L2_EXPOSURE_APERTURE_PRIORITY;
@@ -3349,35 +3349,35 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 	case V4L2_CID_EXPOSURE_ABSOLUTE:
 		if (state->is_imu)
 			return -EINVAL;
-		/* see ds5_hw_set_exposure */
-		ds5_read(state, base | DS5_MANUAL_EXPOSURE_MSB, &reg);
+		/* see d5x_hw_set_exposure */
+		d5x_read(state, base | D5X_MANUAL_EXPOSURE_MSB, &reg);
 		data = ((u32)reg << 16) & 0xffff0000;
-		ds5_read(state, base | DS5_MANUAL_EXPOSURE_LSB, &reg);
+		d5x_read(state, base | D5X_MANUAL_EXPOSURE_LSB, &reg);
 		data |= reg;
 		*ctrl->p_new.p_u32 = data;
 		break;
 
-	case DS5_CAMERA_CID_LASER_POWER:
+	case D5X_CAMERA_CID_LASER_POWER:
 		if (!state->is_rgb)
-			ds5_read(state, base | DS5_LASER_POWER, ctrl->p_new.p_u16);
+			d5x_read(state, base | D5X_LASER_POWER, ctrl->p_new.p_u16);
 		break;
 
-	case DS5_CAMERA_CID_MANUAL_LASER_POWER:
+	case D5X_CAMERA_CID_MANUAL_LASER_POWER:
 		if (!state->is_rgb)
-			ds5_read(state, base | DS5_MANUAL_LASER_POWER, ctrl->p_new.p_u16);
+			d5x_read(state, base | D5X_MANUAL_LASER_POWER, ctrl->p_new.p_u16);
 		break;
 
-	case DS5_CAMERA_CID_LOG:
-		ret = ds5_hwmc_send(state, sizeof(log_prepare), &log_prepare);
+	case D5X_CAMERA_CID_LOG:
+		ret = d5x_hwmc_send(state, sizeof(log_prepare), &log_prepare);
 		if (ret)
 			return ret;
 
-		ret = ds5_hwmc_wait(state);
+		ret = d5x_hwmc_wait(state);
 		if (ret)
 			return ret;
 
 		/* Read response length */
-		ret = ds5_raw_read(state, DS5_HWMC_RESP_LEN, &data, sizeof(data));
+		ret = d5x_raw_read(state, D5X_HWMC_RESP_LEN, &data, sizeof(data));
 		dev_dbg(&state->client->dev, "%s(): log size 0x%x\n", __func__, data);
 		if (ret < 0)
 			return ret;
@@ -3385,40 +3385,40 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 			return 0;
 		if (data > 1024)
 			return -ENOBUFS;
-		ret = ds5_raw_read(state, DS5_HWMC_DATA,
+		ret = d5x_raw_read(state, D5X_HWMC_DATA,
 				ctrl->p_new.p_u8, data);
 		break;
-	case DS5_CAMERA_DEPTH_CALIBRATION_TABLE_GET:
-		ret = ds5_get_calibration_data(state, DEPTH_CALIBRATION_ID,
+	case D5X_CAMERA_DEPTH_CALIBRATION_TABLE_GET:
+		ret = d5x_get_calibration_data(state, DEPTH_CALIBRATION_ID,
 				ctrl->p_new.p_u8, 256);
 		break;
-	case DS5_CAMERA_COEFF_CALIBRATION_TABLE_GET:
-		ret = ds5_get_calibration_data(state, COEF_CALIBRATION_ID,
+	case D5X_CAMERA_COEFF_CALIBRATION_TABLE_GET:
+		ret = d5x_get_calibration_data(state, COEF_CALIBRATION_ID,
 				ctrl->p_new.p_u8, 512);
 		break;
-	case DS5_CAMERA_CID_FW_VERSION:
-		ret = ds5_read(state, DS5_FW_VERSION, &state->fw_version);
-		ret = ds5_read(state, DS5_FW_BUILD, &state->fw_build);
+	case D5X_CAMERA_CID_FW_VERSION:
+		ret = d5x_read(state, D5X_FW_VERSION, &state->fw_version);
+		ret = d5x_read(state, D5X_FW_BUILD, &state->fw_build);
 		*ctrl->p_new.p_u32 = state->fw_version << 16;
 		*ctrl->p_new.p_u32 |= state->fw_build;
 		break;
-	case DS5_CAMERA_CID_DEVICE_TYPE: {
-		u16 dev_type = DS5_DEVICE_TYPE_UNKNOWN;
+	case D5X_CAMERA_CID_DEVICE_TYPE: {
+		u16 dev_type = D5X_DEVICE_TYPE_UNKNOWN;
 
-		ret = ds5_read(state, DS5_DEVICE_TYPE, &dev_type);
-		dev_type = ds5_dev_type(state, dev_type);
-		if (ret && !ds5_is_valid_device_type(dev_type))
+		ret = d5x_read(state, D5X_DEVICE_TYPE, &dev_type);
+		dev_type = d5x_dev_type(state, dev_type);
+		if (ret && !d5x_is_valid_device_type(dev_type))
 			break;
-		if (ds5_is_valid_device_type(dev_type))
-			WRITE_ONCE(state->ds5_dev->cached_device_type, dev_type);
+		if (d5x_is_valid_device_type(dev_type))
+			WRITE_ONCE(state->d5x_dev->cached_device_type, dev_type);
 		*ctrl->p_new.p_u32 = dev_type;
 		ret = 0;
 		break;
 	}
-	case DS5_CAMERA_CID_GVD:
-		ret = ds5_gvd(state, ctrl->p_new.p_u8);
+	case D5X_CAMERA_CID_GVD:
+		ret = d5x_gvd(state, ctrl->p_new.p_u8);
 		break;
-	case DS5_CAMERA_CID_AE_ROI_GET:
+	case D5X_CAMERA_CID_AE_ROI_GET:
 		if (ctrl->p_new.p_u16) {
 			u16 len = sizeof(struct hwm_cmd) + 12;
 			u16 dataLen = 0;
@@ -3432,18 +3432,18 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 				break;
 			}
 			memcpy(ae_roi_cmd, &get_ae_roi, sizeof(struct hwm_cmd));
-			ret = ds5_hwmc_send(state, sizeof(struct hwm_cmd), ae_roi_cmd);
+			ret = d5x_hwmc_send(state, sizeof(struct hwm_cmd), ae_roi_cmd);
 			if (ret) {
 				devm_kfree(&state->client->dev, ae_roi_cmd);
 				return ret;
 			}
-			ret = ds5_get_hwmc(state, ae_roi_cmd->Data, len, &dataLen);
+			ret = d5x_get_hwmc(state, ae_roi_cmd->Data, len, &dataLen);
 			if (!ret && dataLen <= ctrl->dims[0])
 				memcpy(ctrl->p_new.p_u16, ae_roi_cmd->Data + 4, 8);
 			devm_kfree(&state->client->dev, ae_roi_cmd);
 		}
 		break;
-	case DS5_CAMERA_CID_AE_SETPOINT_GET:
+	case D5X_CAMERA_CID_AE_SETPOINT_GET:
 	if (ctrl->p_new.p_s32) {
 		u16 len = sizeof(struct hwm_cmd) + 8;
 		u16 dataLen = 0;
@@ -3457,26 +3457,26 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 			break;
 		}
 		memcpy(ae_setpoint_cmd, &get_ae_setpoint, sizeof(struct hwm_cmd));
-		ret = ds5_hwmc_send(state, sizeof(struct hwm_cmd), ae_setpoint_cmd);
+		ret = d5x_hwmc_send(state, sizeof(struct hwm_cmd), ae_setpoint_cmd);
 		if (ret) {		
 			devm_kfree(&state->client->dev, ae_setpoint_cmd);
 			return ret;
 		}
-		ret = ds5_get_hwmc(state, ae_setpoint_cmd->Data, len, &dataLen);
+		ret = d5x_get_hwmc(state, ae_setpoint_cmd->Data, len, &dataLen);
 		memcpy(ctrl->p_new.p_s32, ae_setpoint_cmd->Data + 4, 4);
 		dev_dbg(&state->client->dev, "%s(): len: %d, 0x%x \n",
 			__func__, dataLen, *(ctrl->p_new.p_s32));
 		devm_kfree(&state->client->dev, ae_setpoint_cmd);
 		}
 		break;
-	case DS5_CAMERA_CID_HWMC_RW: 
+	case D5X_CAMERA_CID_HWMC_RW:
 		if (ctrl->p_new.p_u8) {
 			unsigned char *data = (unsigned char *)ctrl->p_new.p_u8;
 			u16 dataLen = 0;
-			u16 bufLen = ds5_hwmc_rw_buf_len(ctrl);
-			ret = ds5_get_hwmc(state, data,	bufLen, &dataLen);
+			u16 bufLen = d5x_hwmc_rw_buf_len(ctrl);
+			ret = d5x_get_hwmc(state, data,	bufLen, &dataLen);
 			if (!ret)
-				ds5_fix_empty_uamg_response(state, data, bufLen, &dataLen);
+				d5x_fix_empty_uamg_response(state, data, bufLen, &dataLen);
 			/* This is needed for librealsense, to align there code with UVC,
 		 	 * last word is length - 4 bytes header length */
 			if (dataLen >= 4)
@@ -3489,26 +3489,26 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 			data[bufLen - 1] = 0;
 		}
 		break;
-	case DS5_CAMERA_CID_SYNC_MODE:
+	case D5X_CAMERA_CID_SYNC_MODE:
 		if (state->is_depth)
-			ds5_read(state, base | DS5_CAMERA_SYNC_MODE, ctrl->p_new.p_u16);
+			d5x_read(state, base | D5X_CAMERA_SYNC_MODE, ctrl->p_new.p_u16);
 		break;
-	case DS5_CAMERA_CID_PWM:
+	case D5X_CAMERA_CID_PWM:
 		if (state->is_depth)
-			ds5_read(state, base | DS5_PWM_FREQUENCY, ctrl->p_new.p_u16);
+			d5x_read(state, base | D5X_PWM_FREQUENCY, ctrl->p_new.p_u16);
 		break;
 	}
 	return ret;
 }
 
-static const struct v4l2_ctrl_ops ds5_ctrl_ops = {
-	.s_ctrl	= ds5_s_ctrl,
-	.g_volatile_ctrl = ds5_g_volatile_ctrl,
+static const struct v4l2_ctrl_ops d5x_ctrl_ops = {
+	.s_ctrl	= d5x_s_ctrl,
+	.g_volatile_ctrl = d5x_g_volatile_ctrl,
 };
 
-static const struct v4l2_ctrl_config ds5_ctrl_log = {
-	.ops = &ds5_ctrl_ops,
-	.id = DS5_CAMERA_CID_LOG,
+static const struct v4l2_ctrl_config d5x_ctrl_log = {
+	.ops = &d5x_ctrl_ops,
+	.id = D5X_CAMERA_CID_LOG,
 	.name = "Logger",
 	.type = V4L2_CTRL_TYPE_U8,
 	.dims = {1024},
@@ -3517,9 +3517,9 @@ static const struct v4l2_ctrl_config ds5_ctrl_log = {
 	.step = 1,
 };
 
-static const struct v4l2_ctrl_config ds5_ctrl_laser_power = {
-	.ops = &ds5_ctrl_ops,
-	.id = DS5_CAMERA_CID_LASER_POWER,
+static const struct v4l2_ctrl_config d5x_ctrl_laser_power = {
+	.ops = &d5x_ctrl_ops,
+	.id = D5X_CAMERA_CID_LASER_POWER,
 	.name = "Laser power on/off",
 	.type = V4L2_CTRL_TYPE_BOOLEAN,
 	.min = 0,
@@ -3529,9 +3529,9 @@ static const struct v4l2_ctrl_config ds5_ctrl_laser_power = {
 	.flags = V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
 };
 
-static const struct v4l2_ctrl_config ds5_ctrl_manual_laser_power = {
-	.ops = &ds5_ctrl_ops,
-	.id = DS5_CAMERA_CID_MANUAL_LASER_POWER,
+static const struct v4l2_ctrl_config d5x_ctrl_manual_laser_power = {
+	.ops = &d5x_ctrl_ops,
+	.id = D5X_CAMERA_CID_MANUAL_LASER_POWER,
 	.name = "Manual laser power",
 	.type = V4L2_CTRL_TYPE_INTEGER,
 	.min = 0,
@@ -3541,9 +3541,9 @@ static const struct v4l2_ctrl_config ds5_ctrl_manual_laser_power = {
 	.flags = V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
 };
 
-static const struct v4l2_ctrl_config ds5_ctrl_fw_version = {
-	.ops = &ds5_ctrl_ops,
-	.id = DS5_CAMERA_CID_FW_VERSION,
+static const struct v4l2_ctrl_config d5x_ctrl_fw_version = {
+	.ops = &d5x_ctrl_ops,
+	.id = D5X_CAMERA_CID_FW_VERSION,
 	.name = "fw version",
 	.type = V4L2_CTRL_TYPE_U32,
 	.dims = {1},
@@ -3552,9 +3552,9 @@ static const struct v4l2_ctrl_config ds5_ctrl_fw_version = {
 	.step = 1,
 };
 
-static const struct v4l2_ctrl_config ds5_ctrl_device_type = {
-	.ops = &ds5_ctrl_ops,
-	.id = DS5_CAMERA_CID_DEVICE_TYPE,
+static const struct v4l2_ctrl_config d5x_ctrl_device_type = {
+	.ops = &d5x_ctrl_ops,
+	.id = D5X_CAMERA_CID_DEVICE_TYPE,
 	.name = "device type",
 	.type = V4L2_CTRL_TYPE_U32,
 	.dims = {1},
@@ -3563,9 +3563,9 @@ static const struct v4l2_ctrl_config ds5_ctrl_device_type = {
 	.step = 1,
 };
 
-static const struct v4l2_ctrl_config ds5_ctrl_gvd = {
-	.ops = &ds5_ctrl_ops,
-	.id = DS5_CAMERA_CID_GVD,
+static const struct v4l2_ctrl_config d5x_ctrl_gvd = {
+	.ops = &d5x_ctrl_ops,
+	.id = D5X_CAMERA_CID_GVD,
 	.name = "GVD",
 	.type = V4L2_CTRL_TYPE_U8,
 	.dims = {239},
@@ -3574,9 +3574,9 @@ static const struct v4l2_ctrl_config ds5_ctrl_gvd = {
 	.step = 1,
 };
 
-static const struct v4l2_ctrl_config ds5_ctrl_get_depth_calib = {
-	.ops = &ds5_ctrl_ops,
-	.id = DS5_CAMERA_DEPTH_CALIBRATION_TABLE_GET,
+static const struct v4l2_ctrl_config d5x_ctrl_get_depth_calib = {
+	.ops = &d5x_ctrl_ops,
+	.id = D5X_CAMERA_DEPTH_CALIBRATION_TABLE_GET,
 	.name = "get depth calib",
 	.type = V4L2_CTRL_TYPE_U8,
 	.dims = {256},
@@ -3585,9 +3585,9 @@ static const struct v4l2_ctrl_config ds5_ctrl_get_depth_calib = {
 	.step = 1,
 };
 
-static const struct v4l2_ctrl_config ds5_ctrl_set_depth_calib = {
-	.ops = &ds5_ctrl_ops,
-	.id = DS5_CAMERA_DEPTH_CALIBRATION_TABLE_SET,
+static const struct v4l2_ctrl_config d5x_ctrl_set_depth_calib = {
+	.ops = &d5x_ctrl_ops,
+	.id = D5X_CAMERA_DEPTH_CALIBRATION_TABLE_SET,
 	.name = "set depth calib",
 	.type = V4L2_CTRL_TYPE_U8,
 	.dims = {256},
@@ -3598,9 +3598,9 @@ static const struct v4l2_ctrl_config ds5_ctrl_set_depth_calib = {
 	.step = 1,
 };
 
-static const struct v4l2_ctrl_config ds5_ctrl_get_coeff_calib = {
-	.ops = &ds5_ctrl_ops,
-	.id = DS5_CAMERA_COEFF_CALIBRATION_TABLE_GET,
+static const struct v4l2_ctrl_config d5x_ctrl_get_coeff_calib = {
+	.ops = &d5x_ctrl_ops,
+	.id = D5X_CAMERA_COEFF_CALIBRATION_TABLE_GET,
 	.name = "get coeff calib",
 	.type = V4L2_CTRL_TYPE_U8,
 	.dims = {512},
@@ -3609,9 +3609,9 @@ static const struct v4l2_ctrl_config ds5_ctrl_get_coeff_calib = {
 	.step = 1,
 };
 
-static const struct v4l2_ctrl_config ds5_ctrl_set_coeff_calib = {
-	.ops = &ds5_ctrl_ops,
-	.id = DS5_CAMERA_COEFF_CALIBRATION_TABLE_SET,
+static const struct v4l2_ctrl_config d5x_ctrl_set_coeff_calib = {
+	.ops = &d5x_ctrl_ops,
+	.id = D5X_CAMERA_COEFF_CALIBRATION_TABLE_SET,
 	.name = "set coeff calib",
 	.type = V4L2_CTRL_TYPE_U8,
 	.dims = {512},
@@ -3622,9 +3622,9 @@ static const struct v4l2_ctrl_config ds5_ctrl_set_coeff_calib = {
 	.step = 1,
 };
 
-static const struct v4l2_ctrl_config ds5_ctrl_ae_roi_get = {
-	.ops = &ds5_ctrl_ops,
-	.id = DS5_CAMERA_CID_AE_ROI_GET,
+static const struct v4l2_ctrl_config d5x_ctrl_ae_roi_get = {
+	.ops = &d5x_ctrl_ops,
+	.id = D5X_CAMERA_CID_AE_ROI_GET,
 	.name = "ae roi get",
 	.type = V4L2_CTRL_TYPE_U8,
 	.dims = {8},
@@ -3633,9 +3633,9 @@ static const struct v4l2_ctrl_config ds5_ctrl_ae_roi_get = {
 	.step = 1,
 };
 
-static const struct v4l2_ctrl_config ds5_ctrl_ae_roi_set = {
-	.ops = &ds5_ctrl_ops,
-	.id = DS5_CAMERA_CID_AE_ROI_SET,
+static const struct v4l2_ctrl_config d5x_ctrl_ae_roi_set = {
+	.ops = &d5x_ctrl_ops,
+	.id = D5X_CAMERA_CID_AE_ROI_SET,
 	.name = "ae roi set",
 	.type = V4L2_CTRL_TYPE_U8,
 	.dims = {8},
@@ -3646,9 +3646,9 @@ static const struct v4l2_ctrl_config ds5_ctrl_ae_roi_set = {
 	.step = 1,
 };
 
-static const struct v4l2_ctrl_config ds5_ctrl_ae_setpoint_get = {
-	.ops = &ds5_ctrl_ops,
-	.id = DS5_CAMERA_CID_AE_SETPOINT_GET,
+static const struct v4l2_ctrl_config d5x_ctrl_ae_setpoint_get = {
+	.ops = &d5x_ctrl_ops,
+	.id = D5X_CAMERA_CID_AE_SETPOINT_GET,
 	.name = "ae setpoint get",
 	.type = V4L2_CTRL_TYPE_INTEGER,
 	.flags = V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_READ_ONLY,
@@ -3657,9 +3657,9 @@ static const struct v4l2_ctrl_config ds5_ctrl_ae_setpoint_get = {
 	.step = 1,
 };
 
-static const struct v4l2_ctrl_config ds5_ctrl_ae_setpoint_set = {
-	.ops = &ds5_ctrl_ops,
-	.id = DS5_CAMERA_CID_AE_SETPOINT_SET,
+static const struct v4l2_ctrl_config d5x_ctrl_ae_setpoint_set = {
+	.ops = &d5x_ctrl_ops,
+	.id = D5X_CAMERA_CID_AE_SETPOINT_SET,
 	.name = "ae setpoint set",
 	.type = V4L2_CTRL_TYPE_INTEGER,
 	.min = 0,
@@ -3668,9 +3668,9 @@ static const struct v4l2_ctrl_config ds5_ctrl_ae_setpoint_set = {
 	.def = 0,
 };
 
-static const struct v4l2_ctrl_config ds5_ctrl_erb = {
-	.ops = &ds5_ctrl_ops,
-	.id = DS5_CAMERA_CID_ERB,
+static const struct v4l2_ctrl_config d5x_ctrl_erb = {
+	.ops = &d5x_ctrl_ops,
+	.id = D5X_CAMERA_CID_ERB,
 	.name = "ERB eeprom read",
 	.type = V4L2_CTRL_TYPE_U8,
 	.dims = {1020},
@@ -3682,9 +3682,9 @@ static const struct v4l2_ctrl_config ds5_ctrl_erb = {
 	.step = 1,
 };
 
-static const struct v4l2_ctrl_config ds5_ctrl_ewb = {
-	.ops = &ds5_ctrl_ops,
-	.id = DS5_CAMERA_CID_EWB,
+static const struct v4l2_ctrl_config d5x_ctrl_ewb = {
+	.ops = &d5x_ctrl_ops,
+	.id = D5X_CAMERA_CID_EWB,
 	.name = "EWB eeprom write",
 	.type = V4L2_CTRL_TYPE_U8,
 	.dims = {1020},
@@ -3696,12 +3696,12 @@ static const struct v4l2_ctrl_config ds5_ctrl_ewb = {
 	.step = 1,
 };
 
-static const struct v4l2_ctrl_config ds5_ctrl_hwmc = {
-	.ops = &ds5_ctrl_ops,
-	.id = DS5_CAMERA_CID_HWMC,
+static const struct v4l2_ctrl_config d5x_ctrl_hwmc = {
+	.ops = &d5x_ctrl_ops,
+	.id = D5X_CAMERA_CID_HWMC,
 	.name = "HWMC",
 	.type = V4L2_CTRL_TYPE_U8,
-	.dims = {DS5_HWMC_BUFFER_SIZE + 4},
+	.dims = {D5X_HWMC_BUFFER_SIZE + 4},
 	.elem_size = sizeof(u8),
 	.min = 0,
 	.max = 0xFFFFFFFF,
@@ -3710,23 +3710,23 @@ static const struct v4l2_ctrl_config ds5_ctrl_hwmc = {
 	.step = 1,
 };
 
-static const struct v4l2_ctrl_config ds5_ctrl_hwmc_rw = {
-	.ops = &ds5_ctrl_ops,
-	.id = DS5_CAMERA_CID_HWMC_RW,
+static const struct v4l2_ctrl_config d5x_ctrl_hwmc_rw = {
+	.ops = &d5x_ctrl_ops,
+	.id = D5X_CAMERA_CID_HWMC_RW,
 	.name = "HWMC_RW",
 	.type = V4L2_CTRL_TYPE_U8,
-	.dims = {DS5_HWMC_BUFFER_SIZE},
+	.dims = {D5X_HWMC_BUFFER_SIZE},
 	.elem_size = sizeof(u8),
 	.min = 0,
 	.max = 0xFFFFFFFF,
 	.def = 240,
 	.step = 1,
-	.flags = DS5_HWMC_RW_CTRL_FLAGS,
+	.flags = D5X_HWMC_RW_CTRL_FLAGS,
 };
 
-static const struct v4l2_ctrl_config ds5_ctrl_hw_reset = {
-	.ops = &ds5_ctrl_ops,
-	.id = DS5_CAMERA_CID_HW_RESET,
+static const struct v4l2_ctrl_config d5x_ctrl_hw_reset = {
+	.ops = &d5x_ctrl_ops,
+	.id = D5X_CAMERA_CID_HW_RESET,
 	.name = "HW Reset",
 	.type = V4L2_CTRL_TYPE_BUTTON,
 	.min = 0,
@@ -3738,17 +3738,17 @@ static const struct v4l2_ctrl_config ds5_ctrl_hw_reset = {
 
 /* Sync mode menu arrays for different camera platforms */
 static const char * const sync_mode_menu_full[] = {
-	[DS5_SYNC_MODE_DEFAULT]       = "Default",
-	[DS5_SYNC_MODE_MASTER]        = "Master",
-	[DS5_SYNC_MODE_SLAVE]         = "Slave",
-	[DS5_SYNC_MODE_FULL_SLAVE]    = "Full Slave",
-	[DS5_SYNC_MODE_SUB_PREMASTER] = "Sub Pre-Master",
-	[DS5_SYNC_MODE_FULL_MASTER]   = "Full Master",
+	[D5X_SYNC_MODE_DEFAULT]       = "Default",
+	[D5X_SYNC_MODE_MASTER]        = "Master",
+	[D5X_SYNC_MODE_SLAVE]         = "Slave",
+	[D5X_SYNC_MODE_FULL_SLAVE]    = "Full Slave",
+	[D5X_SYNC_MODE_SUB_PREMASTER] = "Sub Pre-Master",
+	[D5X_SYNC_MODE_FULL_MASTER]   = "Full Master",
 };
 
-static struct v4l2_ctrl_config ds5_ctrl_sync_mode = {
-	.ops = &ds5_ctrl_ops,
-	.id = DS5_CAMERA_CID_SYNC_MODE,
+static struct v4l2_ctrl_config d5x_ctrl_sync_mode = {
+	.ops = &d5x_ctrl_ops,
+	.id = D5X_CAMERA_CID_SYNC_MODE,
 	.name = "Camera Sync Mode",
 	.type = V4L2_CTRL_TYPE_MENU,
 	.min = 0,
@@ -3758,9 +3758,9 @@ static struct v4l2_ctrl_config ds5_ctrl_sync_mode = {
 	.flags = V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
 };
 
-static const struct v4l2_ctrl_config ds5_ctrl_pwm = {
-	.ops = &ds5_ctrl_ops,
-	.id = DS5_CAMERA_CID_PWM,
+static const struct v4l2_ctrl_config d5x_ctrl_pwm = {
+	.ops = &d5x_ctrl_ops,
+	.id = D5X_CAMERA_CID_PWM,
 	.name = "PWM Frequency Selector",
 	.type = V4L2_CTRL_TYPE_INTEGER,
 	.min = 0,
@@ -3769,9 +3769,9 @@ static const struct v4l2_ctrl_config ds5_ctrl_pwm = {
 	.def = 1,
 	.flags = V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
 };
-static int ds5_mux_open(struct v4l2_subdev *sd, struct v4l2_subdev_fh *fh)
+static int d5x_mux_open(struct v4l2_subdev *sd, struct v4l2_subdev_fh *fh)
 {
-	struct ds5 *state = v4l2_get_subdevdata(sd);
+	struct d5x *state = v4l2_get_subdevdata(sd);
 
 	dev_dbg(sd->dev, "%s(): %s (%p)\n", __func__, sd->name, fh);
 
@@ -3788,9 +3788,9 @@ static int ds5_mux_open(struct v4l2_subdev *sd, struct v4l2_subdev_fh *fh)
 	return 0;
 };
 
-static int ds5_mux_close(struct v4l2_subdev *sd, struct v4l2_subdev_fh *fh)
+static int d5x_mux_close(struct v4l2_subdev *sd, struct v4l2_subdev_fh *fh)
 {
-	struct ds5 *state = v4l2_get_subdevdata(sd);
+	struct d5x *state = v4l2_get_subdevdata(sd);
 
 	dev_dbg(sd->dev, "%s(): %s (%p)\n", __func__, sd->name, fh);
 	mutex_lock(&state->lock);
@@ -3799,83 +3799,83 @@ static int ds5_mux_close(struct v4l2_subdev *sd, struct v4l2_subdev_fh *fh)
 	return 0;
 };
 
-static const struct v4l2_subdev_internal_ops ds5_sensor_internal_ops = {
-	.open = ds5_mux_open,
-	.close = ds5_mux_close,
+static const struct v4l2_subdev_internal_ops d5x_sensor_internal_ops = {
+	.open = d5x_mux_open,
+	.close = d5x_mux_close,
 };
 
-static void ds5_init_ds5_dev(struct ds5 *state, struct ds5_dev *ds5_dev)
+static void d5x_init_d5x_dev(struct d5x *state, struct d5x_dev *d5x_dev)
 {
-	state->ds5_dev = ds5_dev;
-	mutex_lock(&ds5_dev->lock);
-	ds5_dev->ds5_primary = state;
-	ds5_dev->cached_device_type = DS5_DEVICE_TYPE_UNKNOWN;
-	ds5_dev->sync_mode = DS5_SYNC_MODE_DEFAULT;
-	mutex_unlock(&ds5_dev->lock);
-	ds5_reset_streaming_flags(ds5_dev);
+	state->d5x_dev = d5x_dev;
+	mutex_lock(&d5x_dev->lock);
+	d5x_dev->d5x_primary = state;
+	d5x_dev->cached_device_type = D5X_DEVICE_TYPE_UNKNOWN;
+	d5x_dev->sync_mode = D5X_SYNC_MODE_DEFAULT;
+	mutex_unlock(&d5x_dev->lock);
+	d5x_reset_streaming_flags(d5x_dev);
 }
 
 #ifdef CONFIG_VIDEO_D5XX_SERDES
-static int ds5_setup_and_link(struct ds5 *state)
+static int d5x_setup_and_link(struct d5x *state)
 {
 	int i;
 	int err = 0;
 	struct device *dev = &state->client->dev;
 
 	mutex_lock(&serdes_lock__);
-	ds5_init_global_slots_once();
-	state->ds5_dev = NULL;
-	/* Look for existing DS5 instances */
-	for (i = 0; i < MAX_DS5_NUM; i++) {
+	d5x_init_global_slots_once();
+	state->d5x_dev = NULL;
+	/* Look for existing D5xx instances. */
+	for (i = 0; i < MAX_D5X_NUM; i++) {
 		bool match;
 
-		mutex_lock(&ds5_inited[i].lock);
-		match = ds5_inited[i].ds5_primary &&
-			ds5_inited[i].ds5_primary->ser_dev == state->ser_dev;
-		mutex_unlock(&ds5_inited[i].lock);
+		mutex_lock(&d5x_inited[i].lock);
+		match = d5x_inited[i].d5x_primary &&
+			d5x_inited[i].d5x_primary->ser_dev == state->ser_dev;
+		mutex_unlock(&d5x_inited[i].lock);
 		if (match) { /* Same camera, different stream instance. */
 			state->serdes_primary = false;
-			state->ds5_dev = &ds5_inited[i];
+			state->d5x_dev = &d5x_inited[i];
 			break;
 		}
 	}
-	if (NULL == state->ds5_dev) {
-		/* First stream instance for this camera, setup and link new DS5. */
-		for (i = 0; i < MAX_DS5_NUM; i++) {
+	if (NULL == state->d5x_dev) {
+		/* First stream instance for this camera: set up and link a new D5xx. */
+		for (i = 0; i < MAX_D5X_NUM; i++) {
 			bool free_slot;
 
-			mutex_lock(&ds5_inited[i].lock);
-			free_slot = (NULL == ds5_inited[i].ds5_primary);
-			mutex_unlock(&ds5_inited[i].lock);
+			mutex_lock(&d5x_inited[i].lock);
+			free_slot = (NULL == d5x_inited[i].d5x_primary);
+			mutex_unlock(&d5x_inited[i].lock);
 			if (free_slot) {
 				int j;
-				ds5_init_ds5_dev(state, &ds5_inited[i]);
+				d5x_init_d5x_dev(state, &d5x_inited[i]);
 				state->serdes_primary = true;
 				/* Look for matching deserializer */
-				state->ds5_dev->dser_control = NULL;
+				state->d5x_dev->dser_control = NULL;
 				for (j = 0; j < MAX_DSER_NUM; j++) {
 					mutex_lock(&dser_inited[j].lock);
 					if (dser_inited[j].dser_dev == state->dser_dev)
-						state->ds5_dev->dser_control = &dser_inited[j];
+						state->d5x_dev->dser_control = &dser_inited[j];
 					mutex_unlock(&dser_inited[j].lock);
-					if (state->ds5_dev->dser_control)
+					if (state->d5x_dev->dser_control)
 						break;
 				}
-				if (NULL == state->ds5_dev->dser_control) {
+				if (NULL == state->d5x_dev->dser_control) {
 				/* Setup and link new deserializer */
 					for (j = 0; j < MAX_DSER_NUM; j++) {
 						mutex_lock(&dser_inited[j].lock);
 						if (NULL == dser_inited[j].dser_dev) {
 							dser_inited[j].dser_dev = state->dser_dev;
 							dser_inited[j].datapath_armed = false;
-							state->ds5_dev->dser_control = &dser_inited[j];
+							state->d5x_dev->dser_control = &dser_inited[j];
 						}
 						mutex_unlock(&dser_inited[j].lock);
-						if (state->ds5_dev->dser_control)
+						if (state->d5x_dev->dser_control)
 							break;
 					}
 				}
-				if (NULL == state->ds5_dev->dser_control) {
+				if (NULL == state->d5x_dev->dser_control) {
 					dev_err(dev, "cannot handle more than %d deserializers\n", MAX_DSER_NUM);
 					err = -ENOSPC;
 					goto out_unlock;
@@ -3886,9 +3886,9 @@ static int ds5_setup_and_link(struct ds5 *state)
 			}
 		}
 	}
-	if (NULL == state->ds5_dev) {
+	if (NULL == state->d5x_dev) {
 		err = -ENOSPC;
-		dev_err(dev, "cannot handle more than %d DS5 cameras\n", MAX_DS5_NUM);
+		dev_err(dev, "cannot handle more than %d D5xx cameras\n", MAX_D5X_NUM);
 	}
 
 out_unlock:
@@ -3903,7 +3903,7 @@ out_unlock:
  * link.
  */
 #ifdef CONFIG_OF
-static int ds5_board_setup(struct ds5 *state)
+static int d5x_board_setup(struct d5x *state)
 {
 	struct device *dev = &state->client->dev;
 	struct device_node *node = dev->of_node;
@@ -4061,13 +4061,13 @@ static int ds5_board_setup(struct ds5 *state)
 	state->g_ctx.num_csi_lanes = value;
 	state->g_ctx.s_dev = dev;
 
-	err = ds5_setup_and_link(state);
+	err = d5x_setup_and_link(state);
 error:
 	return err;
 }
 #else /* CONFIG_OF */
 
-static int ds5_board_setup(struct ds5 *state)
+static int d5x_board_setup(struct d5x *state)
 {
 	struct device *dev = &state->client->dev;
 	struct d4xx_pdata *pdata = dev->platform_data;
@@ -4101,12 +4101,12 @@ static int ds5_board_setup(struct ds5 *state)
 
 	/* look for already registered max96724, use same context if found */
 	mutex_lock(&serdes_lock__);
-	ds5_init_global_slots_once();
-	for (i = 0; i < MAX_DS5_NUM; i++) {
-		struct ds5 *primary;
+	d5x_init_global_slots_once();
+	for (i = 0; i < MAX_D5X_NUM; i++) {
+		struct d5x *primary;
 
-		mutex_lock(&ds5_inited[i].lock);
-		primary = ds5_inited[i].ds5_primary;
+		mutex_lock(&d5x_inited[i].lock);
+		primary = d5x_inited[i].d5x_primary;
 		if (primary && primary->dser_i2c) {
 			dev_info(dev, "MAX96724 found device on %d@0x%x\n",
 				primary->dser_i2c->adapter->nr, primary->dser_i2c->addr);
@@ -4117,7 +4117,7 @@ static int ds5_board_setup(struct ds5 *state)
 				state->aggregated = 1;
 			}
 		}
-		mutex_unlock(&ds5_inited[i].lock);
+		mutex_unlock(&d5x_inited[i].lock);
 	}
 	mutex_unlock(&serdes_lock__);
 	if (state->aggregated)
@@ -4195,13 +4195,13 @@ static int ds5_board_setup(struct ds5 *state)
 	state->g_ctx.num_csi_lanes = 2;
 	state->g_ctx.s_dev = dev;
 
-	err = ds5_setup_and_link(state);
+	err = d5x_setup_and_link(state);
 error:
 	return err;
 }
 #endif /* CONFIG_OF */
 
-static int ds5_gmsl_serdes_setup(struct ds5 *state)
+static int d5x_gmsl_serdes_setup(struct d5x *state)
 {
 	int err = 0;
 	int des_err = 0;
@@ -4268,7 +4268,7 @@ error:
 	return err;
 }
 
-static void ds5_serdes_cleanup(struct ds5 *state, bool reset_control)
+static void d5x_serdes_cleanup(struct d5x *state, bool reset_control)
 {
 	int ret;
 	bool do_cleanup = false;
@@ -4280,13 +4280,13 @@ static void ds5_serdes_cleanup(struct ds5 *state, bool reset_control)
 	dev = &state->client->dev;
 
 	mutex_lock(&serdes_lock__);
-	if (state->ds5_dev) {
-		mutex_lock(&state->ds5_dev->lock);
-		if (state->ds5_dev->ds5_primary == state) {
-			state->ds5_dev->ds5_primary = NULL;
+	if (state->d5x_dev) {
+		mutex_lock(&state->d5x_dev->lock);
+		if (state->d5x_dev->d5x_primary == state) {
+			state->d5x_dev->d5x_primary = NULL;
 			do_cleanup = true;
 		}
-		mutex_unlock(&state->ds5_dev->lock);
+		mutex_unlock(&state->d5x_dev->lock);
 	}
 
 	if (do_cleanup) {
@@ -4327,13 +4327,13 @@ static void ds5_serdes_cleanup(struct ds5 *state, bool reset_control)
 	state->serdes_primary = false;
 }
 
-static int ds5_serdes_setup(struct ds5 *state)
+static int d5x_serdes_setup(struct d5x *state)
 {
 	int ret = 0;
 	struct i2c_client *c = state->client;
 	bool control_setup_done = false;
 
-	ret = ds5_board_setup(state);
+	ret = d5x_board_setup(state);
 	if (ret) {
 		dev_err(&c->dev, "board setup failed\n");
 		return ret;
@@ -4341,7 +4341,7 @@ static int ds5_serdes_setup(struct ds5 *state)
 
 	/* 
 	 * Peer instance of an already-initialized camera.
-	 * ds5_setup_and_link() found that another instance already set up
+	 * d5x_setup_and_link() found that another instance already set up
 	 * this serializer and marked us non-primary.  Skip SERDES setup
 	 * (pair, register, gmsl init) — the primary already did it.
 	 */
@@ -4364,7 +4364,7 @@ static int ds5_serdes_setup(struct ds5 *state)
 		goto serdes_setup_end;
 	}
 
-	ret = ds5_gmsl_serdes_setup(state);
+	ret = d5x_gmsl_serdes_setup(state);
 	if (ret) {
 		dev_err(&c->dev, "%s gmsl serdes setup failed\n", __func__);
 		goto serdes_setup_end;
@@ -4372,7 +4372,7 @@ static int ds5_serdes_setup(struct ds5 *state)
 	control_setup_done = true;
 
 	/*
-	 * max96717_init_settings is now called inside ds5_gmsl_serdes_setup,
+	 * max96717_init_settings is now called inside d5x_gmsl_serdes_setup,
 	 * after setup_control(ser) but before setup_control(dser) to avoid
 	 * the deserializer one-shot reset disrupting I2C to the serializer.
 	 */
@@ -4427,7 +4427,7 @@ static int ds5_serdes_setup(struct ds5 *state)
 
 serdes_setup_end:
 	if (ret)
-		ds5_serdes_cleanup(state, control_setup_done);
+		d5x_serdes_cleanup(state, control_setup_done);
 
 	return ret;
 }
@@ -4440,14 +4440,14 @@ enum state_sid {
 	MUX_SID = -1
 };
 
-static int ds5_ctrl_init(struct ds5 *state, int sid)
+static int d5x_ctrl_init(struct d5x *state, int sid)
 {
-	const struct v4l2_ctrl_ops *ops = &ds5_ctrl_ops;
-	struct ds5_ctrls *ctrls = &state->ctrls;
+	const struct v4l2_ctrl_ops *ops = &d5x_ctrl_ops;
+	struct d5x_ctrls *ctrls = &state->ctrls;
 	struct v4l2_ctrl_handler *hdl = &ctrls->handler;
 	struct v4l2_subdev *sd = &state->mux.sd.subdev;
 	int ret = -1;
-	struct ds5_sensor *sensor = NULL;
+	struct d5x_sensor *sensor = NULL;
 
 	switch (sid) {
 	case DEPTH_SID:
@@ -4474,7 +4474,7 @@ static int ds5_ctrl_init(struct ds5 *state, int sid)
 	}
 
 	dev_dbg(NULL, "%s():%d sid: %d\n", __func__, __LINE__, sid);
-	ret = v4l2_ctrl_handler_init(hdl, DS5_N_CONTROLS);
+	ret = v4l2_ctrl_handler_init(hdl, D5X_N_CONTROLS);
 	if (ret < 0) {
 		v4l2_err(sd, "cannot init ctrl handler (%d)\n", ret);
 		return ret;
@@ -4482,10 +4482,10 @@ static int ds5_ctrl_init(struct ds5 *state, int sid)
 
 	if (sid == DEPTH_SID || sid == IR_SID) {
 		ctrls->laser_power = v4l2_ctrl_new_custom(hdl,
-						&ds5_ctrl_laser_power,
+						&d5x_ctrl_laser_power,
 						sensor);
 		ctrls->manual_laser_power = v4l2_ctrl_new_custom(hdl,
-						&ds5_ctrl_manual_laser_power,
+						&d5x_ctrl_manual_laser_power,
 						sensor);
 	}
 
@@ -4548,33 +4548,33 @@ static int ds5_ctrl_init(struct ds5 *state, int sid)
 
 	/* Add these after v4l2_ctrl_handler_setup so they won't be set up */
 	if (sid >= DEPTH_SID && sid < IMU_SID) {
-		ctrls->log = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_log, sensor);
-		ctrls->fw_version = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_fw_version, sensor);
+		ctrls->log = v4l2_ctrl_new_custom(hdl, &d5x_ctrl_log, sensor);
+		ctrls->fw_version = v4l2_ctrl_new_custom(hdl, &d5x_ctrl_fw_version, sensor);
 		ctrls->device_type =
-				v4l2_ctrl_new_custom(hdl, &ds5_ctrl_device_type, sensor);
-		ctrls->gvd = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_gvd, sensor);
+				v4l2_ctrl_new_custom(hdl, &d5x_ctrl_device_type, sensor);
+		ctrls->gvd = v4l2_ctrl_new_custom(hdl, &d5x_ctrl_gvd, sensor);
 		ctrls->get_depth_calib =
-				v4l2_ctrl_new_custom(hdl, &ds5_ctrl_get_depth_calib, sensor);
+				v4l2_ctrl_new_custom(hdl, &d5x_ctrl_get_depth_calib, sensor);
 		ctrls->set_depth_calib =
-				v4l2_ctrl_new_custom(hdl, &ds5_ctrl_set_depth_calib, sensor);
+				v4l2_ctrl_new_custom(hdl, &d5x_ctrl_set_depth_calib, sensor);
 		ctrls->get_coeff_calib =
-				v4l2_ctrl_new_custom(hdl, &ds5_ctrl_get_coeff_calib, sensor);
+				v4l2_ctrl_new_custom(hdl, &d5x_ctrl_get_coeff_calib, sensor);
 		ctrls->set_coeff_calib =
-				v4l2_ctrl_new_custom(hdl, &ds5_ctrl_set_coeff_calib, sensor);
-		ctrls->ae_roi_get = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_ae_roi_get, sensor);
-		ctrls->ae_roi_set = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_ae_roi_set, sensor);
+				v4l2_ctrl_new_custom(hdl, &d5x_ctrl_set_coeff_calib, sensor);
+		ctrls->ae_roi_get = v4l2_ctrl_new_custom(hdl, &d5x_ctrl_ae_roi_get, sensor);
+		ctrls->ae_roi_set = v4l2_ctrl_new_custom(hdl, &d5x_ctrl_ae_roi_set, sensor);
 		ctrls->ae_setpoint_get =
-				v4l2_ctrl_new_custom(hdl, &ds5_ctrl_ae_setpoint_get, sensor);
+				v4l2_ctrl_new_custom(hdl, &d5x_ctrl_ae_setpoint_get, sensor);
 		ctrls->ae_setpoint_set =
-				v4l2_ctrl_new_custom(hdl, &ds5_ctrl_ae_setpoint_set, sensor);
-		ctrls->erb = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_erb, sensor);
-		ctrls->ewb = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_ewb, sensor);
-		ctrls->hwmc = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_hwmc, sensor);
-		ctrls->hwmc_rw = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_hwmc_rw, sensor);
+				v4l2_ctrl_new_custom(hdl, &d5x_ctrl_ae_setpoint_set, sensor);
+		ctrls->erb = v4l2_ctrl_new_custom(hdl, &d5x_ctrl_erb, sensor);
+		ctrls->ewb = v4l2_ctrl_new_custom(hdl, &d5x_ctrl_ewb, sensor);
+		ctrls->hwmc = v4l2_ctrl_new_custom(hdl, &d5x_ctrl_hwmc, sensor);
+		ctrls->hwmc_rw = v4l2_ctrl_new_custom(hdl, &d5x_ctrl_hwmc_rw, sensor);
 
 #ifdef V4L2_CTRL_FLAG_DYNAMIC_ARRAY
 		if (!hdl->error && ctrls->hwmc_rw) {
-			ret = ds5_prime_hwmc_rw_ctrl(ctrls->hwmc_rw);
+			ret = d5x_prime_hwmc_rw_ctrl(ctrls->hwmc_rw);
 			if (ret) {
 				v4l2_err(sd, "cannot prime HWMC_RW control (%d)\n", ret);
 				v4l2_ctrl_handler_free(hdl);
@@ -4582,16 +4582,16 @@ static int ds5_ctrl_init(struct ds5 *state, int sid)
 			}
 		}
 #endif
-		v4l2_ctrl_new_custom(hdl, &ds5_ctrl_hw_reset, sensor);
+		v4l2_ctrl_new_custom(hdl, &d5x_ctrl_hw_reset, sensor);
 	}
 	/* DEPTH custom */
 	if (sid == DEPTH_SID) {
-		ctrls->sync_mode = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_sync_mode, sensor);
-		v4l2_ctrl_new_custom(hdl, &ds5_ctrl_pwm, sensor);
+		ctrls->sync_mode = v4l2_ctrl_new_custom(hdl, &d5x_ctrl_sync_mode, sensor);
+		v4l2_ctrl_new_custom(hdl, &d5x_ctrl_pwm, sensor);
 	}
 	/* IMU custom */
 	if (sid == IMU_SID)
-		ctrls->fw_version = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_fw_version, sensor);
+		ctrls->fw_version = v4l2_ctrl_new_custom(hdl, &d5x_ctrl_fw_version, sensor);
 
 	switch (sid) {
 	case DEPTH_SID:
@@ -4628,8 +4628,8 @@ static int ds5_ctrl_init(struct ds5 *state, int sid)
 	return 0;
 }
 
-static int ds5_sensor_init(struct i2c_client *c, struct ds5 *state,
-		struct ds5_sensor *sensor, const struct v4l2_subdev_ops *ops,
+static int d5x_sensor_init(struct i2c_client *c, struct d5x *state,
+		struct d5x_sensor *sensor, const struct v4l2_subdev_ops *ops,
 		const char *name)
 {
 	struct v4l2_subdev *sd = &sensor->sd;
@@ -4646,7 +4646,7 @@ static int ds5_sensor_init(struct i2c_client *c, struct ds5 *state,
 	/* See tegracam_v4l2.c tegracam_v4l2subdev_register() */
 	/* Set owner to NULL so we can unload the driver module */
 	sd->owner = NULL;
-	sd->internal_ops = &ds5_sensor_internal_ops;
+	sd->internal_ops = &d5x_sensor_internal_ops;
 	sd->grp_id = *dev_num;
 	v4l2_set_subdevdata(sd, state);
 #ifndef CONFIG_OF
@@ -4655,9 +4655,9 @@ static int ds5_sensor_init(struct i2c_client *c, struct ds5 *state,
 	 */
 	if (state->aggregated & 1)
 		suffix += 4;
-	snprintf(sd->name, sizeof(sd->name), DS5_DRIVER_NAME_SENSOR " %s %c", name, suffix);
+	snprintf(sd->name, sizeof(sd->name), D5X_DRIVER_NAME_SENSOR " %s %c", name, suffix);
 #else
-	snprintf(sd->name, sizeof(sd->name), DS5_DRIVER_NAME_SENSOR " %s %d-%04x",
+	snprintf(sd->name, sizeof(sd->name), D5X_DRIVER_NAME_SENSOR " %s %d-%04x",
 		 name, i2c_adapter_id(c->adapter), c->addr);
 #endif
 
@@ -4669,7 +4669,7 @@ static int ds5_sensor_init(struct i2c_client *c, struct ds5 *state,
 	return media_entity_pads_init(entity, 1, pad);
 }
 
-static int ds5_sensor_register(struct ds5 *state, struct ds5_sensor *sensor)
+static int d5x_sensor_register(struct d5x *state, struct d5x_sensor *sensor)
 {
 	struct v4l2_subdev *sd = &sensor->sd;
 	struct media_entity *entity = &sensor->sd.entity;
@@ -4700,44 +4700,44 @@ e_sd:
 	return ret;
 }
 
-static void ds5_sensor_remove(struct ds5_sensor *sensor)
+static void d5x_sensor_remove(struct d5x_sensor *sensor)
 {
 	v4l2_device_unregister_subdev(&sensor->sd);
 
 	media_entity_cleanup(&sensor->sd.entity);
 }
 
-static int ds5_depth_init(struct i2c_client *c, struct ds5 *state)
+static int d5x_depth_init(struct i2c_client *c, struct d5x *state)
 {
 	/* Which mux pad we're connecting to */
-	state->depth.sensor.mux_pad = DS5_MUX_PAD_DEPTH;
-	return ds5_sensor_init(c, state, &state->depth.sensor,
-		       &ds5_subdev_ops, "depth");
+	state->depth.sensor.mux_pad = D5X_MUX_PAD_DEPTH;
+	return d5x_sensor_init(c, state, &state->depth.sensor,
+		       &d5x_subdev_ops, "depth");
 }
 
-static int ds5_ir_init(struct i2c_client *c, struct ds5 *state)
+static int d5x_ir_init(struct i2c_client *c, struct d5x *state)
 {
-	state->ir.sensor.mux_pad = DS5_MUX_PAD_IR;
-	return ds5_sensor_init(c, state, &state->ir.sensor,
-		       &ds5_subdev_ops, "ir");
+	state->ir.sensor.mux_pad = D5X_MUX_PAD_IR;
+	return d5x_sensor_init(c, state, &state->ir.sensor,
+		       &d5x_subdev_ops, "ir");
 }
 
-static int ds5_rgb_init(struct i2c_client *c, struct ds5 *state)
+static int d5x_rgb_init(struct i2c_client *c, struct d5x *state)
 {
-	state->rgb.sensor.mux_pad = DS5_MUX_PAD_RGB;
-	return ds5_sensor_init(c, state, &state->rgb.sensor,
-		       &ds5_subdev_ops, "rgb");
+	state->rgb.sensor.mux_pad = D5X_MUX_PAD_RGB;
+	return d5x_sensor_init(c, state, &state->rgb.sensor,
+		       &d5x_subdev_ops, "rgb");
 }
 
-static int ds5_imu_init(struct i2c_client *c, struct ds5 *state)
+static int d5x_imu_init(struct i2c_client *c, struct d5x *state)
 {
-	state->imu.sensor.mux_pad = DS5_MUX_PAD_IMU;
-	return ds5_sensor_init(c, state, &state->imu.sensor,
-		       &ds5_subdev_ops, "imu");
+	state->imu.sensor.mux_pad = D5X_MUX_PAD_IMU;
+	return d5x_sensor_init(c, state, &state->imu.sensor,
+		       &d5x_subdev_ops, "imu");
 }
 
 /* No locking needed */
-static int ds5_mux_enum_mbus_code(struct v4l2_subdev *sd,
+static int d5x_mux_enum_mbus_code(struct v4l2_subdev *sd,
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
 				     struct v4l2_subdev_pad_config *cfg,
 #else
@@ -4745,26 +4745,26 @@ static int ds5_mux_enum_mbus_code(struct v4l2_subdev *sd,
 #endif
 				  struct v4l2_subdev_mbus_code_enum *mce)
 {
-	struct ds5 *state = container_of(sd, struct ds5, mux.sd.subdev);
+	struct d5x *state = container_of(sd, struct d5x, mux.sd.subdev);
 	struct v4l2_subdev_mbus_code_enum tmp = *mce;
 	struct v4l2_subdev *remote_sd;
 	int ret = -1;
 
 	dev_dbg(&state->client->dev, "%s(): %s \n", __func__, sd->name);
 	switch (mce->pad) {
-	case DS5_MUX_PAD_IR:
+	case D5X_MUX_PAD_IR:
 		remote_sd = &state->ir.sensor.sd;
 		break;
-	case DS5_MUX_PAD_DEPTH:
+	case D5X_MUX_PAD_DEPTH:
 		remote_sd = &state->depth.sensor.sd;
 		break;
-	case DS5_MUX_PAD_RGB:
+	case D5X_MUX_PAD_RGB:
 		remote_sd = &state->rgb.sensor.sd;
 		break;
-	case DS5_MUX_PAD_IMU:
+	case D5X_MUX_PAD_IMU:
 		remote_sd = &state->imu.sensor.sd;
 		break;
-	case DS5_MUX_PAD_EXTERNAL:
+	case D5X_MUX_PAD_EXTERNAL:
 		if (mce->index >= state->ir.sensor.n_formats +
 				state->depth.sensor.n_formats)
 			return -EINVAL;
@@ -4797,30 +4797,30 @@ static int ds5_mux_enum_mbus_code(struct v4l2_subdev *sd,
 		remote_sd = &state->imu.sensor.sd;
 	/* Locks internally */
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
-	ret = ds5_sensor_enum_mbus_code(remote_sd, cfg, &tmp);
+	ret = d5x_sensor_enum_mbus_code(remote_sd, cfg, &tmp);
 #else
-	ret = ds5_sensor_enum_mbus_code(remote_sd, v4l2_state, &tmp);
+	ret = d5x_sensor_enum_mbus_code(remote_sd, v4l2_state, &tmp);
 #endif
 	if (!ret)
 		mce->code = tmp.code;
 
 	return ret;
 }
-static int ds5_state_to_pad(struct ds5 *state) {
+static int d5x_state_to_pad(struct d5x *state) {
 	int pad = -1;
 	if (state->is_depth)
-		pad = DS5_MUX_PAD_DEPTH;
+		pad = D5X_MUX_PAD_DEPTH;
 	if (state->is_y8)
-		pad = DS5_MUX_PAD_IR;
+		pad = D5X_MUX_PAD_IR;
 	if (state->is_rgb)
-		pad = DS5_MUX_PAD_RGB;
+		pad = D5X_MUX_PAD_RGB;
 	if (state->is_imu)
-		pad = DS5_MUX_PAD_IMU;
+		pad = D5X_MUX_PAD_IMU;
 	return pad;
 }
 
 /* No locking needed */
-static int ds5_mux_enum_frame_size(struct v4l2_subdev *sd,
+static int d5x_mux_enum_frame_size(struct v4l2_subdev *sd,
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
 				     struct v4l2_subdev_pad_config *cfg,
 #else
@@ -4828,35 +4828,35 @@ static int ds5_mux_enum_frame_size(struct v4l2_subdev *sd,
 #endif
 				   struct v4l2_subdev_frame_size_enum *fse)
 {
-	struct ds5 *state = container_of(sd, struct ds5, mux.sd.subdev);
+	struct d5x *state = container_of(sd, struct d5x, mux.sd.subdev);
 	struct v4l2_subdev_frame_size_enum tmp = *fse;
 	struct v4l2_subdev *remote_sd;
 	u32 pad = fse->pad;
 	int ret = -1;
 
 	tmp.pad = 0;
-	pad = ds5_state_to_pad(state);
+	pad = d5x_state_to_pad(state);
 
 	switch (pad) {
-	case DS5_MUX_PAD_IR:
+	case D5X_MUX_PAD_IR:
 		remote_sd = &state->ir.sensor.sd;
 		break;
-	case DS5_MUX_PAD_DEPTH:
+	case D5X_MUX_PAD_DEPTH:
 		remote_sd = &state->depth.sensor.sd;
 		break;
-	case DS5_MUX_PAD_RGB:
+	case D5X_MUX_PAD_RGB:
 		remote_sd = &state->rgb.sensor.sd;
 		break;
-	case DS5_MUX_PAD_IMU:
+	case D5X_MUX_PAD_IMU:
 		remote_sd = &state->imu.sensor.sd;
 		break;
-	case DS5_MUX_PAD_EXTERNAL:
+	case D5X_MUX_PAD_EXTERNAL:
 		/*
 		 * Assume, that different sensors don't support the same formats
 		 * Try the Depth sensor first, then the Motion Tracker
 		 */
 		remote_sd = &state->depth.sensor.sd;
-		ret = ds5_sensor_enum_frame_size(remote_sd, NULL, &tmp);
+		ret = d5x_sensor_enum_frame_size(remote_sd, NULL, &tmp);
 		if (!ret) {
 			*fse = tmp;
 			fse->pad = pad;
@@ -4870,7 +4870,7 @@ static int ds5_mux_enum_frame_size(struct v4l2_subdev *sd,
 	}
 
 	/* Locks internally */
-	ret = ds5_sensor_enum_frame_size(remote_sd, NULL, &tmp);
+	ret = d5x_sensor_enum_frame_size(remote_sd, NULL, &tmp);
 	if (!ret) {
 		*fse = tmp;
 		fse->pad = pad;
@@ -4880,7 +4880,7 @@ static int ds5_mux_enum_frame_size(struct v4l2_subdev *sd,
 }
 
 /* No locking needed */
-static int ds5_mux_enum_frame_interval(struct v4l2_subdev *sd,
+static int d5x_mux_enum_frame_interval(struct v4l2_subdev *sd,
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
 				     struct v4l2_subdev_pad_config *cfg,
 #else
@@ -4888,7 +4888,7 @@ static int ds5_mux_enum_frame_interval(struct v4l2_subdev *sd,
 #endif
 				     struct v4l2_subdev_frame_interval_enum *fie)
 {
-	struct ds5 *state = container_of(sd, struct ds5, mux.sd.subdev);
+	struct d5x *state = container_of(sd, struct d5x, mux.sd.subdev);
 	struct v4l2_subdev_frame_interval_enum tmp = *fie;
 	struct v4l2_subdev *remote_sd;
 	u32 pad = fie->pad;
@@ -4900,28 +4900,28 @@ static int ds5_mux_enum_frame_interval(struct v4l2_subdev *sd,
 			"%s(): pad %d code %x width %d height %d\n",
 			__func__, pad, tmp.code, tmp.width, tmp.height);
 
-	pad = ds5_state_to_pad(state);
+	pad = d5x_state_to_pad(state);
 
 	switch (pad) {
-	case DS5_MUX_PAD_IR:
+	case D5X_MUX_PAD_IR:
 		remote_sd = &state->ir.sensor.sd;
 		break;
-	case DS5_MUX_PAD_DEPTH:
+	case D5X_MUX_PAD_DEPTH:
 		remote_sd = &state->depth.sensor.sd;
 		break;
-	case DS5_MUX_PAD_RGB:
+	case D5X_MUX_PAD_RGB:
 		remote_sd = &state->rgb.sensor.sd;
 		break;
-	case DS5_MUX_PAD_IMU:
+	case D5X_MUX_PAD_IMU:
 		remote_sd = &state->imu.sensor.sd;
 		break;
-	case DS5_MUX_PAD_EXTERNAL:
-		/* Similar to ds5_mux_enum_frame_size() above */
+	case D5X_MUX_PAD_EXTERNAL:
+		/* Similar to d5x_mux_enum_frame_size() above */
 		if (state->is_rgb)
 			remote_sd = &state->rgb.sensor.sd;
 		else
 			remote_sd = &state->ir.sensor.sd;
-		ret = ds5_sensor_enum_frame_interval(remote_sd, NULL, &tmp);
+		ret = d5x_sensor_enum_frame_interval(remote_sd, NULL, &tmp);
 		if (!ret) {
 			*fie = tmp;
 			fie->pad = pad;
@@ -4935,7 +4935,7 @@ static int ds5_mux_enum_frame_interval(struct v4l2_subdev *sd,
 	}
 
 	/* Locks internally */
-	ret = ds5_sensor_enum_frame_interval(remote_sd, NULL, &tmp);
+	ret = d5x_sensor_enum_frame_interval(remote_sd, NULL, &tmp);
 	if (!ret) {
 		*fie = tmp;
 		fie->pad = pad;
@@ -4945,7 +4945,7 @@ static int ds5_mux_enum_frame_interval(struct v4l2_subdev *sd,
 }
 
 /* No locking needed */
-static int ds5_mux_set_fmt(struct v4l2_subdev *sd,
+static int d5x_mux_set_fmt(struct v4l2_subdev *sd,
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
 		struct v4l2_subdev_pad_config *cfg,
 #else
@@ -4953,7 +4953,7 @@ static int ds5_mux_set_fmt(struct v4l2_subdev *sd,
 #endif
 		struct v4l2_subdev_format *fmt)
 {
-	struct ds5 *state = container_of(sd, struct ds5, mux.sd.subdev);
+	struct d5x *state = container_of(sd, struct d5x, mux.sd.subdev);
 	struct v4l2_subdev_format tmp;
 	struct v4l2_subdev *remote_sd;
 	u32 pad;
@@ -4962,7 +4962,7 @@ static int ds5_mux_set_fmt(struct v4l2_subdev *sd,
 	if (!state) return -EINVAL;
 	if (!fmt) return -EINVAL;
 
-	pad = ds5_state_to_pad(state);
+	pad = d5x_state_to_pad(state);
 	tmp = *fmt;
 
 	dev_dbg(sd->dev, "%s(): pad: %x %x: %ux%u\n",
@@ -4970,19 +4970,19 @@ static int ds5_mux_set_fmt(struct v4l2_subdev *sd,
 			fmt->format.width, fmt->format.height);
 
 	switch (pad) {
-	case DS5_MUX_PAD_IR:
+	case D5X_MUX_PAD_IR:
 		remote_sd = &state->ir.sensor.sd;
 		break;
-	case DS5_MUX_PAD_DEPTH:
+	case D5X_MUX_PAD_DEPTH:
 		remote_sd = &state->depth.sensor.sd;
 		break;
-	case DS5_MUX_PAD_RGB:
+	case D5X_MUX_PAD_RGB:
 		remote_sd = &state->rgb.sensor.sd;
 		break;
-	case DS5_MUX_PAD_IMU:
+	case D5X_MUX_PAD_IMU:
 		remote_sd = &state->imu.sensor.sd;
 		break;
-	case DS5_MUX_PAD_EXTERNAL:
+	case D5X_MUX_PAD_EXTERNAL:
 		if (state->is_rgb)
 			remote_sd = &state->rgb.sensor.sd;
 		else
@@ -4996,9 +4996,9 @@ static int ds5_mux_set_fmt(struct v4l2_subdev *sd,
 
 	/* Locks internally */
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
-	ret = ds5_sensor_set_fmt(remote_sd, cfg, &tmp);
+	ret = d5x_sensor_set_fmt(remote_sd, cfg, &tmp);
 #else
-	ret = ds5_sensor_set_fmt(remote_sd, v4l2_state, &tmp);
+	ret = d5x_sensor_set_fmt(remote_sd, v4l2_state, &tmp);
 #endif
 	if (!ret) {
 		*fmt = tmp;
@@ -5008,7 +5008,7 @@ static int ds5_mux_set_fmt(struct v4l2_subdev *sd,
 }
 
 /* No locking needed */
-static int ds5_mux_get_fmt(struct v4l2_subdev *sd,
+static int d5x_mux_get_fmt(struct v4l2_subdev *sd,
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
 		struct v4l2_subdev_pad_config *cfg,
 #else
@@ -5016,36 +5016,36 @@ static int ds5_mux_get_fmt(struct v4l2_subdev *sd,
 #endif
 		struct v4l2_subdev_format *fmt)
 {
-	struct ds5 *state = container_of(sd, struct ds5, mux.sd.subdev);
+	struct d5x *state = container_of(sd, struct d5x, mux.sd.subdev);
 	struct v4l2_subdev_format tmp;
 	struct v4l2_subdev *remote_sd;
 	u32 pad;
 	int ret = 0;
-	struct ds5_sensor *sensor;
+	struct d5x_sensor *sensor;
 
 	if (!state) return -EINVAL;
 	if (!fmt) return -EINVAL;
 
 	sensor = state->mux.last_set;
 	tmp = *fmt;
-	pad = ds5_state_to_pad(state);
+	pad = d5x_state_to_pad(state);
 
-	dev_dbg(sd->dev, "%s(): %u %s %p\n", __func__, pad, ds5_get_sensor_name(state), state->mux.last_set);
+	dev_dbg(sd->dev, "%s(): %u %s %p\n", __func__, pad, d5x_get_sensor_name(state), state->mux.last_set);
 
 	switch (pad) {
-	case DS5_MUX_PAD_IR:
+	case D5X_MUX_PAD_IR:
 		remote_sd = &state->ir.sensor.sd;
 		break;
-	case DS5_MUX_PAD_DEPTH:
+	case D5X_MUX_PAD_DEPTH:
 		remote_sd = &state->depth.sensor.sd;
 		break;
-	case DS5_MUX_PAD_EXTERNAL:
+	case D5X_MUX_PAD_EXTERNAL:
 		remote_sd = &state->mux.last_set->sd;
 		break;
-	case DS5_MUX_PAD_RGB:
+	case D5X_MUX_PAD_RGB:
 		remote_sd = &state->rgb.sensor.sd;
 		break;
-	case DS5_MUX_PAD_IMU:
+	case D5X_MUX_PAD_IMU:
 		remote_sd = &state->imu.sensor.sd;
 		break;
 	default:
@@ -5058,9 +5058,9 @@ static int ds5_mux_get_fmt(struct v4l2_subdev *sd,
 		fmt->format.field, fmt->format.colorspace);
 	/* Locks internally */
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
-	ret = ds5_sensor_get_fmt(remote_sd, cfg, &tmp);
+	ret = d5x_sensor_get_fmt(remote_sd, cfg, &tmp);
 #else
-	ret = ds5_sensor_get_fmt(remote_sd, v4l2_state, &tmp);
+	ret = d5x_sensor_get_fmt(remote_sd, v4l2_state, &tmp);
 #endif
 	if (!ret) {
 		*fmt = tmp;
@@ -5071,19 +5071,19 @@ static int ds5_mux_get_fmt(struct v4l2_subdev *sd,
 }
 
 /* Video ops */
-static int ds5_mux_g_frame_interval(struct v4l2_subdev *sd,
+static int d5x_mux_g_frame_interval(struct v4l2_subdev *sd,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
 		struct v4l2_subdev_state *state,
 #endif
 		struct v4l2_subdev_frame_interval *fi)
 {
-	struct ds5 *ds5_state = container_of(sd, struct ds5, mux.sd.subdev);
-	struct ds5_sensor *sensor = NULL;
+	struct d5x *d5x_state = container_of(sd, struct d5x, mux.sd.subdev);
+	struct d5x_sensor *sensor = NULL;
 
 	if (NULL == sd || NULL == fi)
 		return -EINVAL;
 
-	sensor = ds5_state->mux.last_set;
+	sensor = d5x_state->mux.last_set;
 
 	fi->interval.numerator = 1;
 	fi->interval.denominator = sensor->config.framerate;
@@ -5094,7 +5094,7 @@ static int ds5_mux_g_frame_interval(struct v4l2_subdev *sd,
 	return 0;
 }
 
-static u16 __ds5_probe_framerate(const struct ds5_resolution *res, u16 target)
+static u16 __d5x_probe_framerate(const struct d5x_resolution *res, u16 target)
 {
 	int i;
 	u16 framerate;
@@ -5108,23 +5108,23 @@ static u16 __ds5_probe_framerate(const struct ds5_resolution *res, u16 target)
 	return res->framerates[res->n_framerates - 1];
 }
 
-static int ds5_mux_s_frame_interval(struct v4l2_subdev *sd,
+static int d5x_mux_s_frame_interval(struct v4l2_subdev *sd,
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0) || LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
 		struct v4l2_subdev_state *state,
 #endif
 		struct v4l2_subdev_frame_interval *fi)
 {
-	struct ds5 *ds5_state = container_of(sd, struct ds5, mux.sd.subdev);
-	struct ds5_sensor *sensor = NULL;
+	struct d5x *d5x_state = container_of(sd, struct d5x, mux.sd.subdev);
+	struct d5x_sensor *sensor = NULL;
 	u16 framerate = 1;
 
 	if (NULL == sd || NULL == fi || fi->interval.numerator == 0)
 		return -EINVAL;
 
-	sensor = ds5_state->mux.last_set;
+	sensor = d5x_state->mux.last_set;
 
 	framerate = fi->interval.denominator / fi->interval.numerator;
-	framerate = __ds5_probe_framerate(sensor->config.resolution, framerate);
+	framerate = __d5x_probe_framerate(sensor->config.resolution, framerate);
 	sensor->config.framerate = framerate;
 	fi->interval.numerator = 1;
 	fi->interval.denominator = framerate;
@@ -5134,46 +5134,46 @@ static int ds5_mux_s_frame_interval(struct v4l2_subdev *sd,
 	return 0;
 }
 
-static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
+static int d5x_mux_s_stream(struct v4l2_subdev *sd, int on)
 {
-	struct ds5 *state = container_of(sd, struct ds5, mux.sd.subdev);
-#if DS5_BYPASS_CAMERA_I2C
-	struct ds5_sensor *sensor = state->mux.last_set;
+	struct d5x *state = container_of(sd, struct d5x, mux.sd.subdev);
+#if D5X_BYPASS_CAMERA_I2C
+	struct d5x_sensor *sensor = state->mux.last_set;
 	bool *streaming_flag = NULL;
 	int ret;
 
 	dev_info(&state->client->dev,
-		"ds5_mux_s_stream(): BYPASS mode - SERDES pipe setup only, on=%d\n", on);
+		"d5x_mux_s_stream(): BYPASS mode - SERDES pipe setup only, on=%d\n", on);
 
 	if (state->is_depth)
-		streaming_flag = &state->ds5_dev->depth_streaming;
+		streaming_flag = &state->d5x_dev->depth_streaming;
 	else if (state->is_rgb)
-		streaming_flag = &state->ds5_dev->rgb_streaming;
+		streaming_flag = &state->d5x_dev->rgb_streaming;
 	else if (state->is_y8)
-		streaming_flag = &state->ds5_dev->ir_streaming;
+		streaming_flag = &state->d5x_dev->ir_streaming;
 	else if (state->is_imu)
-		streaming_flag = &state->ds5_dev->imu_streaming;
+		streaming_flag = &state->d5x_dev->imu_streaming;
 	else
 		return -EINVAL;
 
 	if (sensor->streaming == on)
 		return 0;
 
-	mutex_lock(&state->ds5_dev->lock);
+	mutex_lock(&state->d5x_dev->lock);
 	*streaming_flag = on;
-	mutex_unlock(&state->ds5_dev->lock);
+	mutex_unlock(&state->d5x_dev->lock);
 	sensor->streaming = on;
 
 	if (on) {
 		/* Configure SERDES pipes - this is essential for MIPI data flow */
-		ret = ds5_configure(state);
+		ret = d5x_configure(state);
 		if (ret < 0) {
 			dev_err(&state->client->dev,
-				"BYPASS: ds5_configure (SERDES pipe setup) failed: %d\n", ret);
+				"BYPASS: d5x_configure (SERDES pipe setup) failed: %d\n", ret);
 			sensor->streaming = false;
-			mutex_lock(&state->ds5_dev->lock);
+			mutex_lock(&state->d5x_dev->lock);
 			*streaming_flag = false;
-			mutex_unlock(&state->ds5_dev->lock);
+			mutex_unlock(&state->d5x_dev->lock);
 			return ret;
 		}
 #ifdef CONFIG_VIDEO_D5XX_SERDES
@@ -5182,9 +5182,9 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		 * immediately.  Re-assert it here after reset/recovery, then
 		 * start the DES internal FSYNC source at the negotiated FPS.
 		 */
-		if (ds5_sync_mode_uses_esync(state)) {
-			ds5_set_ser_esync_tunneling(state, true);
-			ds5_set_des_fsync(state, true);
+		if (d5x_sync_mode_uses_esync(state)) {
+			d5x_set_ser_esync_tunneling(state, true);
+			d5x_set_des_fsync(state, true);
 		}
 #endif
 	} else {
@@ -5195,7 +5195,7 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 			if (state->dser_ops->release_pipe(state->dser_dev, sensor->pipe_id) < 0)
 				dev_warn(&state->client->dev, "release pipe failed\n");
 			else {
-				ds5_disarm_dser_datapath_if_idle(state);
+				d5x_disarm_dser_datapath_if_idle(state);
 				sensor->pipe_id = PIPE_NOT_CONFIGURED;
 				sensor->pipe_reapply_gen = 0;
 			}
@@ -5206,26 +5206,26 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		 * stops.  Serializer GPIO tunneling remains tied to
 		 * camera_sync_mode and is disabled by the control callback.
 		 */
-		if (ds5_sync_mode_uses_esync(state) &&
-		    !state->ds5_dev->depth_streaming &&
-		    !state->ds5_dev->rgb_streaming &&
-		    !state->ds5_dev->ir_streaming &&
-		    !state->ds5_dev->imu_streaming)
-			ds5_set_des_fsync(state, false);
+		if (d5x_sync_mode_uses_esync(state) &&
+		    !state->d5x_dev->depth_streaming &&
+		    !state->d5x_dev->rgb_streaming &&
+		    !state->d5x_dev->ir_streaming &&
+		    !state->d5x_dev->imu_streaming)
+			d5x_set_des_fsync(state, false);
 #endif
 	}
 	return 0;
 #else
 	u16 streaming, status;
 	int ret = 0;
-	unsigned int i = 0, ds5_config_retries = MAX_DS5_CONFIG_RETRIES;
+	unsigned int i = 0, d5x_config_retries = MAX_D5X_CONFIG_RETRIES;
 	unsigned long timeout, ts;
 	int restore_val = 0;
 	u16 stream_cmd;
 	u16 config_status_base, stream_status_base, stream_id, vc_id;
-	struct ds5_sensor *sensor = state->mux.last_set;
+	struct d5x_sensor *sensor = state->mux.last_set;
 	u16 expected_streaming_state;
-	bool ds5_config_done = !on; /* for stop, skip config */
+	bool d5x_config_done = !on; /* for stop, skip config */
 	bool reset_invalidated = false;
 	bool stream_ctrl_locked = false;
 	bool command_read_status;
@@ -5235,32 +5235,32 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 #else
 	int cur_dser = 0;
 #endif
-	int cur_ds5 = atomic_read(ds5_get_reset_gen(state));
+	int cur_d5x = atomic_read(d5x_get_reset_gen(state));
 
 	if (state->is_depth) {
-		config_status_base = DS5_DEPTH_CONFIG_STATUS;
-		stream_status_base = DS5_DEPTH_STREAM_STATUS;
-		stream_id = DS5_STREAM_DEPTH;
+		config_status_base = D5X_DEPTH_CONFIG_STATUS;
+		stream_status_base = D5X_DEPTH_STREAM_STATUS;
+		stream_id = D5X_STREAM_DEPTH;
 		vc_id = 0;
-		streaming_flag = &state->ds5_dev->depth_streaming;
+		streaming_flag = &state->d5x_dev->depth_streaming;
 	} else if (state->is_rgb) {
-		config_status_base = DS5_RGB_CONFIG_STATUS;
-		stream_status_base = DS5_RGB_STREAM_STATUS;
-		stream_id = DS5_STREAM_RGB;
+		config_status_base = D5X_RGB_CONFIG_STATUS;
+		stream_status_base = D5X_RGB_STREAM_STATUS;
+		stream_id = D5X_STREAM_RGB;
 		vc_id = 1;
-		streaming_flag = &state->ds5_dev->rgb_streaming;
+		streaming_flag = &state->d5x_dev->rgb_streaming;
 	} else if (state->is_y8) {
-		config_status_base = DS5_IR_CONFIG_STATUS;
-		stream_status_base = DS5_IR_STREAM_STATUS;
-		stream_id = DS5_STREAM_IR;
+		config_status_base = D5X_IR_CONFIG_STATUS;
+		stream_status_base = D5X_IR_STREAM_STATUS;
+		stream_id = D5X_STREAM_IR;
 		vc_id = 2;
-		streaming_flag = &state->ds5_dev->ir_streaming;
+		streaming_flag = &state->d5x_dev->ir_streaming;
 	} else if (state->is_imu) {
-		config_status_base = DS5_IMU_CONFIG_STATUS;
-		stream_status_base = DS5_IMU_STREAM_STATUS;
-		stream_id = DS5_STREAM_IMU;
+		config_status_base = D5X_IMU_CONFIG_STATUS;
+		stream_status_base = D5X_IMU_STREAM_STATUS;
+		stream_id = D5X_STREAM_IMU;
 		vc_id = 3;
-		streaming_flag = &state->ds5_dev->imu_streaming;
+		streaming_flag = &state->d5x_dev->imu_streaming;
 	} else {
 		return -EINVAL;
 	}
@@ -5270,7 +5270,7 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 #endif
 #endif
 	dev_dbg(&state->client->dev, "s_stream for stream %s, vc:%d, SENSOR=%s on = %d\n",
-			sensor->sd.name, vc_id, ds5_get_sensor_name(state), on);
+			sensor->sd.name, vc_id, d5x_get_sensor_name(state), on);
 
 	/*
 	 * Lazy invalidation after HW or deserializer reset.
@@ -5278,12 +5278,12 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 	 * state, then update refs.  Must run before the duplicate-call
 	 * guard so a reset-killed stream is not mistaken for "already off".
 	 */
-	if (state->reset_ref_ds5 != cur_ds5
+	if (state->reset_ref_d5x != cur_d5x
 			|| state->reset_ref_dser != cur_dser) {
-		ds5_invalidate_sensor(state, sensor);
+		d5x_invalidate_sensor(state, sensor);
 		sensor->streaming = false;
 		reset_invalidated = true;
-		state->reset_ref_ds5 = cur_ds5;
+		state->reset_ref_d5x = cur_d5x;
 		state->reset_ref_dser = cur_dser;
 	}
 
@@ -5292,13 +5292,13 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		return 0;
 
 	if (on) {
-		stream_cmd = (DS5_STREAM_START | stream_id);
-		expected_streaming_state = DS5_STREAM_STREAMING;
+		stream_cmd = (D5X_STREAM_START | stream_id);
+		expected_streaming_state = D5X_STREAM_STREAMING;
 		status = 0;
 	} else {
-		stream_cmd = (DS5_STREAM_STOP | stream_id);
-		expected_streaming_state = DS5_STREAM_IDLE;
-		status = DS5_STATUS_STREAMING;
+		stream_cmd = (D5X_STREAM_STOP | stream_id);
+		expected_streaming_state = D5X_STREAM_IDLE;
+		status = D5X_STATUS_STREAMING;
 	}
 
 	/* START changes pipeline topology and remains fully serialized. STOP only
@@ -5306,46 +5306,46 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 	 * and polls independently, so control I2C remains usable while another
 	 * HKR data path is stopping. */
 	if (on) {
-		mutex_lock(&state->ds5_dev->stream_ctrl_lock);
+		mutex_lock(&state->d5x_dev->stream_ctrl_lock);
 		stream_ctrl_locked = true;
 	}
 
 	if (on) {
-		ret = ds5_configure(state);
+		ret = d5x_configure(state);
 		if (ret < 0) {
 #ifdef CONFIG_VIDEO_D5XX_SERDES
-			ds5_release_serdes_pipe(state, sensor, "stream configure failure");
+			d5x_release_serdes_pipe(state, sensor, "stream configure failure");
 #endif
-			mutex_unlock(&state->ds5_dev->stream_ctrl_lock);
+			mutex_unlock(&state->d5x_dev->stream_ctrl_lock);
 			stream_ctrl_locked = false;
 			return ret;
 		}
-		ds5_config_done = true;
+		d5x_config_done = true;
 	}
 
 	/* Verify stream is in the expected state before issuing command */
 	ts = jiffies;
-	for (timeout = ts + msecs_to_jiffies(on ? DS5_START_MAX_TIME :
-							 DS5_STOP_MAX_TIME), i = 0;
+	for (timeout = ts + msecs_to_jiffies(on ? D5X_START_MAX_TIME :
+							 D5X_STOP_MAX_TIME), i = 0;
 			time_before(jiffies, timeout);
-			i++, msleep_range(ds5_stream_poll_delay(on, i)))
+			i++, msleep_range(d5x_stream_poll_delay(on, i)))
 	{
-		ret = ds5_read(state, config_status_base, &status);
-		if (ret < 0 || status == DS5_STATUS_UNAVAILABLE ||
-		    (status & ~DS5_STATUS_VALID_MASK))
+		ret = d5x_read(state, config_status_base, &status);
+		if (ret < 0 || status == D5X_STATUS_UNAVAILABLE ||
+		    (status & ~D5X_STATUS_VALID_MASK))
 			continue;
 		/* A recovery STOP may race with an HKR-side teardown that already
 		 * made the stream idle.  Let the common no-op cleanup run now rather
 		 * than waiting the full STOP timeout for a state transition that has
 		 * already happened. */
-		if (!on && !(status & DS5_STATUS_STREAMING))
+		if (!on && !(status & D5X_STATUS_STREAMING))
 			break;
-		if (on == !(status & DS5_STATUS_STREAMING)) {
+		if (on == !(status & D5X_STATUS_STREAMING)) {
 			break;
 		}
 #ifdef CONFIG_VIDEO_D5XX_SERDES
-		if (on && status != DS5_STATUS_UNAVAILABLE &&
-		    (status & DS5_STATUS_STREAMING)) {
+		if (on && status != D5X_STATUS_UNAVAILABLE &&
+		    (status & D5X_STATUS_STREAMING)) {
 			dev_info(&state->client->dev,
 				 "stream %d already reports streaming before START; treating as already started\n",
 				 stream_id);
@@ -5353,13 +5353,13 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		}
 #endif
 	}
-	if (on == !(status & DS5_STATUS_STREAMING))
+	if (on == !(status & D5X_STATUS_STREAMING))
 	{
 		dev_dbg(&state->client->dev,
 			"stream %d in expected state, toggling to %d (status: 0x%04x) %dms\n",
 			stream_id, on, status, jiffies_to_msecs(jiffies - ts));
 	} else {
-		if (on && reset_invalidated && (status & DS5_STATUS_STREAMING))
+		if (on && reset_invalidated && (status & D5X_STATUS_STREAMING))
 			dev_warn(&state->client->dev,
 				"stream %d state mismatch after reset invalidation: host=off HKR=streaming (status: 0x%04x)\n",
 				stream_id, status);
@@ -5377,25 +5377,25 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		dev_warn(&state->client->dev,
 			"stream %d in %d state already (status: 0x%04x) %dms, treating as no-op\n",
 			stream_id, on, status, jiffies_to_msecs(jiffies - ts));
-		mutex_lock(&state->ds5_dev->lock);
+		mutex_lock(&state->d5x_dev->lock);
 		*streaming_flag = on;
-		mutex_unlock(&state->ds5_dev->lock);
+		mutex_unlock(&state->d5x_dev->lock);
 		sensor->streaming = on;
 #ifdef CONFIG_VIDEO_D5XX_SERDES
 		if (on)
-			ds5_post_start_dser_datapath_kick(state, stream_id);
+			d5x_post_start_dser_datapath_kick(state, stream_id);
 #endif
 		if (stream_ctrl_locked) {
-			mutex_unlock(&state->ds5_dev->stream_ctrl_lock);
+			mutex_unlock(&state->d5x_dev->stream_ctrl_lock);
 			stream_ctrl_locked = false;
 		}
 		return 0;
 	}
 
 	restore_val = sensor->streaming;
-	mutex_lock(&state->ds5_dev->lock);
+	mutex_lock(&state->d5x_dev->lock);
 	*streaming_flag = on;
-	mutex_unlock(&state->ds5_dev->lock);
+	mutex_unlock(&state->d5x_dev->lock);
 	sensor->streaming = on;
 
 	/*
@@ -5404,19 +5404,19 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 	 */
 	ts = jiffies;
 	streaming = ~expected_streaming_state; /* force initial toggle */
-		for (timeout = ts + msecs_to_jiffies(on ? DS5_START_MAX_TIME :
-								 DS5_STOP_MAX_TIME), i = 0;
+		for (timeout = ts + msecs_to_jiffies(on ? D5X_START_MAX_TIME :
+								 D5X_STOP_MAX_TIME), i = 0;
 				time_before(jiffies, timeout);
-				i++, msleep_range(ds5_stream_poll_delay(on, i)))
+				i++, msleep_range(d5x_stream_poll_delay(on, i)))
 		{
 			command_read_status = false;
-			if (!ds5_config_done) {
-			ret = ds5_configure(state);
+			if (!d5x_config_done) {
+			ret = d5x_configure(state);
 			if (ret < 0) {
 				if (ret == -ENOSR) {
 					/* No recovery can help if no resources are available */
 					if (stream_ctrl_locked) {
-						mutex_unlock(&state->ds5_dev->stream_ctrl_lock);
+						mutex_unlock(&state->d5x_dev->stream_ctrl_lock);
 						stream_ctrl_locked = false;
 					}
 					return ret;
@@ -5425,17 +5425,17 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 					stream_id, i, jiffies_to_msecs(jiffies - ts));
 				continue;
 			}
-			ds5_config_done = true;
+			d5x_config_done = true;
 		}
 
 			if (streaming != expected_streaming_state) {
 				if (!on)
-					mutex_lock(&state->ds5_dev->stream_ctrl_lock);
-				ret = ds5_write_then_read(state, DS5_START_STOP_STREAM,
+					mutex_lock(&state->d5x_dev->stream_ctrl_lock);
+				ret = d5x_write_then_read(state, D5X_START_STOP_STREAM,
 							  stream_cmd, stream_status_base,
 							  &streaming);
 				if (!on)
-					mutex_unlock(&state->ds5_dev->stream_ctrl_lock);
+					mutex_unlock(&state->d5x_dev->stream_ctrl_lock);
 				if (ret < 0) {
 					dev_warn(&state->client->dev, "stream %d cmd 0x%x write failed, retry %d, %dms\n",
 						stream_id, stream_cmd, i, jiffies_to_msecs(jiffies - ts));
@@ -5444,7 +5444,7 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 			}
 
 			if (!command_read_status)
-				ret = ds5_read(state, stream_status_base, &streaming);
+				ret = d5x_read(state, stream_status_base, &streaming);
 			if (ret < 0) {
 			dev_warn(&state->client->dev,
 				"stream %d status i2c read failed (%d), retry %u, %dms\n",
@@ -5457,7 +5457,7 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 			continue;
 		}
 
-		ret = ds5_read(state, config_status_base, &status);
+		ret = d5x_read(state, config_status_base, &status);
 		if (ret < 0) {
 			dev_warn(&state->client->dev,
 				"stream %d config status i2c read failed (%d), retry %u, %dms\n",
@@ -5465,25 +5465,25 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 			continue;
 		}
 
-		if (status == DS5_STATUS_UNAVAILABLE ||
-		    (status & ~DS5_STATUS_VALID_MASK)) {
+		if (status == D5X_STATUS_UNAVAILABLE ||
+		    (status & ~D5X_STATUS_VALID_MASK)) {
 			dev_warn(&state->client->dev,
 				"stream %d config status invalid/unavailable (0x%04x), retry %u, %dms\n",
 				stream_id, status, i, jiffies_to_msecs(jiffies - ts));
 			continue;
 		}
 
-		if (on && (status & (DS5_STATUS_INVALID_DT |
-								DS5_STATUS_INVALID_RES |
-								DS5_STATUS_INVALID_FPS)))
+		if (on && (status & (D5X_STATUS_INVALID_DT |
+								D5X_STATUS_INVALID_RES |
+								D5X_STATUS_INVALID_FPS)))
 		{
 			dev_warn(&state->client->dev,
 				"stream %d config rejected, status 0x%04x, retry %u, %dms\n",
 				stream_id, status, i, jiffies_to_msecs(jiffies - ts));
-			if (ds5_config_retries > 0) {
-				ds5_config_retries--;
-				ds5_config_done = false;
-				ds5_config_cache_clear(sensor);
+			if (d5x_config_retries > 0) {
+				d5x_config_retries--;
+				d5x_config_done = false;
+				d5x_config_cache_clear(sensor);
 			} else {
 				dev_warn(&state->client->dev,
 					"stream %d config failed after %d retries, aborting, %dms\n",
@@ -5493,7 +5493,7 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 			continue;
 		}
 
-		if (!on == !(status & DS5_STATUS_STREAMING))
+		if (!on == !(status & D5X_STATUS_STREAMING))
 		{
 			dev_info(&state->client->dev,
 				"stream %d toggle ok to %d in %dms, retries %d\n",
@@ -5502,7 +5502,7 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		}
 	}
 
-	if (on == !(status & DS5_STATUS_STREAMING))
+	if (on == !(status & D5X_STATUS_STREAMING))
 	{
 		dev_warn(&state->client->dev,
 			"stream %d toggle to %d timeout in %dms, retries %d\n",
@@ -5510,18 +5510,18 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 
 		if (streaming == expected_streaming_state) { /* try to toggle stream back on timeout  */
 			if (!on)
-				mutex_lock(&state->ds5_dev->stream_ctrl_lock);
-			ds5_write(state, DS5_START_STOP_STREAM,
-				(on ? DS5_STREAM_STOP : DS5_STREAM_START) | stream_id);
+				mutex_lock(&state->d5x_dev->stream_ctrl_lock);
+			d5x_write(state, D5X_START_STOP_STREAM,
+				(on ? D5X_STREAM_STOP : D5X_STREAM_START) | stream_id);
 			if (!on)
-				mutex_unlock(&state->ds5_dev->stream_ctrl_lock);
+				mutex_unlock(&state->d5x_dev->stream_ctrl_lock);
 		}
 #ifdef CONFIG_VIDEO_D5XX_SERDES
 		if (on && sensor->pipe_id >= 0) {
 			mutex_lock(&serdes_lock__);
 			ret = state->dser_ops->release_pipe(state->dser_dev, sensor->pipe_id);
 			if (ret >= 0)
-				ds5_disarm_dser_datapath_if_idle(state);
+				d5x_disarm_dser_datapath_if_idle(state);
 			mutex_unlock(&serdes_lock__);
 			if (ret < 0) {
 				dev_warn(&state->client->dev, "release pipe failed\n");
@@ -5531,9 +5531,9 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 			}
 		}
 #endif
-		mutex_lock(&state->ds5_dev->lock);
+		mutex_lock(&state->d5x_dev->lock);
 		*streaming_flag = restore_val;
-		mutex_unlock(&state->ds5_dev->lock);
+		mutex_unlock(&state->d5x_dev->lock);
 		sensor->streaming = restore_val;
 		ret = -EAGAIN;
 	}
@@ -5544,7 +5544,7 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		if (state->dser_ops->release_pipe(state->dser_dev, sensor->pipe_id) < 0)
 			dev_warn(&state->client->dev, "release pipe failed\n");
 		else {
-			ds5_disarm_dser_datapath_if_idle(state);
+			d5x_disarm_dser_datapath_if_idle(state);
 			sensor->pipe_id = PIPE_NOT_CONFIGURED;
 			sensor->pipe_reapply_gen = 0;
 		}
@@ -5558,16 +5558,16 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 
 		/*
 		 * Tear down the DES FSYNC generator when the last stream stops.
-		 * Check the ds5_dev-level streaming flags (already
+		 * Check the d5x_dev-level streaming flags (already
 		 * cleared for *this* sensor before we entered the polling
 		 * loop) to decide whether any stream is still active.
 		 */
-		if (ds5_sync_mode_uses_esync(state) &&
-		    !state->ds5_dev->depth_streaming &&
-		    !state->ds5_dev->rgb_streaming &&
-		    !state->ds5_dev->ir_streaming &&
-		    !state->ds5_dev->imu_streaming)
-			ds5_set_des_fsync(state, false);
+		if (d5x_sync_mode_uses_esync(state) &&
+		    !state->d5x_dev->depth_streaming &&
+		    !state->d5x_dev->rgb_streaming &&
+		    !state->d5x_dev->ir_streaming &&
+		    !state->d5x_dev->imu_streaming)
+			d5x_set_des_fsync(state, false);
 #endif
 	}
 #ifdef CONFIG_VIDEO_D5XX_SERDES
@@ -5577,20 +5577,20 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 	 * start the DES internal FSYNC source at the negotiated FPS.
 	 */
 	if (on && ret >= 0)
-		ds5_post_start_dser_datapath_kick(state, stream_id);
+		d5x_post_start_dser_datapath_kick(state, stream_id);
 
-	if (on && ds5_sync_mode_uses_esync(state)) {
-		ds5_set_ser_esync_tunneling(state, true);
-		ds5_set_des_fsync(state, true);
+	if (on && d5x_sync_mode_uses_esync(state)) {
+		d5x_set_ser_esync_tunneling(state, true);
+		d5x_set_des_fsync(state, true);
 	}
 #endif
 	if (stream_ctrl_locked)
-		mutex_unlock(&state->ds5_dev->stream_ctrl_lock);
+		mutex_unlock(&state->d5x_dev->stream_ctrl_lock);
 	return ret;
-#endif /* !DS5_BYPASS_CAMERA_I2C */
+#endif /* !D5X_BYPASS_CAMERA_I2C */
 }
 
-static int ds5_mux_get_frame_desc(struct v4l2_subdev *sd,
+static int d5x_mux_get_frame_desc(struct v4l2_subdev *sd,
 	unsigned int pad, struct v4l2_mbus_frame_desc *desc)
 {
 	unsigned int i;
@@ -5604,59 +5604,59 @@ static int ds5_mux_get_frame_desc(struct v4l2_subdev *sd,
 		if (i == desc->num_entries - 1) {
 			desc->entry[i].flags = V4L2_MBUS_FRAME_DESC_FL_LEN_MAX;
 			desc->entry[i].pixelcode = MEDIA_BUS_FMT_FIXED;
-			desc->entry[i].length = DS5_CSI_METADATA_MAX_WC;
+			desc->entry[i].length = D5X_CSI_METADATA_MAX_WC;
 		}
 	}
 	return 0;
 }
 
-static const struct v4l2_subdev_pad_ops ds5_mux_pad_ops = {
+static const struct v4l2_subdev_pad_ops d5x_mux_pad_ops = {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
-	.get_frame_interval	= ds5_mux_g_frame_interval,
-	.set_frame_interval	= ds5_mux_s_frame_interval,
+	.get_frame_interval	= d5x_mux_g_frame_interval,
+	.set_frame_interval	= d5x_mux_s_frame_interval,
 #endif
-	.enum_mbus_code		= ds5_mux_enum_mbus_code,
-	.enum_frame_size	= ds5_mux_enum_frame_size,
-	.enum_frame_interval	= ds5_mux_enum_frame_interval,
-	.get_fmt		= ds5_mux_get_fmt,
-	.set_fmt		= ds5_mux_set_fmt,
-	.get_frame_desc		= ds5_mux_get_frame_desc,
+	.enum_mbus_code		= d5x_mux_enum_mbus_code,
+	.enum_frame_size	= d5x_mux_enum_frame_size,
+	.enum_frame_interval	= d5x_mux_enum_frame_interval,
+	.get_fmt		= d5x_mux_get_fmt,
+	.set_fmt		= d5x_mux_set_fmt,
+	.get_frame_desc		= d5x_mux_get_frame_desc,
 };
 
-static const struct v4l2_subdev_core_ops ds5_mux_core_ops = {
+static const struct v4l2_subdev_core_ops d5x_mux_core_ops = {
 	.log_status = v4l2_ctrl_subdev_log_status,
 };
 
-static const struct v4l2_subdev_video_ops ds5_mux_video_ops = {
+static const struct v4l2_subdev_video_ops d5x_mux_video_ops = {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
-	.g_frame_interval	= ds5_mux_g_frame_interval,
-	.s_frame_interval	= ds5_mux_s_frame_interval,
+	.g_frame_interval	= d5x_mux_g_frame_interval,
+	.s_frame_interval	= d5x_mux_s_frame_interval,
 #endif
-	.s_stream		= ds5_mux_s_stream,
+	.s_stream		= d5x_mux_s_stream,
 };
 
-static const struct v4l2_subdev_ops ds5_mux_subdev_ops = {
-	.core = &ds5_mux_core_ops,
-	.pad = &ds5_mux_pad_ops,
-	.video = &ds5_mux_video_ops,
+static const struct v4l2_subdev_ops d5x_mux_subdev_ops = {
+	.core = &d5x_mux_core_ops,
+	.pad = &d5x_mux_pad_ops,
+	.video = &d5x_mux_video_ops,
 };
 
-static int ds5_mux_registered(struct v4l2_subdev *sd)
+static int d5x_mux_registered(struct v4l2_subdev *sd)
 {
-	struct ds5 *state = v4l2_get_subdevdata(sd);
-	int ret = ds5_sensor_register(state, &state->depth.sensor);
+	struct d5x *state = v4l2_get_subdevdata(sd);
+	int ret = d5x_sensor_register(state, &state->depth.sensor);
 	if (ret < 0)
 		return ret;
 
-	ret = ds5_sensor_register(state, &state->ir.sensor);
+	ret = d5x_sensor_register(state, &state->ir.sensor);
 	if (ret < 0)
 		goto e_depth;
 
-	ret = ds5_sensor_register(state, &state->rgb.sensor);
+	ret = d5x_sensor_register(state, &state->rgb.sensor);
 	if (ret < 0)
 		goto e_rgb;
 
-	ret = ds5_sensor_register(state, &state->imu.sensor);
+	ret = d5x_sensor_register(state, &state->imu.sensor);
 	if (ret < 0)
 		goto e_imu;
 
@@ -5674,44 +5674,44 @@ e_depth:
 	return ret;
 }
 
-static void ds5_mux_unregistered(struct v4l2_subdev *sd)
+static void d5x_mux_unregistered(struct v4l2_subdev *sd)
 {
-	struct ds5 *state = v4l2_get_subdevdata(sd);
-	ds5_sensor_remove(&state->imu.sensor);
-	ds5_sensor_remove(&state->rgb.sensor);
-	ds5_sensor_remove(&state->ir.sensor);
-	ds5_sensor_remove(&state->depth.sensor);
+	struct d5x *state = v4l2_get_subdevdata(sd);
+	d5x_sensor_remove(&state->imu.sensor);
+	d5x_sensor_remove(&state->rgb.sensor);
+	d5x_sensor_remove(&state->ir.sensor);
+	d5x_sensor_remove(&state->depth.sensor);
 }
 
-static const struct v4l2_subdev_internal_ops ds5_mux_internal_ops = {
-	.open = ds5_mux_open,
-	.close = ds5_mux_close,
-	.registered = ds5_mux_registered,
-	.unregistered = ds5_mux_unregistered,
+static const struct v4l2_subdev_internal_ops d5x_mux_internal_ops = {
+	.open = d5x_mux_open,
+	.close = d5x_mux_close,
+	.registered = d5x_mux_registered,
+	.unregistered = d5x_mux_unregistered,
 };
 
-static int ds5_mux_register(struct i2c_client *c, struct ds5 *state)
+static int d5x_mux_register(struct i2c_client *c, struct d5x *state)
 {
 	return v4l2_async_register_subdev(&state->mux.sd.subdev);
 }
 
-static int ds5_hw_init(struct i2c_client *c, struct ds5 *state)
+static int d5x_hw_init(struct i2c_client *c, struct d5x *state)
 {
 	struct v4l2_subdev *sd = &state->mux.sd.subdev;
-#if DS5_BYPASS_CAMERA_I2C
+#if D5X_BYPASS_CAMERA_I2C
 	dev_info(sd->dev, "%s(): BYPASS - skip camera MIPI config I2C\n", __func__);
 	return 0;
 #else
 	u16 mipi_status, n_lanes, phy, drate_min, drate_max;
-	int ret = ds5_read(state, DS5_MIPI_SUPPORT_LINES, &n_lanes);
+	int ret = d5x_read(state, D5X_MIPI_SUPPORT_LINES, &n_lanes);
 	if (!ret)
-		ret = ds5_read(state, DS5_MIPI_SUPPORT_PHY, &phy);
+		ret = d5x_read(state, D5X_MIPI_SUPPORT_PHY, &phy);
 
 	if (!ret)
-		ret = ds5_read(state, DS5_MIPI_DATARATE_MIN, &drate_min);
+		ret = d5x_read(state, D5X_MIPI_DATARATE_MIN, &drate_min);
 
 	if (!ret)
-		ret = ds5_read(state, DS5_MIPI_DATARATE_MAX, &drate_max);
+		ret = d5x_read(state, D5X_MIPI_DATARATE_MAX, &drate_max);
 
 	if (!ret)
 		dev_dbg(sd->dev, "%s(): %d: %u lanes, phy %x, data rate %u-%u\n",
@@ -5723,12 +5723,12 @@ static int ds5_hw_init(struct i2c_client *c, struct ds5 *state)
 	n_lanes = 2;
 #endif
 
-	ret = ds5_write(state, DS5_MIPI_LANE_NUMS, n_lanes - 1);
+	ret = d5x_write(state, D5X_MIPI_LANE_NUMS, n_lanes - 1);
 	if (!ret)
-		ret = ds5_write(state, DS5_MIPI_LANE_DATARATE, MIPI_LANE_RATE);
+		ret = d5x_write(state, D5X_MIPI_LANE_DATARATE, MIPI_LANE_RATE);
 
 	if (!ret)
-		ret = ds5_read(state, DS5_MIPI_CONF_STATUS, &mipi_status);
+		ret = d5x_read(state, D5X_MIPI_CONF_STATUS, &mipi_status);
 
 #ifdef CONFIG_TEGRA_CAMERA_PLATFORM
 	dev_dbg(sd->dev, "%s(): %d phandle %x node %s status %x\n", __func__, __LINE__,
@@ -5736,10 +5736,10 @@ static int ds5_hw_init(struct i2c_client *c, struct ds5 *state)
 #endif
 
 	return ret;
-#endif /* !DS5_BYPASS_CAMERA_I2C */
+#endif /* !D5X_BYPASS_CAMERA_I2C */
 }
 
-static int ds5_mux_init(struct i2c_client *c, struct ds5 *state)
+static int d5x_mux_init(struct i2c_client *c, struct d5x *state)
 {
 	struct v4l2_subdev *sd = &state->mux.sd.subdev;
 	struct media_entity *entity = &state->mux.sd.subdev.entity;
@@ -5750,19 +5750,19 @@ static int ds5_mux_init(struct i2c_client *c, struct ds5 *state)
 	struct d4xx_pdata *dpdata = c->dev.platform_data;
 	char suffix = dpdata->suffix;
 #endif
-	v4l2_i2c_subdev_init(sd, c, &ds5_mux_subdev_ops);
+	v4l2_i2c_subdev_init(sd, c, &d5x_mux_subdev_ops);
 	/* See tegracam_v4l2.c tegracam_v4l2subdev_register() */
 	/* Set owner to NULL so we can unload the driver module */
 	sd->owner = NULL;
-	sd->internal_ops = &ds5_mux_internal_ops;
+	sd->internal_ops = &d5x_mux_internal_ops;
 	v4l2_set_subdevdata(sd, state);
 #ifdef CONFIG_OF
-	snprintf(sd->name, sizeof(sd->name), DS5_DRIVER_NAME_MUX " %d-%04x",
+	snprintf(sd->name, sizeof(sd->name), D5X_DRIVER_NAME_MUX " %d-%04x",
 		 i2c_adapter_id(c->adapter), c->addr);
 #else
 	if (state->aggregated)
 		suffix += 4;
-	snprintf(sd->name, sizeof(sd->name), DS5_DRIVER_NAME_MUX " %c", suffix);
+	snprintf(sd->name, sizeof(sd->name), D5X_DRIVER_NAME_MUX " %c", suffix);
 #endif
 	sd->flags |= V4L2_SUBDEV_FL_HAS_DEVNODE;
 	entity->obj_type = MEDIA_ENTITY_TYPE_V4L2_SUBDEV;
@@ -5777,28 +5777,28 @@ static int ds5_mux_init(struct i2c_client *c, struct ds5 *state)
 		return ret;
 
 	/*set for mux*/
-	ret = ds5_ctrl_init(state, MUX_SID);
+	ret = d5x_ctrl_init(state, MUX_SID);
 	if (ret < 0)
 		goto e_entity;
 
 	/*set for depth*/
-	ret = ds5_ctrl_init(state, DEPTH_SID);
+	ret = d5x_ctrl_init(state, DEPTH_SID);
 	if (ret < 0)
 		return ret;
 	/*set for rgb*/
-	ret = ds5_ctrl_init(state, RGB_SID);
+	ret = d5x_ctrl_init(state, RGB_SID);
 	if (ret < 0)
 		return ret;
 	/*set for y8*/
-	ret = ds5_ctrl_init(state, IR_SID);
+	ret = d5x_ctrl_init(state, IR_SID);
 	if (ret < 0)
 		return ret;
 	/*set for imu*/
-	ret = ds5_ctrl_init(state, IMU_SID);
+	ret = d5x_ctrl_init(state, IMU_SID);
 	if (ret < 0)
 		return ret;
 
-	ds5_set_state_last_set(state);
+	d5x_set_state_last_set(state);
 
 #ifdef CONFIG_TEGRA_CAMERA_PLATFORM
 	if (state->is_depth) {
@@ -5836,7 +5836,7 @@ static int ds5_mux_init(struct i2c_client *c, struct ds5 *state)
 
 	state->mux.sd.dev = &c->dev;
 #if defined(CONFIG_TEGRA_CAMERA_PLATFORM) && defined(CONFIG_TEGRA_EMBEDDED_METADATA_OPS)
-	state->mux.sd.embedded_metadata_ops = &ds5_csi_metadata_ops;
+	state->mux.sd.embedded_metadata_ops = &d5x_csi_metadata_ops;
 #endif
 	ret = camera_common_initialize(&state->mux.sd, "d5xx");
 	if (ret) {
@@ -5859,14 +5859,14 @@ e_entity:
 
 #define USE_Y
 
-static int ds5_fixed_configuration(struct i2c_client *client, struct ds5 *state)
+static int d5x_fixed_configuration(struct i2c_client *client, struct d5x *state)
 {
-	struct ds5_sensor *sensor;
+	struct d5x_sensor *sensor;
 	u16 cfg0 = 0, cfg0_md = 0, cfg1 = 0, cfg1_md = 0;
 	u16 dw = 0, dh = 0, yw = 0, yh = 0, dev_type = 0;
 	int ret;
 
-#if DS5_BYPASS_CAMERA_I2C
+#if D5X_BYPASS_CAMERA_I2C
 	/* Hardcode D58X configuration - no camera I2C available */
 	dev_info(&client->dev, "%s(): BYPASS - using hardcoded D58X config\n", __func__);
 	cfg0 = 0x1e;   /* depth DT: GMSL_CSI_DT_YUV422_8 */
@@ -5875,26 +5875,26 @@ static int ds5_fixed_configuration(struct i2c_client *client, struct ds5 *state)
 	cfg1 = 0x2a;   /* IR DT: RAW8 */
 	yw = 1280;
 	yh = 720;
-	dev_type = DS5_DEVICE_TYPE_D58X;
+	dev_type = D5X_DEVICE_TYPE_D58X;
 	ret = 0;
 #else
-	ret = ds5_read(state, DS5_DEPTH_STREAM_DT, &cfg0);
+	ret = d5x_read(state, D5X_DEPTH_STREAM_DT, &cfg0);
 	if (!ret)
-		ret = ds5_read(state, DS5_DEPTH_STREAM_MD, &cfg0_md);
+		ret = d5x_read(state, D5X_DEPTH_STREAM_MD, &cfg0_md);
 	if (!ret)
-		ret = ds5_read(state, DS5_DEPTH_RES_WIDTH, &dw);
+		ret = d5x_read(state, D5X_DEPTH_RES_WIDTH, &dw);
 	if (!ret)
-		ret = ds5_read(state, DS5_DEPTH_RES_HEIGHT, &dh);
+		ret = d5x_read(state, D5X_DEPTH_RES_HEIGHT, &dh);
 	if (!ret)
-		ret = ds5_read(state, DS5_IR_STREAM_DT, &cfg1);
+		ret = d5x_read(state, D5X_IR_STREAM_DT, &cfg1);
 	if (!ret)
-		ret = ds5_read(state, DS5_IR_STREAM_MD, &cfg1_md);
+		ret = d5x_read(state, D5X_IR_STREAM_MD, &cfg1_md);
 	if (!ret)
-		ret = ds5_read(state, DS5_IR_RES_WIDTH, &yw);
+		ret = d5x_read(state, D5X_IR_RES_WIDTH, &yw);
 	if (!ret)
-		ret = ds5_read(state, DS5_IR_RES_HEIGHT, &yh);
+		ret = d5x_read(state, D5X_IR_RES_HEIGHT, &yh);
 	if (!ret)
-		ret = ds5_read(state, DS5_DEVICE_TYPE, &dev_type);
+		ret = d5x_read(state, D5X_DEVICE_TYPE, &dev_type);
 	if (ret < 0)
 		return ret;
 #endif
@@ -5906,39 +5906,39 @@ static int ds5_fixed_configuration(struct i2c_client *client, struct ds5 *state)
 		 cfg1, dw, dh, cfg1_md, yw, yh);
 
 	sensor = &state->depth.sensor;
-	dev_type = ds5_dev_type(state, dev_type);
+	dev_type = d5x_dev_type(state, dev_type);
 	switch (dev_type) {
-	case DS5_DEVICE_TYPE_D58X:
+	case D5X_DEVICE_TYPE_D58X:
 	default:
-		if (dev_type != DS5_DEVICE_TYPE_D58X)
+		if (dev_type != D5X_DEVICE_TYPE_D58X)
 			dev_warn(&client->dev,
 				"%s(): unknown device type 0x%x, using D58X format tables\n",
 				__func__, dev_type);
-		sensor->formats = ds5_depth_formats_d58x;
+		sensor->formats = d5x_depth_formats_d58x;
 	}
 	sensor->n_formats = 1;
-	sensor->mux_pad = DS5_MUX_PAD_DEPTH;
+	sensor->mux_pad = D5X_MUX_PAD_DEPTH;
 
 	sensor = &state->ir.sensor;
 	switch (dev_type) {
-	case DS5_DEVICE_TYPE_D58X:
-		sensor->formats = ds5_y_formats_d58x;
-		sensor->n_formats = ARRAY_SIZE(ds5_y_formats_d58x);
+	case D5X_DEVICE_TYPE_D58X:
+		sensor->formats = d5x_y_formats_d58x;
+		sensor->n_formats = ARRAY_SIZE(d5x_y_formats_d58x);
 		break;
 	default:
 		sensor->formats = state->variant->formats;
 		sensor->n_formats = state->variant->n_formats;
 	}
-	sensor->mux_pad = DS5_MUX_PAD_IR;
+	sensor->mux_pad = D5X_MUX_PAD_IR;
 
 	sensor = &state->rgb.sensor;
 	switch (dev_type) {
-	case DS5_DEVICE_TYPE_D58X:
+	case D5X_DEVICE_TYPE_D58X:
 	default:
-		sensor->formats = &ds5_d58x_rgb_format;
-		sensor->n_formats = DS5_D58X_RGB_N_FORMATS;
+		sensor->formats = &d5x_d58x_rgb_format;
+		sensor->n_formats = D5X_D58X_RGB_N_FORMATS;
 	}
-	sensor->mux_pad = DS5_MUX_PAD_RGB;
+	sensor->mux_pad = D5X_MUX_PAD_RGB;
 
 	sensor = &state->imu.sensor;
 
@@ -5948,12 +5948,12 @@ static int ds5_fixed_configuration(struct i2c_client *client, struct ds5 *state)
  	 * 5.16.x.y = firmware version: 0x0510
 	 */
 	if (state->fw_version >= 0x510)
-		sensor->formats = ds5_imu_formats_extended;
+		sensor->formats = d5x_imu_formats_extended;
 	else
-		sensor->formats = ds5_imu_formats;
+		sensor->formats = d5x_imu_formats;
 	
 	sensor->n_formats = 1;
-	sensor->mux_pad = DS5_MUX_PAD_IMU;
+	sensor->mux_pad = D5X_MUX_PAD_IMU;
 
 	/* Development: set a configuration during probing */
 	if ((cfg0 & 0xff00) == 0x1800) {
@@ -5962,7 +5962,7 @@ static int ds5_fixed_configuration(struct i2c_client *client, struct ds5 *state)
 			.which = V4L2_SUBDEV_FORMAT_ACTIVE,
 			.pad = 0,
 			/* Use template to fill in .field, .colorspace etc. */
-			.format = ds5_mbus_framefmt_template,
+			.format = d5x_mbus_framefmt_template,
 		};
 
 //#undef USE_Y
@@ -5976,7 +5976,7 @@ static int ds5_fixed_configuration(struct i2c_client *client, struct ds5 *state)
 #endif
 		state->ir.sensor.streaming = true;
 		state->depth.sensor.streaming = true;
-		ret = __ds5_sensor_set_fmt(state, &state->ir.sensor, NULL, &fmt);
+		ret = __d5x_sensor_set_fmt(state, &state->ir.sensor, NULL, &fmt);
 #else
 		fmt.format.width = dw;
 		fmt.format.height = dh;
@@ -5986,7 +5986,7 @@ static int ds5_fixed_configuration(struct i2c_client *client, struct ds5 *state)
 #endif
 		state->ir.sensor.streaming = false;
 		state->depth.sensor.streaming = true;
-		ret = __ds5_sensor_set_fmt(state, &state->depth.sensor, NULL, &fmt);
+		ret = __d5x_sensor_set_fmt(state, &state->depth.sensor, NULL, &fmt);
 #endif
 		if (ret < 0)
 			return ret;
@@ -5995,23 +5995,23 @@ static int ds5_fixed_configuration(struct i2c_client *client, struct ds5 *state)
 	return 0;
 }
 
-static int ds5_parse_cam(struct i2c_client *client, struct ds5 *state)
+static int d5x_parse_cam(struct i2c_client *client, struct d5x *state)
 {
 	int ret;
 
-	ret = ds5_fixed_configuration(client, state);
+	ret = d5x_fixed_configuration(client, state);
 	if (ret < 0)
 		return ret;
 
-	ds5_sensor_format_init(&state->depth.sensor);
-	ds5_sensor_format_init(&state->ir.sensor);
-	ds5_sensor_format_init(&state->rgb.sensor);
-	ds5_sensor_format_init(&state->imu.sensor);
+	d5x_sensor_format_init(&state->depth.sensor);
+	d5x_sensor_format_init(&state->ir.sensor);
+	d5x_sensor_format_init(&state->rgb.sensor);
+	d5x_sensor_format_init(&state->imu.sensor);
 
 	return 0;
 }
 
-static void ds5_mux_remove(struct ds5 *state)
+static void d5x_mux_remove(struct d5x *state)
 {
 #ifdef CONFIG_TEGRA_CAMERA_PLATFORM
 	camera_common_cleanup(&state->mux.sd);
@@ -6021,20 +6021,20 @@ static void ds5_mux_remove(struct ds5 *state)
 	media_entity_cleanup(&state->mux.sd.subdev.entity);
 }
 
-static const struct regmap_config ds5_regmap_config = {
+static const struct regmap_config d5x_regmap_config = {
 	.reg_bits = 16,
 	.val_bits = 8,
 	.reg_format_endian = REGMAP_ENDIAN_NATIVE,
 	.val_format_endian = REGMAP_ENDIAN_NATIVE,
 };
 
-static int ds5_dfu_wait_for_status(struct ds5 *state)
+static int d5x_dfu_wait_for_status(struct d5x *state)
 {
 	int i, ret = 0;
 	u16 status;
 
-	for (i = 0; i < DS5_START_MAX_COUNT; i++) {
-		ds5_read(state, 0x5000, &status);
+	for (i = 0; i < D5X_START_MAX_COUNT; i++) {
+		d5x_read(state, 0x5000, &status);
 		if (status == 0x0001 || status == 0x0002) {
 			dev_err(&state->client->dev,
 					"%s(): dfu failed status(0x%4x)\n",
@@ -6044,31 +6044,31 @@ static int ds5_dfu_wait_for_status(struct ds5 *state)
 		}
 		if (!status)
 			break;
-		msleep_range(DS5_START_POLL_TIME);
+		msleep_range(D5X_START_POLL_TIME);
 	}
 
 	return ret;
 };
 
-static int ds5_dfu_switch_to_dfu(struct ds5 *state)
+static int d5x_dfu_switch_to_dfu(struct d5x *state)
 {
 	int ret;
-	int i = DS5_START_MAX_COUNT;
+	int i = D5X_START_MAX_COUNT;
 	u16 status;
 
-	ret = ds5_hwmc_send(state, sizeof(cmd_switch_to_dfu),
+	ret = d5x_hwmc_send(state, sizeof(cmd_switch_to_dfu),
 			    (struct hwm_cmd *)&cmd_switch_to_dfu);
 	if (ret)
 		return ret;
 	/*Wait for DFU fw to boot*/
 	do {
-		msleep_range(DS5_START_POLL_TIME*10);
-		ret = ds5_read(state, 0x5000, &status);
+		msleep_range(D5X_START_POLL_TIME*10);
+		ret = d5x_read(state, 0x5000, &status);
 	} while (ret && i--);
 	return ret;
 };
 
-static int ds5_dfu_wait_for_get_dfu_status(struct ds5 *state,
+static int d5x_dfu_wait_for_get_dfu_status(struct d5x *state,
 		enum dfu_fw_state exp_state)
 {
 	int ret = 0;
@@ -6078,9 +6078,9 @@ static int ds5_dfu_wait_for_get_dfu_status(struct ds5 *state,
 
 	do {
 		/* Get Write state */
-		ds5_write_with_check(state, 0x5008, 0x0003);
+		d5x_write_with_check(state, 0x5008, 0x0003);
 		do {
-			ds5_read_with_check(state, 0x5000, &status);
+			d5x_read_with_check(state, 0x5000, &status);
 			if (status == 0x0001) {
 				dev_err(&state->client->dev,
 						"%s(): Write status error I2C_STATUS_ERROR(1)\n",
@@ -6092,13 +6092,13 @@ static int ds5_dfu_wait_for_get_dfu_status(struct ds5 *state,
 
 		} while (status);
 
-		ds5_read_with_check(state, 0x5004, &dfu_state_len);
+		d5x_read_with_check(state, 0x5004, &dfu_state_len);
 		if (dfu_state_len != DFU_WAIT_RET_LEN) {
 			dev_err(&state->client->dev,
 					"%s(): Wrong answer len (%d)\n", __func__, dfu_state_len);
 			return -EINVAL;
 		}
-		ds5_raw_read_with_check(state, 0x4e00, &dfu_asw_buf, DFU_WAIT_RET_LEN);
+		d5x_raw_read_with_check(state, 0x4e00, &dfu_asw_buf, DFU_WAIT_RET_LEN);
 		if (dfu_asw_buf[0]) {
 			dev_err(&state->client->dev,
 					"%s(): Wrong dfu_status (%d)\n", __func__, dfu_asw_buf[0]);
@@ -6122,19 +6122,19 @@ static int ds5_dfu_wait_for_get_dfu_status(struct ds5 *state,
 	return ret;
 };
 
-static int ds5_dfu_get_dev_info(struct ds5 *state, struct __fw_status *buf)
+static int d5x_dfu_get_dev_info(struct d5x *state, struct __fw_status *buf)
 {
 	int ret = 0;
 	u16 len = 0;
 
-	ret = ds5_write(state, 0x5008, 0x0002); //Upload DFU cmd
+	ret = d5x_write(state, 0x5008, 0x0002); //Upload DFU cmd
 	if (!ret)
-		ret = ds5_dfu_wait_for_status(state);
+		ret = d5x_dfu_wait_for_status(state);
 	if (!ret)
-		ds5_read_with_check(state, 0x5004, &len);
+		d5x_read_with_check(state, 0x5004, &len);
 	/*Sanity check*/
 	if (len == sizeof(struct __fw_status)) {
-		ds5_raw_read_with_check(state, 0x4e00, buf, len);
+		d5x_raw_read_with_check(state, 0x4e00, buf, len);
 	} else {
 		dev_err(&state->client->dev,
 				"%s(): Wrong state size (%d)\n",
@@ -6144,15 +6144,15 @@ static int ds5_dfu_get_dev_info(struct ds5 *state, struct __fw_status *buf)
 	return ret;
 };
 
-static int ds5_dfu_detach(struct ds5 *state)
+static int d5x_dfu_detach(struct d5x *state)
 {
 	int ret;
 	struct __fw_status buf = {0};
 
-	ds5_write_with_check(state, 0x500c, 0x00);
-	ret = ds5_dfu_wait_for_get_dfu_status(state, dfuIDLE);
+	d5x_write_with_check(state, 0x500c, 0x00);
+	ret = d5x_dfu_wait_for_get_dfu_status(state, dfuIDLE);
 	if (!ret)
-		ret = ds5_dfu_get_dev_info(state, &buf);
+		ret = d5x_dfu_get_dev_info(state, &buf);
 	dev_notice(&state->client->dev, "%s():DFU ver (0x%x) received\n",
 			__func__, buf.DFU_version);
 	dev_notice(&state->client->dev, "%s():FW last version (0x%x) received\n",
@@ -6163,10 +6163,10 @@ static int ds5_dfu_detach(struct ds5 *state)
 };
 
 /* When a process reads from our device, this gets called. */
-static ssize_t ds5_dfu_device_read(struct file *flip,
+static ssize_t d5x_dfu_device_read(struct file *flip,
 		char __user *buffer, size_t len, loff_t *offset)
 {
-	struct ds5 *state = flip->private_data;
+	struct d5x *state = flip->private_data;
 	u16 fw_ver, fw_build;
 	char msg[64];
 	int ret = 0;
@@ -6174,12 +6174,12 @@ static ssize_t ds5_dfu_device_read(struct file *flip,
 
 	if (mutex_lock_interruptible(&state->lock))
 		return -ERESTARTSYS;
-	if (state->dfu_dev.dfu_state_flag == DS5_DFU_RECOVERY) {
+	if (state->dfu_dev.dfu_state_flag == D5X_DFU_RECOVERY) {
 		/* Read device info in recovery mode */
-		ret = ds5_dfu_detach(state);
+		ret = d5x_dfu_detach(state);
 		if (ret < 0)
 			goto e_dfu_read_failed;
-		ret = ds5_dfu_get_dev_info(state, &f);
+		ret = d5x_dfu_get_dev_info(state, &f);
 		if (ret < 0)
 			goto e_dfu_read_failed;
 		snprintf(msg, sizeof(msg) ,
@@ -6187,8 +6187,8 @@ static ssize_t ds5_dfu_device_read(struct file *flip,
 			 f.ivcamSerialNum[0], f.ivcamSerialNum[1], f.ivcamSerialNum[2],
 			 f.ivcamSerialNum[3], f.ivcamSerialNum[4], f.ivcamSerialNum[5] );
 	} else {
-		ret |= ds5_read(state, DS5_FW_VERSION, &fw_ver);
-		ret |= ds5_read(state, DS5_FW_BUILD, &fw_build);
+		ret |= d5x_read(state, D5X_FW_VERSION, &fw_ver);
+		ret |= d5x_read(state, D5X_FW_BUILD, &fw_build);
 		if (ret < 0)
 			goto e_dfu_read_failed;
 		snprintf(msg, sizeof(msg) ,"DFU info: \tver:  %d.%d.%d.%d\n",
@@ -6208,10 +6208,10 @@ e_dfu_read_failed:
 	return ret;
 };
 
-static ssize_t ds5_dfu_device_write(struct file *flip,
+static ssize_t d5x_dfu_device_write(struct file *flip,
 		const char __user *buffer, size_t len, loff_t *offset)
 {
-	struct ds5 *state = flip->private_data;
+	struct d5x *state = flip->private_data;
 	int ret = 0;
 	(void)offset;
 
@@ -6219,8 +6219,8 @@ static ssize_t ds5_dfu_device_write(struct file *flip,
 		return -ERESTARTSYS;
 	switch (state->dfu_dev.dfu_state_flag) {
 
-	case DS5_DFU_OPEN:
-		ret = ds5_dfu_switch_to_dfu(state);
+	case D5X_DFU_OPEN:
+		ret = d5x_dfu_switch_to_dfu(state);
 		if (ret < 0) {
 			dev_err(&state->client->dev, "%s(): Switch to dfu failed (%d)\n",
 					__func__, ret);
@@ -6228,16 +6228,16 @@ static ssize_t ds5_dfu_device_write(struct file *flip,
 		}
 	/* fallthrough - procceed to recovery */
 	__attribute__((__fallthrough__));
-	case DS5_DFU_RECOVERY:
-		ret = ds5_dfu_detach(state);
+	case D5X_DFU_RECOVERY:
+		ret = d5x_dfu_detach(state);
 		if (ret < 0) {
 			dev_err(&state->client->dev, "%s(): Detach failed (%d)\n",
 					__func__, ret);
 			goto dfu_write_error;
 		}
-		state->dfu_dev.dfu_state_flag = DS5_DFU_IN_PROGRESS;
+		state->dfu_dev.dfu_state_flag = D5X_DFU_IN_PROGRESS;
 	__attribute__((__fallthrough__));
-	case DS5_DFU_IN_PROGRESS: {
+	case D5X_DFU_IN_PROGRESS: {
 		unsigned int dfu_full_blocks = len / DFU_BLOCK_SIZE;
 		unsigned int dfu_part_blocks = len % DFU_BLOCK_SIZE;
 
@@ -6246,11 +6246,11 @@ static ssize_t ds5_dfu_device_write(struct file *flip,
 				ret = -EFAULT;
 				goto dfu_write_error;
 			}
-			ret = ds5_raw_write(state, 0x4a00,
+			ret = d5x_raw_write(state, 0x4a00,
 					state->dfu_dev.dfu_msg, DFU_BLOCK_SIZE);
 			if (ret < 0)
 				goto dfu_write_error;
-			ret = ds5_dfu_wait_for_get_dfu_status(state, dfuDNLOAD_IDLE);
+			ret = d5x_dfu_wait_for_get_dfu_status(state, dfuDNLOAD_IDLE);
 			if (ret < 0)
 				goto dfu_write_error;
 			buffer += DFU_BLOCK_SIZE;
@@ -6260,18 +6260,18 @@ static ssize_t ds5_dfu_device_write(struct file *flip,
 				goto dfu_write_error;
 		}
 		if (dfu_part_blocks) {
-			ret = ds5_raw_write(state, 0x4a00,
+			ret = d5x_raw_write(state, 0x4a00,
 					state->dfu_dev.dfu_msg, dfu_part_blocks);
 			if (!ret)
-				ret = ds5_dfu_wait_for_get_dfu_status(state, dfuDNLOAD_IDLE);
+				ret = d5x_dfu_wait_for_get_dfu_status(state, dfuDNLOAD_IDLE);
 			if (!ret)
-				ret = ds5_write(state, 0x4a04, 0x00); /*Download complete */
+				ret = d5x_write(state, 0x4a04, 0x00); /*Download complete */
 			if (!ret)
-				ret = ds5_dfu_wait_for_get_dfu_status(state,
+				ret = d5x_dfu_wait_for_get_dfu_status(state,
 								      dfuMANIFEST_WAIT_RESET);
 			if (ret < 0)
 				goto dfu_write_error;
-			state->dfu_dev.dfu_state_flag = DS5_DFU_DONE;
+			state->dfu_dev.dfu_state_flag = D5X_DFU_DONE;
 		}
 		if (len)
 			dev_notice(&state->client->dev, "%s(): DFU block (%d) bytes written\n",
@@ -6289,18 +6289,18 @@ static ssize_t ds5_dfu_device_write(struct file *flip,
 	return len;
 
 dfu_write_error:
-	state->dfu_dev.dfu_state_flag = DS5_DFU_ERROR;
+	state->dfu_dev.dfu_state_flag = D5X_DFU_ERROR;
 	/* Reset DFU device to IDLE states */
-	if (!ds5_write(state, 0x5010, 0x0))
-		state->dfu_dev.dfu_state_flag = DS5_DFU_IDLE;
+	if (!d5x_write(state, 0x5010, 0x0))
+		state->dfu_dev.dfu_state_flag = D5X_DFU_IDLE;
 	mutex_unlock(&state->lock);
 	return ret;
 };
 
-static int ds5_dfu_device_open(struct inode *inode, struct file *file)
+static int d5x_dfu_device_open(struct inode *inode, struct file *file)
 {
-	struct ds5 *state = container_of(inode->i_cdev, struct ds5,
-			dfu_dev.ds5_cdev);
+	struct d5x *state = container_of(inode->i_cdev, struct d5x,
+			dfu_dev.d5x_cdev);
 #ifdef CONFIG_TEGRA_CAMERA_PLATFORM
 	struct i2c_adapter *parent = i2c_parent_is_i2c_adapter(
 			state->client->adapter);
@@ -6311,8 +6311,8 @@ static int ds5_dfu_device_open(struct inode *inode, struct file *file)
 		return -EBUSY;
 	}
 	state->dfu_dev.device_open_count++;
-	if (state->dfu_dev.dfu_state_flag != DS5_DFU_RECOVERY)
-		state->dfu_dev.dfu_state_flag = DS5_DFU_OPEN;
+	if (state->dfu_dev.dfu_state_flag != D5X_DFU_RECOVERY)
+		state->dfu_dev.dfu_state_flag = D5X_DFU_OPEN;
 	state->dfu_dev.dfu_msg = devm_kzalloc(&state->client->dev,
 			DFU_BLOCK_SIZE, GFP_KERNEL);
 	if (!state->dfu_dev.dfu_msg) {
@@ -6344,30 +6344,30 @@ static int ds5_dfu_device_open(struct inode *inode, struct file *file)
 
 /* 
  * Adjust sync_mode control range based on device type.
- * Must be called after ds5_mux_init() which creates the control.
+ * Must be called after d5x_mux_init() which creates the control.
  */
-static void ds5_adjust_sync_mode_control(struct i2c_client *client, struct ds5 *state)
+static void d5x_adjust_sync_mode_control(struct i2c_client *client, struct d5x *state)
 {
 	u16 dev_type = 0;
-#if !DS5_BYPASS_CAMERA_I2C
+#if !D5X_BYPASS_CAMERA_I2C
 	int ret;
 #endif
 
 	if (!state->ctrls.sync_mode)
 		return;
 
-	#if DS5_BYPASS_CAMERA_I2C
-	dev_type = DS5_DEVICE_TYPE_D58X;
+	#if D5X_BYPASS_CAMERA_I2C
+	dev_type = D5X_DEVICE_TYPE_D58X;
 #else
-	ret = ds5_read(state, DS5_DEVICE_TYPE, &dev_type);
+	ret = d5x_read(state, D5X_DEVICE_TYPE, &dev_type);
 	if (ret < 0) {
 		dev_warn(&client->dev, "%s(): Failed to read device type\n", __func__);
 		return;
 	}
-	dev_type = ds5_dev_type(state, dev_type);
+	dev_type = d5x_dev_type(state, dev_type);
 #endif
 	switch (dev_type) {
-	case DS5_DEVICE_TYPE_D58X:
+	case D5X_DEVICE_TYPE_D58X:
 		/* D58X supports all 6 sync modes (0-5) */
 		__v4l2_ctrl_modify_range(state->ctrls.sync_mode, 0, 5, 0, 0);
 		state->ctrls.sync_mode->qmenu = sync_mode_menu_full;
@@ -6382,51 +6382,51 @@ static void ds5_adjust_sync_mode_control(struct i2c_client *client, struct ds5 *
 	}
 }
 
-static int ds5_v4l_init(struct i2c_client *c, struct ds5 *state)
+static int d5x_v4l_init(struct i2c_client *c, struct d5x *state)
 {
 	int ret;
 
-	ret = ds5_parse_cam(c, state);
+	ret = d5x_parse_cam(c, state);
 	if (ret < 0)
 		return ret;
 
-	ret = ds5_depth_init(c, state);
+	ret = d5x_depth_init(c, state);
 	if (ret < 0)
 		return ret;
 
-	ret = ds5_ir_init(c, state);
+	ret = d5x_ir_init(c, state);
 	if (ret < 0)
 		goto e_depth;
 
-	ret = ds5_rgb_init(c, state);
+	ret = d5x_rgb_init(c, state);
 	if (ret < 0)
 		goto e_ir;
 
-	ret = ds5_imu_init(c, state);
+	ret = d5x_imu_init(c, state);
 	if (ret < 0)
 		goto e_rgb;
 
-	ret = ds5_mux_init(c, state);
+	ret = d5x_mux_init(c, state);
 	if (ret < 0)
 		goto e_imu;
 
 	/* 
 	 * Adjust sync_mode control range based on device type - must be done
-	 * after ds5_mux_init() creates the control
+	 * after d5x_mux_init() creates the control
 	 */
-	ds5_adjust_sync_mode_control(c, state);
+	d5x_adjust_sync_mode_control(c, state);
 
-	ret = ds5_hw_init(c, state);
+	ret = d5x_hw_init(c, state);
 	if (ret < 0)
 		goto e_mux;
 
-	ret = ds5_mux_register(c, state);
+	ret = d5x_mux_register(c, state);
 	if (ret < 0)
 		goto e_mux;
 
 	return 0;
 e_mux:
-	ds5_mux_remove(state);
+	d5x_mux_remove(state);
 e_imu:
 	media_entity_cleanup(&state->imu.sensor.sd.entity);
 e_rgb:
@@ -6438,9 +6438,9 @@ e_depth:
 	return ret;
 }
 
-static int ds5_dfu_device_release(struct inode *inode, struct file *file)
+static int d5x_dfu_device_release(struct inode *inode, struct file *file)
 {
-	struct ds5 *state = container_of(inode->i_cdev, struct ds5, dfu_dev.ds5_cdev);
+	struct d5x *state = container_of(inode->i_cdev, struct d5x, dfu_dev.d5x_cdev);
 #ifdef CONFIG_TEGRA_CAMERA_PLATFORM
 	struct i2c_adapter *parent = i2c_parent_is_i2c_adapter(
 			state->client->adapter);
@@ -6448,13 +6448,13 @@ static int ds5_dfu_device_release(struct inode *inode, struct file *file)
 	int ret = 0, retry = 10;
 	mutex_lock(&state->lock);
 	state->dfu_dev.device_open_count--;
-	if (state->dfu_dev.dfu_state_flag != DS5_DFU_RECOVERY)
-		state->dfu_dev.dfu_state_flag = DS5_DFU_IDLE;
+	if (state->dfu_dev.dfu_state_flag != D5X_DFU_RECOVERY)
+		state->dfu_dev.dfu_state_flag = D5X_DFU_IDLE;
 	/* We disable this section as it has no effect when device in operational
 	   mode and has not enough effect when device in recovery mode */
-	// if (state->dfu_dev.dfu_state_flag == DS5_DFU_DONE
+	// if (state->dfu_dev.dfu_state_flag == D5X_DFU_DONE
 	// 		&& state->dfu_dev.init_v4l_f)
-	// 	ds5_v4l_init(state->client, state);
+	// 	d5x_v4l_init(state->client, state);
 	// state->dfu_dev.init_v4l_f = 0;
 	if (state->dfu_dev.dfu_msg)
 		devm_kfree(&state->client->dev, state->dfu_dev.dfu_msg);
@@ -6476,7 +6476,7 @@ static int ds5_dfu_device_release(struct inode *inode, struct file *file)
 #endif
 	/* Verify communication */
 	do {
-		ret = ds5_read(state, DS5_FW_VERSION, &state->fw_version);
+		ret = d5x_read(state, D5X_FW_VERSION, &state->fw_version);
 		if (ret)
 			msleep_range(10);
 	} while (retry-- && ret != 0 );
@@ -6486,62 +6486,62 @@ static int ds5_dfu_device_release(struct inode *inode, struct file *file)
 		mutex_unlock(&state->lock);
 		return ret;
 	}
-	ret = ds5_read(state, DS5_FW_BUILD, &state->fw_build);
+	ret = d5x_read(state, D5X_FW_BUILD, &state->fw_build);
 	mutex_unlock(&state->lock);
 	return ret;
 };
 
-static const struct file_operations ds5_device_file_ops = {
+static const struct file_operations d5x_device_file_ops = {
 	.owner = THIS_MODULE,
-	.read = &ds5_dfu_device_read,
-	.write = &ds5_dfu_device_write,
-	.open = &ds5_dfu_device_open,
-	.release = &ds5_dfu_device_release
+	.read = &d5x_dfu_device_read,
+	.write = &d5x_dfu_device_write,
+	.open = &d5x_dfu_device_open,
+	.release = &d5x_dfu_device_release
 };
 
-struct class *g_ds5_class;
-atomic_t primary_chardev = ATOMIC_INIT(0);
+struct class *d5x_global_class;
+atomic_t d5x_primary_chardev = ATOMIC_INIT(0);
 
-static int ds5_chrdev_init(struct i2c_client *c, struct ds5 *state)
+static int d5x_chrdev_init(struct i2c_client *c, struct d5x *state)
 {
-	struct cdev *ds5_cdev = &state->dfu_dev.ds5_cdev;
-	struct class **ds5_class = &state->dfu_dev.ds5_class;
+	struct cdev *d5x_cdev = &state->dfu_dev.d5x_cdev;
+	struct class **d5x_class = &state->dfu_dev.d5x_class;
 #ifndef CONFIG_OF
 	struct d4xx_pdata *pdata = c->dev.platform_data;
 	char suffix = pdata->suffix;
 #endif
 	struct device *chr_dev;
-	char dev_name[sizeof(DS5_DRIVER_NAME_DFU) + 8];
+	char dev_name[sizeof(D5X_DRIVER_NAME_DFU) + 8];
 	dev_t *dev_num = &c->dev.devt;
 	int ret;
 
 	dev_dbg(&c->dev, "%s()\n", __func__);
 	/* Request the kernel for N_MINOR devices */
-	ret = alloc_chrdev_region(dev_num, 0, 1, DS5_DRIVER_NAME_DFU);
+	ret = alloc_chrdev_region(dev_num, 0, 1, D5X_DRIVER_NAME_DFU);
 	if (ret < 0)
 		return ret;
 
-	if (!atomic_read(&primary_chardev)) {
+	if (!atomic_read(&d5x_primary_chardev)) {
 		dev_dbg(&c->dev, "%s(): <Major, Minor>: <%d, %d>\n",
 				__func__, MAJOR(*dev_num), MINOR(*dev_num));
 		/* Create a class : appears at /sys/class */
 #if defined(NV_CLASS_CREATE_HAS_NO_OWNER_ARG) || LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
-		*ds5_class = class_create(THIS_MODULE, DS5_DRIVER_NAME_CLASS);
+		*d5x_class = class_create(THIS_MODULE, D5X_DRIVER_NAME_CLASS);
 #else
-		*ds5_class = class_create(DS5_DRIVER_NAME_CLASS);
+		*d5x_class = class_create(D5X_DRIVER_NAME_CLASS);
 #endif
 		dev_warn(&state->client->dev, "%s() class_create\n", __func__);
-		if (IS_ERR(*ds5_class)) {
+		if (IS_ERR(*d5x_class)) {
 			dev_err(&c->dev, "Could not create class device\n");
 			unregister_chrdev_region(0, 1);
-			ret = PTR_ERR(*ds5_class);
+			ret = PTR_ERR(*d5x_class);
 			return ret;
 		}
-		g_ds5_class = *ds5_class;
+		d5x_global_class = *d5x_class;
 	} else
-		*ds5_class = g_ds5_class;
+		*d5x_class = d5x_global_class;
 	/* Associate the cdev with a set of file_operations */
-	cdev_init(ds5_cdev, &ds5_device_file_ops);
+	cdev_init(d5x_cdev, &d5x_device_file_ops);
 	/* Build up the current device number. To be used further */
 	*dev_num = MKDEV(MAJOR(*dev_num), MINOR(*dev_num));
 	/* Create a device node for this device. */
@@ -6549,135 +6549,135 @@ static int ds5_chrdev_init(struct i2c_client *c, struct ds5 *state)
 	if (state->aggregated)
 		suffix += 4;
 	snprintf(dev_name, sizeof(dev_name), "%s-%c",
-		DS5_DRIVER_NAME_DFU, suffix);
+		D5X_DRIVER_NAME_DFU, suffix);
 #else
 	snprintf (dev_name, sizeof(dev_name), "%s-%d-%04x",
-			DS5_DRIVER_NAME_DFU, i2c_adapter_id(c->adapter), c->addr);
+			D5X_DRIVER_NAME_DFU, i2c_adapter_id(c->adapter), c->addr);
 #endif
-	chr_dev = device_create(*ds5_class, NULL, *dev_num, NULL, dev_name);
+	chr_dev = device_create(*d5x_class, NULL, *dev_num, NULL, dev_name);
 	if (IS_ERR(chr_dev)) {
 		ret = PTR_ERR(chr_dev);
 		dev_err(&c->dev, "Could not create device\n");
-		class_destroy(*ds5_class);
+		class_destroy(*d5x_class);
 		unregister_chrdev_region(0, 1);
 		return ret;
 	}
-	cdev_add(ds5_cdev, *dev_num, 1);
-	atomic_inc(&primary_chardev);
+	cdev_add(d5x_cdev, *dev_num, 1);
+	atomic_inc(&d5x_primary_chardev);
 	return 0;
 };
 
-static int ds5_chrdev_remove(struct ds5 *state)
+static int d5x_chrdev_remove(struct d5x *state)
 {
-	struct class **ds5_class = &state->dfu_dev.ds5_class;
+	struct class **d5x_class = &state->dfu_dev.d5x_class;
 	dev_t *dev_num = &state->client->dev.devt;
-	if (!ds5_class) {
+	if (!d5x_class) {
 		return 0;
 	}
 	dev_dbg(&state->client->dev, "%s()\n", __func__);
 	unregister_chrdev_region(*dev_num, 1);
-	device_destroy(*ds5_class, *dev_num);
-	if (atomic_dec_and_test(&primary_chardev)) {
+	device_destroy(*d5x_class, *dev_num);
+	if (atomic_dec_and_test(&d5x_primary_chardev)) {
 		dev_warn(&state->client->dev, "%s() class_destroy\n", __func__);
-		class_destroy(*ds5_class);
+		class_destroy(*d5x_class);
 	}
 	return 0;
 }
 
 /* SYSFS attributes */
 #ifdef CONFIG_SYSFS
-static ssize_t ds5_fw_ver_show(struct device *dev,
+static ssize_t d5x_fw_ver_show(struct device *dev,
 		struct device_attribute *attr, char *buf)
 {
 	struct i2c_client *c = to_i2c_client(dev);
-	struct ds5 *state = container_of(i2c_get_clientdata(c),
-			struct ds5, mux.sd.subdev);
+	struct d5x *state = container_of(i2c_get_clientdata(c),
+			struct d5x, mux.sd.subdev);
 
-	ds5_read(state, DS5_FW_VERSION, &state->fw_version);
-	ds5_read(state, DS5_FW_BUILD, &state->fw_build);
+	d5x_read(state, D5X_FW_VERSION, &state->fw_version);
+	d5x_read(state, D5X_FW_BUILD, &state->fw_build);
 
 	return snprintf(buf, PAGE_SIZE, "D4XX Sensor: %s, Version: %d.%d.%d.%d\n",
-			ds5_get_sensor_name(state),
+			d5x_get_sensor_name(state),
 			(state->fw_version >> 8) & 0xff, state->fw_version & 0xff,
 			(state->fw_build >> 8) & 0xff, state->fw_build & 0xff);
 }
 
-static DEVICE_ATTR_RO(ds5_fw_ver);
+static DEVICE_ATTR_RO(d5x_fw_ver);
 
 /* Derive 'device_attribute' structure for a read register's attribute */
-struct dev_ds5_reg_attribute {
+struct dev_d5x_reg_attribute {
 	struct device_attribute attr;
 	u16 reg;
 	u8 valid;
 };
 
 /*
- * Read DS5 register.
- * ds5_read_reg_show will actually read register from ds5 while
- * ds5_read_reg_store will store register to read
+ * Read a D5xx register.
+ * d5x_read_reg_show will actually read register from d5x while
+ * d5x_read_reg_store will store register to read
  * Example:
- * echo -n "0xc03c" >ds5_read_reg
+ * echo -n "0xc03c" >d5x_read_reg
  * Read register result:
- * cat ds5_read_reg
+ * cat d5x_read_reg
  * Expected:
  * reg:0xc93c, result:0x11
  */
-static ssize_t ds5_read_reg_show(struct device *dev,
+static ssize_t d5x_read_reg_show(struct device *dev,
 		struct device_attribute *attr, char *buf)
 {
 	u16 rbuf;
 	int n;
 	struct i2c_client *c = to_i2c_client(dev);
-	struct ds5 *state = container_of(i2c_get_clientdata(c),
-			struct ds5, mux.sd.subdev);
-	struct dev_ds5_reg_attribute *ds5_rw_attr = container_of(attr,
-			struct dev_ds5_reg_attribute, attr);
-	if (ds5_rw_attr->valid != 1)
+	struct d5x *state = container_of(i2c_get_clientdata(c),
+			struct d5x, mux.sd.subdev);
+	struct dev_d5x_reg_attribute *d5x_rw_attr = container_of(attr,
+			struct dev_d5x_reg_attribute, attr);
+	if (d5x_rw_attr->valid != 1)
 		return -EINVAL;
-	ds5_read(state, ds5_rw_attr->reg, &rbuf);
+	d5x_read(state, d5x_rw_attr->reg, &rbuf);
 
 	n = snprintf(buf, PAGE_SIZE, "register:0x%4x, value:0x%02x\n",
-			ds5_rw_attr->reg, rbuf);
+			d5x_rw_attr->reg, rbuf);
 
 	return n;
 }
 
 /* 
- * Read DS5 register - Store reg to attr struct pointer
- * ds5_read_reg_show will actually read register from ds5 while
- * ds5_read_reg_store will store module, offset and length
+ * Select the D5xx register exposed through the read attribute.
+ * d5x_read_reg_show will actually read register from d5x while
+ * d5x_read_reg_store will store module, offset and length
  */
-static ssize_t ds5_read_reg_store(struct device *dev,
+static ssize_t d5x_read_reg_store(struct device *dev,
 		struct device_attribute *attr, const char *buf, size_t count)
 {
-	struct dev_ds5_reg_attribute *ds5_rw_attr = container_of(attr,
-			struct dev_ds5_reg_attribute, attr);
+	struct dev_d5x_reg_attribute *d5x_rw_attr = container_of(attr,
+			struct dev_d5x_reg_attribute, attr);
 	int rc = -1;
 	u32 reg;
-	ds5_rw_attr->valid = 0;
+	d5x_rw_attr->valid = 0;
 	/* Decode input */
 	rc = sscanf(buf, "0x%04x", &reg);
 	if (rc != 1)
 		return -EINVAL;
-	ds5_rw_attr->reg = reg;
-	ds5_rw_attr->valid = 1;
+	d5x_rw_attr->reg = reg;
+	d5x_rw_attr->valid = 1;
 	return count;
 }
 
-#define DS5_RW_REG_ATTR(_name) \
-		struct dev_ds5_reg_attribute dev_attr_##_name = { \
+#define D5X_RW_REG_ATTR(_name) \
+		struct dev_d5x_reg_attribute dev_attr_##_name = { \
 			__ATTR(_name, S_IRUGO | S_IWUSR, \
-			ds5_read_reg_show, ds5_read_reg_store), \
+			d5x_read_reg_show, d5x_read_reg_store), \
 			0, 0 }
 
-static DS5_RW_REG_ATTR(ds5_read_reg);
+static D5X_RW_REG_ATTR(d5x_read_reg);
 
-static ssize_t ds5_write_reg_store(struct device *dev,
+static ssize_t d5x_write_reg_store(struct device *dev,
 		struct device_attribute *attr, const char *buf, size_t count)
 {
 	struct i2c_client *c = to_i2c_client(dev);
-	struct ds5 *state = container_of(i2c_get_clientdata(c),
-			struct ds5, mux.sd.subdev);
+	struct d5x *state = container_of(i2c_get_clientdata(c),
+			struct d5x, mux.sd.subdev);
 
 	int rc = -1;
 	u32 reg, w_val = 0;
@@ -6688,32 +6688,32 @@ static ssize_t ds5_write_reg_store(struct device *dev,
 		return -EINVAL;
 	val = w_val & 0xffff;
 	mutex_lock(&state->lock);
-	ds5_write(state, reg, val);
+	d5x_write(state, reg, val);
 	mutex_unlock(&state->lock);
 	return count;
 }
 
-static DEVICE_ATTR_WO(ds5_write_reg);
+static DEVICE_ATTR_WO(d5x_write_reg);
 
-static struct attribute *ds5_attributes[] = {
-		&dev_attr_ds5_fw_ver.attr,
-		&dev_attr_ds5_read_reg.attr.attr,
-		&dev_attr_ds5_write_reg.attr,
+static struct attribute *d5x_attributes[] = {
+		&dev_attr_d5x_fw_ver.attr,
+		&dev_attr_d5x_read_reg.attr.attr,
+		&dev_attr_d5x_write_reg.attr,
 		NULL
 };
 
-static const struct attribute_group ds5_attr_group = {
-	.attrs = ds5_attributes,
+static const struct attribute_group d5x_attr_group = {
+	.attrs = d5x_attributes,
 };
 #endif /* CONFIG_SYSFS */
 
-static int ds5_probe(struct i2c_client *c
+static int d5x_probe(struct i2c_client *c
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 		, const struct i2c_device_id *id
 #endif
 		)
 {
-	struct ds5 *state = devm_kzalloc(&c->dev, sizeof(*state), GFP_KERNEL);
+	struct d5x *state = devm_kzalloc(&c->dev, sizeof(*state), GFP_KERNEL);
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
 	const struct i2c_device_id *id = i2c_client_get_device_id(c);
 #endif
@@ -6743,7 +6743,7 @@ static int ds5_probe(struct i2c_client *c
 		c->addr = override_addr;
 	}
 #endif
-	state->variant = ds5_variants + id->driver_data;
+	state->variant = d5x_variants + id->driver_data;
 #ifdef CONFIG_OF
 	state->vcc = devm_regulator_get(&c->dev, "vcc");
 	if (IS_ERR(state->vcc)) {
@@ -6760,7 +6760,7 @@ static int ds5_probe(struct i2c_client *c
 		}
 	}
 #endif
-	state->regmap = devm_regmap_init_i2c(c, &ds5_regmap_config);
+	state->regmap = devm_regmap_init_i2c(c, &d5x_regmap_config);
 	if (IS_ERR(state->regmap)) {
 		ret = PTR_ERR(state->regmap);
 		dev_err(&c->dev, "regmap init failed: %d\n", ret);
@@ -6768,30 +6768,30 @@ static int ds5_probe(struct i2c_client *c
 	}
 
 #ifdef CONFIG_VIDEO_D5XX_SERDES
-	ret = ds5_serdes_setup(state);
+	ret = d5x_serdes_setup(state);
 	if (ret < 0)
 		goto e_regulator;
 	serdes_setup_done = true;
 	state->reset_ref_dser = atomic_read(dser_get_reset_gen(state));
 #else
-	ds5_init_global_slots_once();
-	mutex_lock(&ds5_inited[0].lock);
-	if (NULL == ds5_inited[0].ds5_primary) {
-		ds5_init_ds5_dev(state, &ds5_inited[0]);
-		dev_dbg(&c->dev, "%s(): set primary ds5 instance\n", __func__);
+	d5x_init_global_slots_once();
+	mutex_lock(&d5x_inited[0].lock);
+	if (NULL == d5x_inited[0].d5x_primary) {
+		d5x_init_d5x_dev(state, &d5x_inited[0]);
+		dev_dbg(&c->dev, "%s(): set primary d5x instance\n", __func__);
 	}
-	state->ds5_dev = &ds5_inited[0];
-	mutex_unlock(&ds5_inited[0].lock);
+	state->d5x_dev = &d5x_inited[0];
+	mutex_unlock(&d5x_inited[0].lock);
 #endif
-	state->reset_ref_ds5 = atomic_read(ds5_get_reset_gen(state));
+	state->reset_ref_d5x = atomic_read(d5x_get_reset_gen(state));
 
-#if DS5_BYPASS_CAMERA_I2C
+#if D5X_BYPASS_CAMERA_I2C
 	/* Skip camera I2C verification - use hardcoded FW version */
 	state->fw_version = 0x0516;
 	dev_info(&c->dev, "%s(): BYPASS - skip camera I2C verify, fake FW 5.22\n", __func__);
 #else
 	/* Verify communication */
-	ret = ds5_read(state, DS5_FW_VERSION, &state->fw_version);
+	ret = d5x_read(state, D5X_FW_VERSION, &state->fw_version);
 	if (ret < 0) {
 		dev_err(&c->dev,
 			"%s(): cannot communicate with D4XX: %d on addr: 0x%x\n",
@@ -6808,23 +6808,23 @@ static int ds5_probe(struct i2c_client *c
 	ret = of_property_read_string(c->dev.of_node, "cam-type", &str);
 	if (!ret && !strncmp(str, "Depth", strlen("Depth"))) {
 		state->is_depth = 1;
-		state->control_base = DS5_DEPTH_CONTROL_BASE;
-		state->control_status_reg = DS5_DEPTH_CONTROL_STATUS;
+		state->control_base = D5X_DEPTH_CONTROL_BASE;
+		state->control_status_reg = D5X_DEPTH_CONTROL_STATUS;
 	}
 	if (!ret && !strncmp(str, "Y8", strlen("Y8"))) {
 		state->is_y8 = 1;
-		state->control_base = DS5_DEPTH_CONTROL_BASE;
-		state->control_status_reg = DS5_DEPTH_CONTROL_STATUS;
+		state->control_base = D5X_DEPTH_CONTROL_BASE;
+		state->control_status_reg = D5X_DEPTH_CONTROL_STATUS;
 	}
 	if (!ret && !strncmp(str, "RGB", strlen("RGB"))) {
 		state->is_rgb = 1;
-		state->control_base = DS5_RGB_CONTROL_BASE;
-		state->control_status_reg = DS5_RGB_CONTROL_STATUS;
+		state->control_base = D5X_RGB_CONTROL_BASE;
+		state->control_status_reg = D5X_RGB_CONTROL_STATUS;
 	}
 	if (!ret && !strncmp(str, "IMU", strlen("IMU"))) {
 		state->is_imu = 1;
-		state->control_base = DS5_DEPTH_CONTROL_BASE;
-		state->control_status_reg = DS5_DEPTH_CONTROL_STATUS;
+		state->control_base = D5X_DEPTH_CONTROL_BASE;
+		state->control_status_reg = D5X_DEPTH_CONTROL_STATUS;
 	}
 
 	mode0_node = of_get_child_by_name(state->client->dev.of_node, "mode0");
@@ -6848,32 +6848,32 @@ static int ds5_probe(struct i2c_client *c
 	dev_dbg(&state->client->dev, "metadata_enabled = %d\n", state->metadata_enabled);
 #else
 	state->is_depth = 1;
-	state->control_base = DS5_DEPTH_CONTROL_BASE;
-	state->control_status_reg = DS5_DEPTH_CONTROL_STATUS;
+	state->control_base = D5X_DEPTH_CONTROL_BASE;
+	state->control_status_reg = D5X_DEPTH_CONTROL_STATUS;
 #endif
 
 	if (!state->control_base) {
-		state->control_base = DS5_DEPTH_CONTROL_BASE;
-		state->control_status_reg = DS5_DEPTH_CONTROL_STATUS;
+		state->control_base = D5X_DEPTH_CONTROL_BASE;
+		state->control_status_reg = D5X_DEPTH_CONTROL_STATUS;
 	}
 	/* create DFU chardev once */
 	if (state->is_depth) {
-		ret = ds5_chrdev_init(c, state);
+		ret = d5x_chrdev_init(c, state);
 		if (ret < 0)
 			goto e_regulator;
 	}
 
 	/* 
 	 * Verify format-discovery readiness.
-	 * FW_VERSION becomes readable earlier than DS5_DEVICE_TYPE, while later
+	 * FW_VERSION becomes readable earlier than D5X_DEVICE_TYPE, while later
 	 * probe code depends on DEVICE_TYPE to pick the correct format tables.
 	 */
-#if DS5_BYPASS_CAMERA_I2C
-	rec_state = DS5_DEVICE_TYPE_D58X;
-	WRITE_ONCE(state->ds5_dev->cached_device_type, rec_state);
+#if D5X_BYPASS_CAMERA_I2C
+	rec_state = D5X_DEVICE_TYPE_D58X;
+	WRITE_ONCE(state->d5x_dev->cached_device_type, rec_state);
 	dev_info(&c->dev, "%s(): BYPASS - hardcode device type D58X\n", __func__);
 #else
-	ret = ds5_wait_device_type(state, &rec_state);
+	ret = d5x_wait_device_type(state, &rec_state);
 	if (ret < 0) {
 		dev_err(&c->dev,
 			"%s(): device type is not valid: %d (last val 0x%x)\n",
@@ -6881,32 +6881,32 @@ static int ds5_probe(struct i2c_client *c
 		goto e_chardev;
 	}
 
-	ret = ds5_read(state, DS5_DFU_MAGIC_REG, &rec_state);
+	ret = d5x_read(state, D5X_DFU_MAGIC_REG, &rec_state);
 	if (ret < 0)
 		rec_state = 0;
 
-	if (rec_state == DS5_DFU_MAGIC_LSW) {
+	if (rec_state == D5X_DFU_MAGIC_LSW) {
 		dev_info(&c->dev, "%s(): D4XX recovery state\n", __func__);
-		state->dfu_dev.dfu_state_flag = DS5_DFU_RECOVERY;
+		state->dfu_dev.dfu_state_flag = D5X_DFU_RECOVERY;
 		/* Override I2C drvdata with state for use in remove function */
 		i2c_set_clientdata(c, state);
 		return 0;
 	}
 #endif
 
-#if DS5_BYPASS_CAMERA_I2C
+#if D5X_BYPASS_CAMERA_I2C
 	state->fw_build = 0x0100;
 #else
-	ds5_read_with_check(state, DS5_FW_VERSION, &state->fw_version);
-	ds5_read_with_check(state, DS5_FW_BUILD, &state->fw_build);
+	d5x_read_with_check(state, D5X_FW_VERSION, &state->fw_version);
+	d5x_read_with_check(state, D5X_FW_BUILD, &state->fw_build);
 #endif
 
 	dev_info(&c->dev, "D4XX Sensor: %s, firmware build: %d.%d.%d.%d\n",
-			ds5_get_sensor_name(state),
+			d5x_get_sensor_name(state),
 			(state->fw_version >> 8) & 0xff, state->fw_version & 0xff,
 			(state->fw_build >> 8) & 0xff, state->fw_build & 0xff);
 
-	ret = ds5_v4l_init(c, state);
+	ret = d5x_v4l_init(c, state);
 	if (ret < 0)
 		goto e_chardev;
 
@@ -6916,16 +6916,16 @@ static int ds5_probe(struct i2c_client *c
 #ifdef CONFIG_SYSFS
 	/* Custom sysfs attributes */
 	/* create the sysfs file group */
-	err = sysfs_create_group(&state->client->dev.kobj, &ds5_attr_group);
+	err = sysfs_create_group(&state->client->dev.kobj, &d5x_attr_group);
 #endif
 	return 0;
 
 e_chardev:
-	if (state->dfu_dev.ds5_class)
-		ds5_chrdev_remove(state);
+	if (state->dfu_dev.d5x_class)
+		d5x_chrdev_remove(state);
 e_regulator:
 #ifdef CONFIG_VIDEO_D5XX_SERDES
-	ds5_serdes_cleanup(state, serdes_setup_done);
+	d5x_serdes_cleanup(state, serdes_setup_done);
 #endif
 	if (state->vcc)
 		regulator_disable(state->vcc);
@@ -6941,18 +6941,18 @@ e_regulator:
 }
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 12)
-static int ds5_remove(struct i2c_client *c)
+static int d5x_remove(struct i2c_client *c)
 #else
-static void ds5_remove(struct i2c_client *c)
+static void d5x_remove(struct i2c_client *c)
 #endif
 {
-	struct ds5 *state = container_of(i2c_get_clientdata(c), struct ds5, mux.sd.subdev);
+	struct d5x *state = container_of(i2c_get_clientdata(c), struct d5x, mux.sd.subdev);
 	if (state && !state->mux.sd.subdev.v4l2_dev) {
 		state = i2c_get_clientdata(c);
 	}
 
 #ifdef CONFIG_VIDEO_D5XX_SERDES
-	ds5_serdes_cleanup(state, true);
+	d5x_serdes_cleanup(state, true);
 #ifndef CONFIG_OF
 	if (state->ser_i2c)
 		i2c_unregister_device(state->ser_i2c);
@@ -6964,20 +6964,20 @@ static void ds5_remove(struct i2c_client *c)
 	state->is_depth = 1;
 #endif
 	dev_info(&c->dev, "D4XX remove %s\n",
-			ds5_get_sensor_name(state));
+			d5x_get_sensor_name(state));
 	if (state->vcc)
 		regulator_disable(state->vcc);
 
-	if (state->dfu_dev.dfu_state_flag != DS5_DFU_RECOVERY && \
+	if (state->dfu_dev.dfu_state_flag != D5X_DFU_RECOVERY && \
 		 state->mux.sd.subdev.v4l2_dev) {
 #ifdef CONFIG_SYSFS
-		sysfs_remove_group(&c->dev.kobj, &ds5_attr_group);
+		sysfs_remove_group(&c->dev.kobj, &d5x_attr_group);
 #endif
-		ds5_mux_remove(state);
+		d5x_mux_remove(state);
 	}
 
-	if (state->is_depth && state->dfu_dev.ds5_class) {
-		ds5_chrdev_remove(state);
+	if (state->is_depth && state->dfu_dev.d5x_class) {
+		d5x_chrdev_remove(state);
 	}
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 12)
@@ -6985,13 +6985,13 @@ static void ds5_remove(struct i2c_client *c)
 #endif
 }
 
-static const struct i2c_device_id ds5_id[] = {
-	{ DS5_DRIVER_NAME, DS5_DS5U },
-	{ DS5_DRIVER_NAME_ASR, DS5_ASR },
-	{ DS5_DRIVER_NAME_AWG, DS5_AWG },
+static const struct i2c_device_id d5x_id[] = {
+	{ D5X_DRIVER_NAME, D5X_DS5U },
+	{ D5X_DRIVER_NAME_ASR, D5X_ASR },
+	{ D5X_DRIVER_NAME_AWG, D5X_AWG },
 	{ },
 };
-MODULE_DEVICE_TABLE(i2c, ds5_id);
+MODULE_DEVICE_TABLE(i2c, d5x_id);
 
 static const struct of_device_id d5xx_of_match[] = {
 	{ .compatible = "realsense,d5xx", },
@@ -6999,18 +6999,18 @@ static const struct of_device_id d5xx_of_match[] = {
 };
 MODULE_DEVICE_TABLE(of, d5xx_of_match);
 
-static struct i2c_driver ds5_i2c_driver = {
+static struct i2c_driver d5x_i2c_driver = {
 	.driver = {
 		.owner = THIS_MODULE,
 		.of_match_table = of_match_ptr(d5xx_of_match),
-		.name = DS5_DRIVER_NAME
+		.name = D5X_DRIVER_NAME
 	},
-	.probe		= ds5_probe,
-	.remove		= ds5_remove,
-	.id_table	= ds5_id,
+	.probe		= d5x_probe,
+	.remove		= d5x_remove,
+	.id_table	= d5x_id,
 };
 
-module_i2c_driver(ds5_i2c_driver);
+module_i2c_driver(d5x_i2c_driver);
 
 MODULE_DESCRIPTION("RealSense D5XX Camera Driver");
 MODULE_AUTHOR("Guennadi Liakhovetski <guennadi.liakhovetski@intel.com>,\n\

--- a/kernel/realsense/d5xx.c
+++ b/kernel/realsense/d5xx.c
@@ -4268,10 +4268,70 @@ error:
 	return err;
 }
 
+static void ds5_serdes_cleanup(struct ds5 *state, bool reset_control)
+{
+	int ret;
+	bool do_cleanup = false;
+	struct device *dev;
+
+	if (!state || !state->serdes_primary)
+		return;
+
+	dev = &state->client->dev;
+
+	mutex_lock(&serdes_lock__);
+	if (state->ds5_dev) {
+		mutex_lock(&state->ds5_dev->lock);
+		if (state->ds5_dev->ds5_primary == state) {
+			state->ds5_dev->ds5_primary = NULL;
+			do_cleanup = true;
+		}
+		mutex_unlock(&state->ds5_dev->lock);
+	}
+
+	if (do_cleanup) {
+		if (reset_control && state->ser_dev) {
+			ret = max96717_reset_control(state->ser_dev);
+			if (ret)
+				dev_warn(dev, "failed in 96717 reset control\n");
+		}
+
+		if (reset_control && state->dser_ops && state->dser_dev) {
+			ret = state->dser_ops->reset_control(state->dser_dev,
+							    state->g_ctx.s_dev);
+			if (ret)
+				dev_warn(dev, "failed in %s reset control\n",
+					 state->dser_ops->name);
+		}
+
+		if (state->ser_dev) {
+			ret = max96717_sdev_unpair(state->ser_dev,
+						   state->g_ctx.s_dev);
+			if (ret)
+				dev_warn(dev, "failed to unpair sdev\n");
+		}
+
+		if (state->dser_ops && state->dser_dev) {
+			ret = state->dser_ops->sdev_unregister(state->dser_dev,
+							      state->g_ctx.s_dev);
+			if (ret)
+				dev_warn(dev, "failed to %s unregister sdev\n",
+					 state->dser_ops->name);
+		}
+
+		if (reset_control && state->dser_ops && state->dser_dev)
+			state->dser_ops->power_off(state->dser_dev);
+	}
+	mutex_unlock(&serdes_lock__);
+
+	state->serdes_primary = false;
+}
+
 static int ds5_serdes_setup(struct ds5 *state)
 {
 	int ret = 0;
 	struct i2c_client *c = state->client;
+	bool control_setup_done = false;
 
 	ret = ds5_board_setup(state);
 	if (ret) {
@@ -4309,6 +4369,7 @@ static int ds5_serdes_setup(struct ds5 *state)
 		dev_err(&c->dev, "%s gmsl serdes setup failed\n", __func__);
 		goto serdes_setup_end;
 	}
+	control_setup_done = true;
 
 	/*
 	 * max96717_init_settings is now called inside ds5_gmsl_serdes_setup,
@@ -4365,10 +4426,8 @@ static int ds5_serdes_setup(struct ds5 *state)
 	state->dser_ops->reset_oneshot(state->dser_dev);
 
 serdes_setup_end:
-	if (ret) {
-		max96717_sdev_unpair(state->ser_dev, state->g_ctx.s_dev);
-		state->dser_ops->sdev_unregister(state->dser_dev, state->g_ctx.s_dev);
-	}
+	if (ret)
+		ds5_serdes_cleanup(state, control_setup_done);
 
 	return ret;
 }
@@ -6665,6 +6724,9 @@ static int ds5_probe(struct i2c_client *c
 	uint32_t override_addr = 0;
 	struct device_node *mode0_node;
 #endif
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+	bool serdes_setup_done = false;
+#endif
 	if (!state)
 		return -ENOMEM;
 
@@ -6709,6 +6771,7 @@ static int ds5_probe(struct i2c_client *c
 	ret = ds5_serdes_setup(state);
 	if (ret < 0)
 		goto e_regulator;
+	serdes_setup_done = true;
 	state->reset_ref_dser = atomic_read(dser_get_reset_gen(state));
 #else
 	ds5_init_global_slots_once();
@@ -6861,6 +6924,9 @@ e_chardev:
 	if (state->dfu_dev.ds5_class)
 		ds5_chrdev_remove(state);
 e_regulator:
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+	ds5_serdes_cleanup(state, serdes_setup_done);
+#endif
 	if (state->vcc)
 		regulator_disable(state->vcc);
 #ifdef CONFIG_VIDEO_D5XX_SERDES
@@ -6886,45 +6952,7 @@ static void ds5_remove(struct i2c_client *c)
 	}
 
 #ifdef CONFIG_VIDEO_D5XX_SERDES
-	if (state->serdes_primary) {
-		int ret;
-		bool do_cleanup = false;
-
-		mutex_lock(&serdes_lock__);
-		mutex_lock(&state->ds5_dev->lock);
-
-		if (state->ds5_dev->ds5_primary) {
-			state->ds5_dev->ds5_primary = NULL;
-			do_cleanup = true;
-		}
-
-		mutex_unlock(&state->ds5_dev->lock);
-
-		if (do_cleanup) {
-			ret = max96717_reset_control(state->ser_dev);
-			if (ret)
-				dev_warn(&c->dev,
-					"failed in 96717 reset control\n");
-			ret = state->dser_ops->reset_control(state->dser_dev,
-				state->g_ctx.s_dev);
-			if (ret)
-				dev_warn(&c->dev,
-					"failed in %s reset control\n", state->dser_ops->name);
-			ret = max96717_sdev_unpair(state->ser_dev,
-				state->g_ctx.s_dev);
-			if (ret)
-				dev_warn(&c->dev, "failed to unpair sdev\n");
-			ret = state->dser_ops->sdev_unregister(state->dser_dev,
-				state->g_ctx.s_dev);
-			if (ret)
-				dev_warn(&c->dev,
-					"failed to %s unregister sdev\n", state->dser_ops->name);
-			state->dser_ops->power_off(state->dser_dev);
-		}
-
-		mutex_unlock(&serdes_lock__);
-
-	}
+	ds5_serdes_cleanup(state, true);
 #ifndef CONFIG_OF
 	if (state->ser_i2c)
 		i2c_unregister_device(state->ser_i2c);

--- a/nvidia-oot/files/6.2/drivers/media/i2c/max96724.c
+++ b/nvidia-oot/files/6.2/drivers/media/i2c/max96724.c
@@ -663,11 +663,12 @@ static int max96724_get_sdev_idx(struct device *dev,
 	int err = 0;
 
 	mutex_lock(&priv->lock);
-	for (i = 0; i < priv->max_src; i++) {
-		if (priv->sources[i].g_ctx->s_dev == s_dev)
+	for (i = 0; i < priv->num_src; i++) {
+		if (priv->sources[i].g_ctx &&
+		    priv->sources[i].g_ctx->s_dev == s_dev)
 			break;
 	}
-	if (i == priv->max_src) {
+	if (i == priv->num_src) {
 		dev_err(dev, "no sdev found\n");
 		err = -EINVAL;
 		goto ret;
@@ -714,6 +715,15 @@ static void max96724_reset_ctx(struct max96724 *priv)
 	max96724_pipes_reset(priv);
 	for (i = 0; i < priv->num_src; i++)
 		priv->sources[i].st_enabled = false;
+}
+
+static bool max96724_same_link_source(const struct gmsl_link_ctx *a,
+				      const struct gmsl_link_ctx *b)
+{
+	return a && b &&
+	       a->serdes_csi_link == b->serdes_csi_link &&
+	       a->num_csi_lanes == b->num_csi_lanes &&
+	       a->csi_mode == b->csi_mode;
 }
 
 static void max96724_apply_porta_subset(struct device *dev,
@@ -1191,41 +1201,63 @@ int max96724_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx)
 
 	mutex_lock(&priv->lock);
 
-	if (priv->num_src > priv->max_src) {
-		dev_err(dev,
-			"%s: MAX96724 inputs size exhausted\n", __func__);
-		err = -ENOMEM;
-		goto error;
-	}
-
 	if (priv->csi_mode == MAX96724_CSI_MODE_2X4) {
 		if (!((g_ctx->csi_mode == GMSL_CSI_1X4_MODE) ||
 		      (g_ctx->csi_mode == GMSL_CSI_2X4_MODE))) {
 			dev_err(dev, "%s: csi mode not supported\n", __func__);
 			err = -EINVAL;
-			goto error;
+			goto done;
 		}
 	} else {
 		dev_err(dev, "%s: only csi 2x4 mode is supported\n", __func__);
 		err = -EINVAL;
-		goto error;
+		goto done;
 	}
 
 	for (i = 0; i < priv->num_src; i++) {
-		if (g_ctx->serdes_csi_link ==
-		    priv->sources[i].g_ctx->serdes_csi_link) {
-			dev_err(dev,
-				"%s: serdes csi link is in use\n", __func__);
-			err = -EINVAL;
-			goto error;
+		struct gmsl_link_ctx *old_ctx = priv->sources[i].g_ctx;
+
+		if (!old_ctx)
+			continue;
+
+		if (old_ctx->s_dev == g_ctx->s_dev) {
+			priv->sources[i].g_ctx = g_ctx;
+			priv->sources[i].st_enabled = false;
+			goto done;
 		}
-		if (g_ctx->num_csi_lanes !=
-		    priv->sources[i].g_ctx->num_csi_lanes) {
+
+		if (g_ctx->serdes_csi_link ==
+		    old_ctx->serdes_csi_link) {
+			if (max96724_same_link_source(g_ctx, old_ctx)) {
+				dev_info(dev,
+					 "%s: reusing GMSL link %u for %s\n",
+					 __func__, g_ctx->serdes_csi_link,
+					 dev_name(g_ctx->s_dev));
+				priv->sources[i].g_ctx = g_ctx;
+				priv->sources[i].st_enabled = false;
+				goto done;
+			}
+
+			dev_err(dev,
+				"%s: serdes csi link %u is already registered with incompatible source settings\n",
+				__func__, g_ctx->serdes_csi_link);
+			err = -EINVAL;
+			goto done;
+		}
+		if (g_ctx->num_csi_lanes != old_ctx->num_csi_lanes) {
 			dev_err(dev,
 				"%s: csi num lanes mismatch\n", __func__);
 			err = -EINVAL;
-			goto error;
+			goto done;
 		}
+	}
+
+	if (priv->num_src >= priv->max_src ||
+	    priv->num_src >= MAX96724_MAX_SOURCES) {
+		dev_err(dev,
+			"%s: MAX96724 inputs size exhausted\n", __func__);
+		err = -ENOMEM;
+		goto done;
 	}
 
 	priv->sources[priv->num_src].g_ctx = g_ctx;
@@ -1233,7 +1265,7 @@ int max96724_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx)
 
 	priv->num_src++;
 
-error:
+done:
 	mutex_unlock(&priv->lock);
 	return err;
 }
@@ -1254,27 +1286,30 @@ int max96724_sdev_unregister(struct device *dev, struct device *s_dev)
 	mutex_lock(&priv->lock);
 
 	if (priv->num_src == 0) {
-		dev_err(dev, "%s: no source found\n", __func__);
-		err = -ENODATA;
-		goto error;
+		dev_dbg(dev, "%s: no source registered\n", __func__);
+		goto done;
 	}
 
 	for (i = 0; i < priv->num_src; i++) {
-		if (s_dev == priv->sources[i].g_ctx->s_dev) {
-			priv->sources[i].g_ctx = NULL;
+		if (priv->sources[i].g_ctx &&
+		    s_dev == priv->sources[i].g_ctx->s_dev)
 			break;
-		}
 	}
 
 	if (i == priv->num_src) {
-		dev_err(dev,
-			"%s: requested device not found\n", __func__);
-		err = -EINVAL;
-		goto error;
+		dev_dbg(dev,
+			"%s: requested device is not registered\n", __func__);
+		goto done;
 	}
-	priv->num_src--;
 
-error:
+	for (; i + 1 < priv->num_src; i++)
+		priv->sources[i] = priv->sources[i + 1];
+
+	priv->num_src--;
+	priv->sources[priv->num_src].g_ctx = NULL;
+	priv->sources[priv->num_src].st_enabled = false;
+
+done:
 	mutex_unlock(&priv->lock);
 	return err;
 }

--- a/nvidia-oot/files/6.2/drivers/media/i2c/max96724.c
+++ b/nvidia-oot/files/6.2/drivers/media/i2c/max96724.c
@@ -445,7 +445,18 @@
 #define MAX96724_LANE_MAP2_2X4		0x44  /* keep unused PHY2/3 straight in 0x08 mode */
 
 struct max96724_source_ctx {
+	/*
+	 * g_ctx is borrowed for live stream operations. Registry identity and
+	 * compatibility checks use the copied fields below, so unregister never
+	 * dereferences sensor-owned state that may already have been released.
+	 */
 	struct gmsl_link_ctx *g_ctx;
+	struct device *s_dev;
+	u32 serdes_csi_link;
+	u32 num_csi_lanes;
+	u32 csi_mode;
+	bool control_setup;
+	bool serdev_found;
 	bool st_enabled;
 };
 
@@ -655,31 +666,24 @@ static int max96724_wait_link_lock(struct device *dev, u32 link)
  * Internal Helpers
  * ================================================================ */
 
-static int max96724_get_sdev_idx(struct device *dev,
-				 struct device *s_dev, unsigned int *idx)
+/* Caller must hold priv->lock. */
+static int max96724_get_sdev_idx_locked(struct max96724 *priv,
+					struct device *s_dev,
+					unsigned int *idx)
 {
-	struct max96724 *priv = dev_get_drvdata(dev);
 	unsigned int i;
-	int err = 0;
 
-	mutex_lock(&priv->lock);
 	for (i = 0; i < priv->num_src; i++) {
-		if (priv->sources[i].g_ctx &&
-		    priv->sources[i].g_ctx->s_dev == s_dev)
+		if (priv->sources[i].s_dev == s_dev)
 			break;
 	}
-	if (i == priv->num_src) {
-		dev_err(dev, "no sdev found\n");
-		err = -EINVAL;
-		goto ret;
-	}
+	if (i == priv->num_src)
+		return -EINVAL;
 
 	if (idx)
 		*idx = i;
 
-ret:
-	mutex_unlock(&priv->lock);
-	return err;
+	return 0;
 }
 
 static void max96724_pipes_reset(struct max96724 *priv)
@@ -713,17 +717,53 @@ static void max96724_reset_ctx(struct max96724 *priv)
 	priv->src_link = 0;
 	priv->splitter_enabled = false;
 	max96724_pipes_reset(priv);
-	for (i = 0; i < priv->num_src; i++)
+	for (i = 0; i < priv->num_src; i++) {
+		priv->sources[i].control_setup = false;
+		priv->sources[i].serdev_found = false;
 		priv->sources[i].st_enabled = false;
+	}
 }
 
-static bool max96724_same_link_source(const struct gmsl_link_ctx *a,
-				      const struct gmsl_link_ctx *b)
+static bool max96724_source_control_put(struct max96724 *priv,
+					unsigned int source_idx)
 {
-	return a && b &&
-	       a->serdes_csi_link == b->serdes_csi_link &&
-	       a->num_csi_lanes == b->num_csi_lanes &&
-	       a->csi_mode == b->csi_mode;
+	struct max96724_source_ctx *source = &priv->sources[source_idx];
+
+	if (!source->control_setup)
+		return false;
+
+	source->control_setup = false;
+	if (source->serdev_found) {
+		if (WARN_ON(!priv->num_src_found))
+			priv->num_src_found = 0;
+		else
+			priv->num_src_found--;
+		source->serdev_found = false;
+	}
+
+	if (WARN_ON(!priv->sdev_ref))
+		priv->sdev_ref = 0;
+	else
+		priv->sdev_ref--;
+
+	return priv->sdev_ref == 0;
+}
+
+static int max96724_reset_control_locked(struct device *dev,
+					 struct max96724 *priv,
+					 unsigned int source_idx)
+{
+	int err = 0;
+
+	if (!max96724_source_control_put(priv, source_idx))
+		return 0;
+
+	max96724_reset_ctx(priv);
+	err = max96724_write_reg(dev, MAX96724_REG13_ADDR,
+				 MAX96724_SOFT_RESET);
+	msleep(100);
+
+	return err;
 }
 
 static void max96724_apply_porta_subset(struct device *dev,
@@ -981,10 +1021,6 @@ int max96724_setup_link(struct device *dev, struct device *s_dev)
 	int err = 0;
 	unsigned int i = 0;
 
-	err = max96724_get_sdev_idx(dev, s_dev, &i);
-	if (err)
-		return err;
-
 	/*
 	 * [FG24-4CH] Enable board POC / MFP8 output path BEFORE the GMSL
 	 * link is brought up.  The camera draws power over coax (PoC), so
@@ -999,10 +1035,15 @@ int max96724_setup_link(struct device *dev, struct device *s_dev)
 	}
 
 	mutex_lock(&priv->lock);
+	err = max96724_get_sdev_idx_locked(priv, s_dev, &i);
+	if (err) {
+		dev_err(dev, "%s: no sdev found\n", __func__);
+		goto ret;
+	}
 
 	if (!priv->splitter_enabled) {
 		err = max96724_write_link(dev,
-					  priv->sources[i].g_ctx->serdes_csi_link);
+					  priv->sources[i].serdes_csi_link);
 		if (err)
 			goto ret;
 
@@ -1029,8 +1070,15 @@ EXPORT_SYMBOL(max96724_setup_link);
 int max96724_setup_control(struct device *dev, struct device *s_dev)
 {
 	struct max96724 *priv = dev_get_drvdata(dev);
+	struct max96724_source_ctx *source;
+	u32 next_num_src_found;
+	u32 next_sdev_ref;
+	u32 next_src_link;
+	bool next_splitter_enabled;
+	bool source_found;
 	int err = 0;
-	unsigned int i = 0;
+	unsigned int i;
+	unsigned int source_idx;
 
 	static const u16 tun_en_addrs[] = {
 		MAX96724_PIPE0_TUN_EN_ADDR,
@@ -1046,11 +1094,13 @@ int max96724_setup_control(struct device *dev, struct device *s_dev)
 		MAX96724_PIPE3_TUN_DEST_ADDR,
 	};
 
-	err = max96724_get_sdev_idx(dev, s_dev, &i);
-	if (err)
-		return err;
-
 	mutex_lock(&priv->lock);
+	err = max96724_get_sdev_idx_locked(priv, s_dev, &source_idx);
+	if (err) {
+		dev_err(dev, "%s: no sdev found\n", __func__);
+		goto error;
+	}
+	source = &priv->sources[source_idx];
 
 	if (!priv->link_setup) {
 		dev_err(dev, "%s: invalid state\n", __func__);
@@ -1058,15 +1108,26 @@ int max96724_setup_control(struct device *dev, struct device *s_dev)
 		goto error;
 	}
 
-	if (priv->sources[i].g_ctx->serdev_found) {
-		priv->num_src_found++;
-		priv->src_link = priv->sources[i].g_ctx->serdes_csi_link;
+	if (source->control_setup)
+		goto error;
+
+	if (!source->g_ctx) {
+		dev_err(dev, "%s: source context is not live\n", __func__);
+		err = -EINVAL;
+		goto error;
 	}
+
+	source_found = source->g_ctx->serdev_found;
+	next_num_src_found = priv->num_src_found + source_found;
+	next_sdev_ref = priv->sdev_ref + 1;
+	next_src_link = source_found ? source->serdes_csi_link :
+			priv->src_link;
+	next_splitter_enabled = priv->splitter_enabled;
 
 	/* Enable splitter mode for multi-camera configurations */
 	if ((priv->max_src > 1U) &&
-	    (priv->num_src_found > 0U) &&
-	    (priv->splitter_enabled == false)) {
+	    (next_num_src_found > 0U) &&
+	    (next_splitter_enabled == false)) {
 		/*
 		 * [UG Table 3] Multi-camera: set link rates and enable all links
 		 */
@@ -1091,7 +1152,7 @@ int max96724_setup_control(struct device *dev, struct device *s_dev)
 					   MAX96724_ERRCH_FORCE_ON);
 		}
 
-		priv->splitter_enabled = true;
+		next_splitter_enabled = true;
 
 		msleep(100);
 	}
@@ -1105,7 +1166,6 @@ int max96724_setup_control(struct device *dev, struct device *s_dev)
 				   MAX96724_MIPI_CTRL_SEL_PIXEL);
 		max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
 				   MAX96724_ONESHOT_ALL);
-		priv->sdev_ref++;
 		goto maybe_reset_splitter;
 	}
 
@@ -1134,21 +1194,33 @@ int max96724_setup_control(struct device *dev, struct device *s_dev)
 	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
 			   MAX96724_ONESHOT_ALL);
 
-	priv->sdev_ref++;
-
 maybe_reset_splitter:
 
 	/* Reset splitter mode if not all devices found */
-	if ((priv->sdev_ref == priv->max_src) &&
-	    (priv->splitter_enabled == true) &&
-	    (priv->num_src_found > 0U) &&
-	    (priv->num_src_found < priv->max_src)) {
-		err = max96724_write_link(dev, priv->src_link);
-		if (err)
+	if ((next_sdev_ref == priv->max_src) &&
+	    (next_splitter_enabled == true) &&
+	    (next_num_src_found > 0U) &&
+	    (next_num_src_found < priv->max_src)) {
+		err = max96724_write_link(dev, next_src_link);
+		if (err) {
+			if (!priv->sdev_ref) {
+				max96724_reset_ctx(priv);
+				max96724_write_reg(dev, MAX96724_REG13_ADDR,
+						   MAX96724_SOFT_RESET);
+				msleep(100);
+			}
 			goto error;
+		}
 
-		priv->splitter_enabled = false;
+		next_splitter_enabled = false;
 	}
+
+	source->control_setup = true;
+	source->serdev_found = source_found;
+	priv->num_src_found = next_num_src_found;
+	priv->sdev_ref = next_sdev_ref;
+	priv->src_link = next_src_link;
+	priv->splitter_enabled = next_splitter_enabled;
 
 error:
 	mutex_unlock(&priv->lock);
@@ -1159,22 +1231,22 @@ EXPORT_SYMBOL(max96724_setup_control);
 int max96724_reset_control(struct device *dev, struct device *s_dev)
 {
 	struct max96724 *priv = dev_get_drvdata(dev);
+	unsigned int i;
 	int err = 0;
 
 	mutex_lock(&priv->lock);
-	if (!priv->sdev_ref) {
-		dev_info(dev, "%s: dev is already in reset state\n", __func__);
+	err = max96724_get_sdev_idx_locked(priv, s_dev, &i);
+	if (err) {
+		dev_err(dev, "%s: no sdev found\n", __func__);
 		goto ret;
 	}
 
-	priv->sdev_ref--;
-	if (priv->sdev_ref == 0) {
-		max96724_reset_ctx(priv);
-		max96724_write_reg(dev, MAX96724_REG13_ADDR,
-				   MAX96724_SOFT_RESET);
-
-		msleep(100);
+	if (!priv->sources[i].control_setup) {
+		dev_info(dev, "%s: source is already in reset state\n", __func__);
+		goto ret;
 	}
+
+	err = max96724_reset_control_locked(dev, priv, i);
 
 ret:
 	mutex_unlock(&priv->lock);
@@ -1215,36 +1287,27 @@ int max96724_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx)
 	}
 
 	for (i = 0; i < priv->num_src; i++) {
-		struct gmsl_link_ctx *old_ctx = priv->sources[i].g_ctx;
+		struct max96724_source_ctx *source = &priv->sources[i];
 
-		if (!old_ctx)
-			continue;
-
-		if (old_ctx->s_dev == g_ctx->s_dev) {
-			priv->sources[i].g_ctx = g_ctx;
-			priv->sources[i].st_enabled = false;
-			goto done;
-		}
-
-		if (g_ctx->serdes_csi_link ==
-		    old_ctx->serdes_csi_link) {
-			if (max96724_same_link_source(g_ctx, old_ctx)) {
-				dev_info(dev,
-					 "%s: reusing GMSL link %u for %s\n",
-					 __func__, g_ctx->serdes_csi_link,
-					 dev_name(g_ctx->s_dev));
-				priv->sources[i].g_ctx = g_ctx;
-				priv->sources[i].st_enabled = false;
+		if (source->s_dev == g_ctx->s_dev) {
+			if (source->g_ctx == g_ctx)
 				goto done;
-			}
 
 			dev_err(dev,
-				"%s: serdes csi link %u is already registered with incompatible source settings\n",
-				__func__, g_ctx->serdes_csi_link);
-			err = -EINVAL;
+				"%s: source %s is already registered\n",
+				__func__, dev_name(g_ctx->s_dev));
+			err = -EBUSY;
 			goto done;
 		}
-		if (g_ctx->num_csi_lanes != old_ctx->num_csi_lanes) {
+
+		if (g_ctx->serdes_csi_link == source->serdes_csi_link) {
+			dev_err(dev,
+				"%s: serdes csi link %u is already registered\n",
+				__func__, g_ctx->serdes_csi_link);
+			err = -EBUSY;
+			goto done;
+		}
+		if (g_ctx->num_csi_lanes != source->num_csi_lanes) {
 			dev_err(dev,
 				"%s: csi num lanes mismatch\n", __func__);
 			err = -EINVAL;
@@ -1260,8 +1323,15 @@ int max96724_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx)
 		goto done;
 	}
 
+	memset(&priv->sources[priv->num_src], 0,
+	       sizeof(priv->sources[priv->num_src]));
 	priv->sources[priv->num_src].g_ctx = g_ctx;
-	priv->sources[priv->num_src].st_enabled = false;
+	priv->sources[priv->num_src].s_dev = g_ctx->s_dev;
+	priv->sources[priv->num_src].serdes_csi_link =
+		g_ctx->serdes_csi_link;
+	priv->sources[priv->num_src].num_csi_lanes =
+		g_ctx->num_csi_lanes;
+	priv->sources[priv->num_src].csi_mode = g_ctx->csi_mode;
 
 	priv->num_src++;
 
@@ -1291,8 +1361,7 @@ int max96724_sdev_unregister(struct device *dev, struct device *s_dev)
 	}
 
 	for (i = 0; i < priv->num_src; i++) {
-		if (priv->sources[i].g_ctx &&
-		    s_dev == priv->sources[i].g_ctx->s_dev)
+		if (s_dev == priv->sources[i].s_dev)
 			break;
 	}
 
@@ -1302,12 +1371,20 @@ int max96724_sdev_unregister(struct device *dev, struct device *s_dev)
 		goto done;
 	}
 
+	if (priv->sources[i].control_setup) {
+		err = max96724_reset_control_locked(dev, priv, i);
+		if (err)
+			dev_warn(dev,
+				 "%s: failed to reset source control: %d\n",
+				 __func__, err);
+	}
+
 	for (; i + 1 < priv->num_src; i++)
 		priv->sources[i] = priv->sources[i + 1];
 
 	priv->num_src--;
-	priv->sources[priv->num_src].g_ctx = NULL;
-	priv->sources[priv->num_src].st_enabled = false;
+	memset(&priv->sources[priv->num_src], 0,
+	       sizeof(priv->sources[priv->num_src]));
 
 done:
 	mutex_unlock(&priv->lock);
@@ -1346,11 +1423,12 @@ int max96724_setup_streaming(struct device *dev, struct device *s_dev)
 	u8 pipe_sel1;
 	u8 dpll_cfg;
 
-	err = max96724_get_sdev_idx(dev, s_dev, &i);
-	if (err)
-		return err;
-
 	mutex_lock(&priv->lock);
+	err = max96724_get_sdev_idx_locked(priv, s_dev, &i);
+	if (err) {
+		dev_err(dev, "%s: no sdev found\n", __func__);
+		goto ret;
+	}
 
 	dev_info(dev, "=== setup_streaming ENTER src=%u st_enabled=%d ===\n",
 		 i, priv->sources[i].st_enabled);
@@ -1483,11 +1561,12 @@ int max96724_start_streaming(struct device *dev, struct device *s_dev)
 	int err = 0;
 	unsigned int i = 0;
 
-	err = max96724_get_sdev_idx(dev, s_dev, &i);
-	if (err)
-		return err;
-
 	mutex_lock(&priv->lock);
+	err = max96724_get_sdev_idx_locked(priv, s_dev, &i);
+	if (err) {
+		dev_err(dev, "%s: no sdev found\n", __func__);
+		goto ret;
+	}
 	g_ctx = priv->sources[i].g_ctx;
 
 	for (i = 0; i < g_ctx->num_streams; i++) {
@@ -1497,9 +1576,10 @@ int max96724_start_streaming(struct device *dev, struct device *s_dev)
 			max96724_write_reg(dev, g_stream->des_pipe,
 					   g_stream->st_id_sel);
 	}
+ret:
 	mutex_unlock(&priv->lock);
 
-	return 0;
+	return err;
 }
 EXPORT_SYMBOL(max96724_start_streaming);
 
@@ -1511,11 +1591,12 @@ int max96724_stop_streaming(struct device *dev, struct device *s_dev)
 	int err = 0;
 	unsigned int i = 0;
 
-	err = max96724_get_sdev_idx(dev, s_dev, &i);
-	if (err)
-		return err;
-
 	mutex_lock(&priv->lock);
+	err = max96724_get_sdev_idx_locked(priv, s_dev, &i);
+	if (err) {
+		dev_err(dev, "%s: no sdev found\n", __func__);
+		goto ret;
+	}
 	g_ctx = priv->sources[i].g_ctx;
 
 	for (i = 0; i < g_ctx->num_streams; i++) {
@@ -1526,9 +1607,10 @@ int max96724_stop_streaming(struct device *dev, struct device *s_dev)
 					   MAX96724_RESET_ST_ID);
 	}
 
+ret:
 	mutex_unlock(&priv->lock);
 
-	return 0;
+	return err;
 }
 EXPORT_SYMBOL(max96724_stop_streaming);
 


### PR DESCRIPTION
## Status

Ready for review.

Review page: http://zsy-nuc13.lan:3000/pr513-d5xx-probe-reload-202607201546

NVCSI debugfs diagnostics are out of scope and remain isolated in PR #514.

## Summary

Fix D5xx GMSL probe stability across repeated `d5xx` module reloads, make the
MAX96724 source registry safe across probe teardown, and isolate D5xx internal
symbols from the D4xx `ds5` namespace.

## Root Cause

The FG24 topology exposes Depth, RGB, IR, and IMU as logical D5xx instances
that share one physical GMSL link. Probe failure and remove paths did not
consistently release the primary instance, serializer state, and MAX96724
source registration. A later reload could retain stale registration or
reference state, reject the primary instance, and leave peer instances unable
to access the camera through the I2C alias.

The MAX96724 registry also used a borrowed `gmsl_link_ctx` pointer for identity
checks. That context is embedded in devm-managed D5xx probe state and cannot be
dereferenced after teardown. Control references and detected-source accounting
were global rather than balanced per registered source.

`d4xx.c` and `d5xx.c` retained overlapping global `ds5_*` and `DS5_*`
identifiers from their common origin. They currently build as separate
modules, but the overlap makes diagnostics ambiguous and prevents safe future
linkage into the same kernel object.

## Changes

- Add one primary-instance SERDES cleanup path for setup failure, later probe
  failure, remove, and module reload.
- Track serializer and deserializer control setup independently so each
  successful stage is reset exactly once.
- Clear the shared D5xx primary pointer under lock before unpairing and
  unregistering the source.
- Store MAX96724 source identity and compatibility fields by value; retain the
  borrowed context only for live operations under the registry mutex.
- Reject active duplicate device or GMSL-link registrations instead of
  replacing their contexts.
- Track control setup and serializer discovery per source, with balanced
  `sdev_ref` and `num_src_found` updates on reset and unregister.
- Commit setup accounting only after control configuration succeeds and make
  repeated setup/reset calls idempotent.
- Compact released source slots and enforce configured and array capacities.
- Rename D5xx internal functions, types, globals, and macros to `d5x_*` and
  `D5X_*`.
- Rename D5xx diagnostic attributes to `d5x_fw_ver`, `d5x_read_reg`, and
  `d5x_write_reg`.
- Document the D4xx/D5xx naming boundary in the repository development
  guidance.

## Compatibility

The following externally consumed names remain unchanged:

- I2C driver and device-tree matching: `d5xx`, `realsense,d5xx`
- Media graph entities: `DS5 mux`, `D4XX`
- DFU class and character device: `d4xx-class`, `d4xx-dfu`
- Existing V4L2 formats, controls, media topology, and metadata behavior

Only the three D5xx diagnostic sysfs filenames change from inherited `ds5_*`
names to `d5x_*`. No consumer was found in the host application, tests,
librealsense, or installed enumeration rules.

## Validation

Validated on Jetson 67 with JetPack 6.2.2 and kernel `5.15.185-tegra`.

- JP6.2.2 modules-only build: PASS.
- Build-log scan for warnings, compiler errors, undefined references, and
  duplicate definitions: PASS.
- Package deployment, reboot, module vermagic, and installed hash checks: PASS.
- Three consecutive `rmmod d5xx; modprobe d5xx` cycles while MAX96717 and
  MAX96724 remained loaded: PASS.
- All four logical D5xx instances rebound after every reload: PASS.
- Seven V4L2 nodes were recreated and device register `0x030c` remained
  readable after every reload: PASS.
- Kernel scan found no duplicate registration, failed probe, refcount,
  WARNING, BUG, KASAN, or use-after-free diagnostics.
- Depth, IR, and RGB 1280x720 headless decode: PASS with zero sequence drops
  and zero out-of-order frames.
- Depth, IR, and RGB metadata sidecars: PASS; all buffers parsed and validated
  with zero missing, truncated, mismatched, or backwards metadata.
