### PR TITLE
[D5xx] Set RGB gain range to 16-248

### DIFF
--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -5018,9 +5018,14 @@ static int ds5_ctrl_init(struct ds5 *state, int sid)
 						V4L2_CID_ANALOGUE_GAIN,
 						16, 248, 1, 16);
 	} else if (sid == RGB_SID) {
-		ctrls->gain = v4l2_ctrl_new_std(hdl, ops,
-						V4L2_CID_ANALOGUE_GAIN,
-						0, 128, 1, 64);
+		if (is_d58x)
+			ctrls->gain = v4l2_ctrl_new_std(hdl, ops,
+							V4L2_CID_ANALOGUE_GAIN,
+							16, 248, 1, 16);
+		else
+			ctrls->gain = v4l2_ctrl_new_std(hdl, ops,
+							V4L2_CID_ANALOGUE_GAIN,
+							0, 128, 1, 64);
 	}
 
 	if ((ctrls->gain) && (sid >= DEPTH_SID && sid < IMU_SID)) {


### PR DESCRIPTION
## Summary

- expose the D5xx/D58x RGB analogue gain range as 16–248 with a default of 16
- preserve the existing D4xx RGB gain range of 0–128 with a default of 64
- keep the existing direct firmware register read/write path unchanged

## Why

D500-series RGB camera SKUs use the 16–248 gain range, while the unified driver previously exposed the D4xx 0–128 range for every RGB SKU.

## Validation

- `git diff --check`
- Linux kernel `checkpatch.pl --no-tree --terse`
