### PR TITLE
Use D5xx compatible string for MAX96712 overlays

### DIFF
--- a/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-16ch-cams-0-1-d5xx-d4xx.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-16ch-cams-0-1-d5xx-d4xx.dts
@@ -640,7 +640,7 @@
 								def-addr = <0x10>;
 								reg = <0x1d>;
 								override_reg = <0x1a>;
-								compatible = "intel,d4xx";
+								compatible = "realsense,d5xx";
 								use_sensor_mode_id = "true";
 								vcc-supply = <&vdd_cam12v_poc>;
 								cam-type = "IMU";
@@ -689,7 +689,7 @@
 								def-addr = <0x10>;
 								reg = <0x1c>;
 								override_reg = <0x1a>;
-								compatible = "intel,d4xx";
+								compatible = "realsense,d5xx";
 								use_sensor_mode_id = "true";
 								vcc-supply = <&vdd_cam12v_poc>;
 								cam-type = "Y8";
@@ -739,7 +739,7 @@
 								def-addr = <0x10>;
 								reg = <0x1b>;
 								override_reg = <0x1a>;
-								compatible = "intel,d4xx";
+								compatible = "realsense,d5xx";
 								use_sensor_mode_id = "true";
 								vcc-supply = <&vdd_cam12v_poc>;
 								cam-type = "RGB";
@@ -787,7 +787,7 @@
 								status = "okay";
 								def-addr = <0x10>;
 								reg = <0x1a>;
-								compatible = "intel,d4xx";
+								compatible = "realsense,d5xx";
 								use_sensor_mode_id = "true";
 								vcc-supply = <&vdd_cam12v_poc>;
 								cam-type = "Depth";

--- a/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-16ch-d5xx.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-16ch-d5xx.dts
@@ -284,7 +284,7 @@
 								def-addr = <0x10>;
 								reg = <0x1d>;
 								override_reg = <0x1a>;
-								compatible = "intel,d4xx";
+								compatible = "realsense,d5xx";
 								use_sensor_mode_id = "true";
 								vcc-supply = <&vdd_cam12v_poc>;
 								cam-type = "IMU";
@@ -333,7 +333,7 @@
 								def-addr = <0x10>;
 								reg = <0x1c>;
 								override_reg = <0x1a>;
-								compatible = "intel,d4xx";
+								compatible = "realsense,d5xx";
 								use_sensor_mode_id = "true";
 								vcc-supply = <&vdd_cam12v_poc>;
 								cam-type = "Y8";
@@ -383,7 +383,7 @@
 								def-addr = <0x10>;
 								reg = <0x1b>;
 								override_reg = <0x1a>;
-								compatible = "intel,d4xx";
+								compatible = "realsense,d5xx";
 								use_sensor_mode_id = "true";
 								vcc-supply = <&vdd_cam12v_poc>;
 								cam-type = "RGB";
@@ -431,7 +431,7 @@
 								status = "okay";
 								def-addr = <0x10>;
 								reg = <0x1a>;
-								compatible = "intel,d4xx";
+								compatible = "realsense,d5xx";
 								use_sensor_mode_id = "true";
 								vcc-supply = <&vdd_cam12v_poc>;
 								cam-type = "Depth";

--- a/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-4ch-d5xx.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-4ch-d5xx.dts
@@ -299,7 +299,7 @@
 							def-addr = <0x10>;
 							reg = <0x1d>;
 							override_reg = <0x1a>;
-							compatible = "intel,d4xx";
+							compatible = "realsense,d5xx";
 							use_sensor_mode_id = "true";
 							cam-type = "IMU";
 							nvidia,gmsl-ser-device = <&ser_a>;
@@ -347,7 +347,7 @@
 							def-addr = <0x10>;
 							reg = <0x1c>;
 							override_reg = <0x1a>;
-							compatible = "intel,d4xx";
+							compatible = "realsense,d5xx";
 							use_sensor_mode_id = "true";
 							cam-type = "Y8";
 							nvidia,gmsl-ser-device = <&ser_a>;
@@ -396,7 +396,7 @@
 							def-addr = <0x10>;
 							reg = <0x1b>;
 							override_reg = <0x1a>;
-							compatible = "intel,d4xx";
+							compatible = "realsense,d5xx";
 							use_sensor_mode_id = "true";
 							cam-type = "RGB";
 							nvidia,gmsl-ser-device = <&ser_a>;
@@ -443,7 +443,7 @@
 							status = "okay";
 							def-addr = <0x10>;
 							reg = <0x1a>;
-							compatible = "intel,d4xx";
+							compatible = "realsense,d5xx";
 							use_sensor_mode_id = "true";
 							cam-type = "Depth";
 							nvidia,gmsl-ser-device = <&ser_a>;

--- a/hardware/realsense/tegra234-camera-d4xx-overlay-seeed-d5xx.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-seeed-d5xx.dts
@@ -263,7 +263,7 @@
 						def-addr = <0x10>;
 						reg = <0x1d>;
 						override_reg = <0x1a>;
-						compatible = "intel,d4xx";
+						compatible = "realsense,d5xx";
 						use_sensor_mode_id = "true";
 						cam-type = "IMU";
 						nvidia,gmsl-ser-device = <&ser_a>;
@@ -311,7 +311,7 @@
 						def-addr = <0x10>;
 						reg = <0x1c>;
 						override_reg = <0x1a>;
-						compatible = "intel,d4xx";
+						compatible = "realsense,d5xx";
 						use_sensor_mode_id = "true";
 						cam-type = "Y8";
 						nvidia,gmsl-ser-device = <&ser_a>;
@@ -360,7 +360,7 @@
 						def-addr = <0x10>;
 						reg = <0x1b>;
 						override_reg = <0x1a>;
-						compatible = "intel,d4xx";
+						compatible = "realsense,d5xx";
 						use_sensor_mode_id = "true";
 						cam-type = "RGB";
 						nvidia,gmsl-ser-device = <&ser_a>;
@@ -407,7 +407,7 @@
 						status = "okay";
 						def-addr = <0x10>;
 						reg = <0x1a>;
-						compatible = "intel,d4xx";
+						compatible = "realsense,d5xx";
 						use_sensor_mode_id = "true";
 						cam-type = "Depth";
 						nvidia,gmsl-ser-device = <&ser_a>;


### PR DESCRIPTION
## Summary

- identify D5xx camera nodes with `realsense,d5xx` in the MAX96712 pixel-mode overlays
- update all Depth, RGB, IR, and IMU nodes in the pure D5xx overlays
- update only the D5xx/MAX96717 link in the mixed D5xx/D4xx overlay, leaving the D4xx/MAX9295 link unchanged

## Why

The affected overlays describe D5xx cameras but still use the legacy `intel,d4xx` compatible string. The unified host driver already matches `realsense,d5xx`, so the more specific compatible string makes the device-tree identity accurate without changing the probe or streaming path.

## Validation

- `git diff --check`
- preprocessed and compiled all four modified overlays with the JetPack 6.2.1 NVIDIA headers and `dtc`
- verified the mixed topology retains four `intel,d4xx` nodes for the D4xx/MAX9295 link and uses four `realsense,d5xx` nodes for the D5xx/MAX96717 link
