### PR TITLE
RSDSO-21787 Fix Y16I hunk context rejected by GNU patch

### DIFF
--- a/kernel/nvidia/5.0.2/0001-Porting-driver-patches-to-jetpack-5.0.2.patch
+++ b/kernel/nvidia/5.0.2/0001-Porting-driver-patches-to-jetpack-5.0.2.patch
@@ -1688,10 +1688,7 @@ index 69ebee6a8..6e08f65ea 100644
  
  	chan->request[vi_port] = dma_alloc_coherent(chan->tegra_vi_channel[vi_port]->rtcpu_dev,
  					setup.queue_depth * setup.request_size,
-@@ -334,9 +334,16 @@ static void vi5_setup_surface(struct tegra_channel *chan,
- 	if (chan->valid_ports > NVCSI_STREAM_1) {
- 		height = chan->gang_height;
- 		width = chan->gang_width;
+@@ -337,6 +337,13 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  		offset = buf->addr + chan->buffer_offset[1 - vi_port];
  	}
  

--- a/kernel/nvidia/5.1.2/0001-Porting-driver-patches-to-jetpack-5.1.2.patch
+++ b/kernel/nvidia/5.1.2/0001-Porting-driver-patches-to-jetpack-5.1.2.patch
@@ -1148,10 +1148,7 @@ diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/p
 index b54833d3f..042a80e51 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -385,9 +385,16 @@ static void vi5_setup_surface(struct tegra_channel *chan,
- 	if (chan->valid_ports > NVCSI_STREAM_1) {
- 		height = chan->gang_height;
- 		width = chan->gang_width;
+@@ -388,6 +388,13 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  		offset = buf->addr + chan->buffer_offset[1 - vi_port];
  	}
  

--- a/kernel/nvidia/5.1.6/0001-Porting-driver-patches-to-jetpack-5.1.2.patch
+++ b/kernel/nvidia/5.1.6/0001-Porting-driver-patches-to-jetpack-5.1.2.patch
@@ -1151,10 +1151,7 @@ diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/p
 index b54833d3f..042a80e51 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -397,9 +397,16 @@ static void vi5_setup_surface(struct tegra_channel *chan,
- 	if (chan->valid_ports > NVCSI_STREAM_1) {
- 		height = chan->gang_height;
- 		width = chan->gang_width;
+@@ -400,6 +400,13 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  		offset = buf->addr + chan->buffer_offset[1 - vi_port];
  	}
  

--- a/nvidia-oot/6.0/0001-embedded-metadata-support-for-D4xx.patch
+++ b/nvidia-oot/6.0/0001-embedded-metadata-support-for-D4xx.patch
@@ -666,10 +666,7 @@ diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/p
 index 7b16dcaf..cd58d4aa 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -383,9 +383,16 @@ static void vi5_setup_surface(struct tegra_channel *chan,
- 	if (chan->valid_ports > NVCSI_STREAM_1) {
- 		height = chan->gang_height;
- 		width = chan->gang_width;
+@@ -386,6 +386,13 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  		offset = buf->addr + chan->buffer_offset[1 - vi_port];
  	}
  

--- a/nvidia-oot/7.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/7.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -992,10 +992,7 @@ diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/p
 index 7b16dcaf..487ae44b 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -416,9 +416,16 @@ static void vi5_setup_surface(struct tegra_channel *chan,
- 							   &offset)) {
- 			dev_err(chan->vi->dev, "%s: Buf addr overflow\n", __func__);
- 			return;
+@@ -419,6 +419,13 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  		}
  	}
  

--- a/nvidia-oot/7.1/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/7.1/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -992,10 +992,7 @@ diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/p
 index 7b16dcaf..487ae44b 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -416,9 +416,16 @@ static void vi5_setup_surface(struct tegra_channel *chan,
- 							   &offset)) {
- 			dev_err(chan->vi->dev, "%s: Buf addr overflow\n", __func__);
- 			return;
+@@ -419,6 +419,13 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  		}
  	}
  

--- a/nvidia-oot/7.2/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/7.2/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -969,10 +969,7 @@ diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/p
 index 69d76521..e23df865 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -416,9 +416,16 @@ static void vi5_setup_surface(struct tegra_channel *chan,
- 							   &offset)) {
- 			dev_err(chan->vi->dev, "%s: Buf addr overflow\n", __func__);
- 			return;
+@@ -419,6 +419,13 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  		}
  	}
  


### PR DESCRIPTION
Fixes the JP6 driver release failure in [D4xx_Kernel_Module_Jetson_JP6 #3084](https://rsjenkins.realsenseai.com/job/D4xx_Kernel_Module_Jetson_JP6/3084/console):

```
+ ./apply_patches_ext.sh 6.0 ./Linux_for_Tegra/source
1 out of 3 hunks FAILED -- saving rejects to file drivers/media/platform/tegra/camera/vi/vi5_fops.c.rej
```

## Root cause

The Y16I `frame_x` fixup hunk added to `vi5_setup_surface` (merged in b032d72) used **6 leading / 3 trailing** context lines. GNU `patch` rejects a hunk whose leading and trailing context lengths differ.

The asymmetry slipped through because it was verified with `git apply`, which tolerates it. `apply_patches_ext.sh` uses GNU `patch` instead:

```sh
cat "${PWD}/$2/$1/"* | patch --quiet -p1 --directory="${PWD}/$TARGET/$2"
```

Confirmed empirically against the pristine JP6.0 tree — the hunk's old side matched the file byte-for-byte, so only the context shape mattered:

| leading / trailing | header | GNU patch |
|---|---|---|
| 6 / 3 (merged) | `@@ -383,9 +383,16 @@` | **FAILS** |
| 6 / 6 | `@@ -383,12 +383,19 @@` | applies |
| 3 / 3 | `@@ -386,6 +386,13 @@` | applies |

## Fix

Rebalanced the seven affected hunks to **3 / 3** — what `diff -u` emits by default, and what the already-working `nvidia-oot/6.2/0001` hunk uses.

6/6 was rejected as an option because on JP7.0 and JP7.1 the next hunk starts at `-426`; a 6-line trailing context would make the hunk span 416–427 and overlap it.

| patch | before | after |
|---|---|---|
| `nvidia-oot/6.0/0001` | `-383,9 +383,16` | `-386,6 +386,13` |
| `nvidia-oot/7.0/0001` | `-416,9 +416,16` | `-419,6 +419,13` |
| `nvidia-oot/7.1/0001` | `-416,9 +416,16` | `-419,6 +419,13` |
| `nvidia-oot/7.2/0001` | `-416,9 +416,16` | `-419,6 +419,13` |
| `kernel/nvidia/5.0.2/0001` | `-334,9 +334,16` | `-337,6 +337,13` |
| `kernel/nvidia/5.1.2/0001` | `-385,9 +385,16` | `-388,6 +388,13` |
| `kernel/nvidia/5.1.6/0001` | `-397,9 +397,16` | `-400,6 +400,13` |

`nvidia-oot/6.2/0001` (hard-linked to 6.2.1 / 6.2.2) was already 3/3 and is unchanged.

**No functional change** — the seven added lines are byte-identical; only the surrounding context and the hunk header counts differ.

## Verification

Ran the CI invocation (`cat <dir>/*.patch | patch -p1`) against the pristine tree of every JetPack with local sources:

```
JP6.0 6.2 6.2.1 7.0 7.1 7.2 5.0.2 5.1.2 5.1.6   all CLEAN
   fixup=1 entry=1 VF_RAW16=1 DT_RAW16=1  (each, exactly once)
kernel-5.10 5.0.2 5.1.2 5.1.6                   all CLEAN, Y16I_fourcc=1
```

No asymmetric-context hunks remain anywhere in the Y16I change set. Not tested on hardware — this is a patch-format fix with no change to the applied result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)