### PR TITLE
Disable NVCSI deskew for D58x Y8 tunnel mode

### DIFF
--- a/hardware/realsense/tegra234-camera-d4xx-overlay-fg24-4ch-d5xx.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-fg24-4ch-d5xx.dts
@@ -532,8 +532,6 @@
 								phy_mode = "DPHY";
 								discontinuous_clk = "no";
 								cil_settletime = "0";
-								deskew_initial_enable = "true";
-								deskew_periodic_enable = "true";
 								mclk_khz = "24000";
 								pix_clk_hz = "1000000000";
 								serdes_pix_clk_hz = "1000000000";


### PR DESCRIPTION
## Summary

Remove `deskew_initial_enable` and `deskew_periodic_enable` from the D58x Y8 mode in the FG24/MAX96724 tunnel overlay.

## Root cause

The Y8 mode advertises a 1 GHz SerDes pixel clock, which exceeds Tegra's 750 MHz NVCSI deskew threshold. Enabling the DT properties therefore starts NVCSI deskew during stream-on. The calibration does not complete on this MAX96724 tunnel path, so Tegra retries stream start five times and can enter VI capture recovery.

The MAX96717 input deskew and MAX96724 tunnel deskew configuration remain unchanged. This patch only prevents Tegra NVCSI from starting the failing software-controlled calibration for D58x Y8.

`tegra234-camera-d4xx-overlay-d5xx.dts` is not changed: it has no deskew properties and its D5xx modes use a 175 MHz pixel clock.

## Validation

- `./build_all.sh 6.2`
- Jetson Orin Nano + FG24 + D585
- IR 640x360@90, 10-frame V4L2 capture: one stream start/stop, no VI recovery
- IR 60 fps and 90 fps start/stop: 20/20 passes at each rate
- RGB + IR at 60 fps and 90 fps: 20/20 passes at each rate
- RGB/Depth/IR stream combinations at 60 fps and 90 fps: no VI capture errors
