### PR TITLE
Enhance D500 reset recovery for serializer power loss

### DIFF
--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -31,6 +31,7 @@
 #include <linux/videodev2.h>
 #include <linux/version.h>
 #include <linux/mutex.h>
+#include <linux/workqueue.h>
 #include <media/media-entity.h>
 #include <media/v4l2-ctrls.h>
 #include <media/v4l2-device.h>
@@ -633,6 +634,10 @@ struct ds5 {
 	struct ds5_dev *ds5_dev; /* pointer to DS5 device struct */
 };
 
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+#define DS5_REENUM_ROLE_COUNT 4
+#endif
+
 struct ds5_dev {
 	struct mutex lock;
 	/*
@@ -667,13 +672,20 @@ struct ds5_dev {
 	unsigned long last_reset_jiffies;
 
 #ifdef CONFIG_VIDEO_D4XX_SERDES
- 	/* Pointer to the deserializer dev */
+	/* Pointer to the deserializer dev */
 	struct dser_control *dser_control;
 
 	/* Cold-bring-up flush request for this camera's GMSL link: the first
 	 * stream on a link the deser already served for another camera wedges
 	 * (VI discards every frame) until a one-shot. Guarded by lock. */
 	bool link_flush_pending;
+
+	/* Bound I2C functions belonging to this physical camera.  D500 reset
+	 * recovery uses these to reproduce the remove/probe lifecycle after the
+	 * remote serializer loses power.  Guarded by lock.
+	 */
+	struct device *reenum_members[DS5_REENUM_ROLE_COUNT];
+	bool reenum_member_primary[DS5_REENUM_ROLE_COUNT];
 #endif
 
 	/* Pointer to the primary DS5 struct */
@@ -700,6 +712,33 @@ static struct dser_control dser_inited[MAX_DSER_NUM];
 #define MAX_DS5_NUM (MAX_DSER_NUM * 4) /* assuming max 4 DS5 cameras per deserializer (true for max96712) */
 static struct ds5_dev ds5_inited[MAX_DS5_NUM];
 
+enum ds5_reenum_role {
+	DS5_REENUM_DEPTH = 0,
+	DS5_REENUM_RGB,
+	DS5_REENUM_IR,
+	DS5_REENUM_IMU,
+};
+
+struct ds5_reenum_entry {
+	struct device *dev;
+	u8 role;
+	u8 group;
+	bool was_primary;
+};
+
+#define DS5_REENUM_MAX_DEVICES (MAX_DS5_NUM * DS5_REENUM_ROLE_COUNT)
+#define DS5_REENUM_DELAY_MS 1000
+#define DS5_REENUM_ATTACH_RETRIES 3
+#define DS5_REENUM_ATTACH_RETRY_MS 500
+
+static DEFINE_MUTEX(ds5_reenum_lock);
+static struct delayed_work ds5_reenum_work;
+static struct ds5_reenum_entry ds5_reenum_entries[DS5_REENUM_MAX_DEVICES];
+static unsigned int ds5_reenum_num_entries;
+static bool ds5_reenum_pending;
+
+static void ds5_reenum_work_fn(struct work_struct *work);
+
 static void ds5_init_global_slots_once(void)
 {
 	int i;
@@ -712,6 +751,7 @@ static void ds5_init_global_slots_once(void)
 		mutex_init(&ds5_inited[i].lock);
 		mutex_init(&ds5_inited[i].reset_lock);
 	}
+	INIT_DELAYED_WORK(&ds5_reenum_work, ds5_reenum_work_fn);
 
 	for (i = 0; i < MAX_DSER_NUM; i++)
 		mutex_init(&dser_inited[i].lock);
@@ -856,6 +896,258 @@ static inline bool ds5_is_d58x(struct ds5 *state)
 		READ_ONCE(state->ds5_dev->cached_device_type) ==
 			DS5_DEVICE_TYPE_D58X;
 }
+
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+static int ds5_reenum_role(struct ds5 *state)
+{
+	if (state->is_depth)
+		return DS5_REENUM_DEPTH;
+	if (state->is_rgb)
+		return DS5_REENUM_RGB;
+	if (state->is_y8)
+		return DS5_REENUM_IR;
+	if (state->is_imu)
+		return DS5_REENUM_IMU;
+
+	return -EINVAL;
+}
+
+static void ds5_reenum_register_member(struct ds5 *state)
+{
+	int role = ds5_reenum_role(state);
+
+	if (role < 0 || !state->ds5_dev)
+		return;
+
+	mutex_lock(&state->ds5_dev->lock);
+	state->ds5_dev->reenum_members[role] = &state->client->dev;
+	state->ds5_dev->reenum_member_primary[role] = state->ser_primary;
+	mutex_unlock(&state->ds5_dev->lock);
+}
+
+static void ds5_reenum_unregister_member(struct ds5 *state)
+{
+	int role = ds5_reenum_role(state);
+
+	if (role < 0 || !state->ds5_dev)
+		return;
+
+	mutex_lock(&state->ds5_dev->lock);
+	if (state->ds5_dev->reenum_members[role] == &state->client->dev) {
+		state->ds5_dev->reenum_members[role] = NULL;
+		state->ds5_dev->reenum_member_primary[role] = false;
+	}
+	mutex_unlock(&state->ds5_dev->lock);
+}
+
+static int ds5_reenum_attach_device(struct device *dev)
+{
+	int attempt;
+	int ret = -ENODEV;
+
+	for (attempt = 1; attempt <= DS5_REENUM_ATTACH_RETRIES; attempt++) {
+		if (READ_ONCE(dev->driver))
+			return 0;
+
+		ret = device_attach(dev);
+		if (ret > 0 || READ_ONCE(dev->driver))
+			return 0;
+
+		if (attempt < DS5_REENUM_ATTACH_RETRIES)
+			msleep(DS5_REENUM_ATTACH_RETRY_MS);
+	}
+
+	return ret < 0 ? ret : -ENODEV;
+}
+
+static void ds5_reenum_work_fn(struct work_struct *work)
+{
+	bool group_ready[MAX_DS5_NUM] = { false };
+	unsigned int num_entries;
+	int role;
+	int pass;
+	int i;
+
+	mutex_lock(&ds5_reenum_lock);
+	num_entries = ds5_reenum_num_entries;
+	mutex_unlock(&ds5_reenum_lock);
+
+	pr_warn("d4xx: D500 recovery rebinding %u I2C functions\n",
+		num_entries);
+
+	/* Match a complete module removal: remove peers before the function
+	 * which owns the serializer/deserializer registration.
+	 */
+	for (pass = 0; pass < 2; pass++) {
+		for (i = (int)num_entries - 1; i >= 0; i--) {
+			struct ds5_reenum_entry *entry = &ds5_reenum_entries[i];
+
+			if (entry->was_primary != (pass == 1))
+				continue;
+			device_release_driver(entry->dev);
+		}
+	}
+
+	/* Depth must claim each camera slot first.  Its probe performs the full
+	 * serializer address assignment and, for the first camera, deserializer
+	 * power/setup.  Only then may the peer functions share that setup.
+	 */
+	for (i = 0; i < num_entries; i++) {
+		struct ds5_reenum_entry *entry = &ds5_reenum_entries[i];
+		int ret;
+
+		if (entry->role != DS5_REENUM_DEPTH)
+			continue;
+
+		ret = ds5_reenum_attach_device(entry->dev);
+		if (ret) {
+			dev_err(entry->dev,
+				"D500 recovery failed to reattach Depth (%d)\n", ret);
+			continue;
+		}
+		group_ready[entry->group] = true;
+	}
+
+	for (role = DS5_REENUM_RGB; role < DS5_REENUM_ROLE_COUNT; role++) {
+		for (i = 0; i < num_entries; i++) {
+			struct ds5_reenum_entry *entry = &ds5_reenum_entries[i];
+			int ret;
+
+			if (entry->role != role || !group_ready[entry->group])
+				continue;
+
+			ret = ds5_reenum_attach_device(entry->dev);
+			if (ret)
+				dev_err(entry->dev,
+					"D500 recovery failed to reattach role %d (%d)\n",
+					role, ret);
+		}
+	}
+
+	mutex_lock(&ds5_reenum_lock);
+	for (i = 0; i < ds5_reenum_num_entries; i++) {
+		put_device(ds5_reenum_entries[i].dev);
+		ds5_reenum_entries[i].dev = NULL;
+	}
+	ds5_reenum_num_entries = 0;
+	ds5_reenum_pending = false;
+	mutex_unlock(&ds5_reenum_lock);
+
+	pr_info("d4xx: D500 recovery rebind completed\n");
+}
+
+static int ds5_schedule_reenumeration(struct ds5 *state)
+{
+	struct dser_control *target_dser;
+	unsigned int count = 0;
+	bool have_depth = false;
+	int i;
+	int role;
+
+	if (!state->ds5_dev)
+		return -ENODEV;
+
+	mutex_lock(&state->ds5_dev->lock);
+	target_dser = state->ds5_dev->dser_control;
+	mutex_unlock(&state->ds5_dev->lock);
+	if (!target_dser)
+		return -ENODEV;
+
+	mutex_lock(&ds5_reenum_lock);
+	if (ds5_reenum_pending) {
+		mutex_unlock(&ds5_reenum_lock);
+		return 0;
+	}
+
+	for (i = 0; i < MAX_DS5_NUM; i++) {
+		mutex_lock(&ds5_inited[i].lock);
+		if (ds5_inited[i].dser_control != target_dser) {
+			mutex_unlock(&ds5_inited[i].lock);
+			continue;
+		}
+
+		for (role = 0; role < DS5_REENUM_ROLE_COUNT; role++) {
+			struct device *dev = ds5_inited[i].reenum_members[role];
+
+			if (!dev)
+				continue;
+			if (count >= DS5_REENUM_MAX_DEVICES)
+				break;
+			if (!get_device(dev))
+				continue;
+
+			ds5_reenum_entries[count].dev = dev;
+			ds5_reenum_entries[count].role = role;
+			ds5_reenum_entries[count].group = i;
+			ds5_reenum_entries[count].was_primary =
+				ds5_inited[i].reenum_member_primary[role];
+			count++;
+			if (role == DS5_REENUM_DEPTH)
+				have_depth = true;
+		}
+		mutex_unlock(&ds5_inited[i].lock);
+	}
+
+	if (!count || !have_depth) {
+		while (count)
+			put_device(ds5_reenum_entries[--count].dev);
+		mutex_unlock(&ds5_reenum_lock);
+		return -ENODEV;
+	}
+
+	ds5_reenum_num_entries = count;
+	ds5_reenum_pending = true;
+	schedule_delayed_work(&ds5_reenum_work,
+		msecs_to_jiffies(DS5_REENUM_DELAY_MS));
+	mutex_unlock(&ds5_reenum_lock);
+
+	dev_warn(&state->client->dev,
+		"D500 serializer power loss: scheduled driver-core re-enumeration of %u I2C functions\n",
+		count);
+	return 0;
+}
+
+static int ds5_reenumerate_after_reset_failure(struct ds5 *state,
+		bool d500_serdes_cold_reset, int failure)
+{
+	int ret;
+
+	if (!d500_serdes_cold_reset)
+		return failure;
+
+	ret = ds5_schedule_reenumeration(state);
+	if (ret) {
+		dev_err(&state->client->dev,
+			"D500 driver-core re-enumeration could not be scheduled (%d)\n",
+			ret);
+		return failure;
+	}
+
+	/* The reset command was accepted.  The old device instances disappear
+	 * asynchronously and fresh instances will be probed after full SERDES
+	 * setup, matching module remove/insert semantics.
+	 */
+	return 0;
+}
+
+static void ds5_cancel_reenumeration(void)
+{
+	int i;
+
+	if (!ds5_slots_inited)
+		return;
+
+	cancel_delayed_work_sync(&ds5_reenum_work);
+	mutex_lock(&ds5_reenum_lock);
+	for (i = 0; i < ds5_reenum_num_entries; i++) {
+		put_device(ds5_reenum_entries[i].dev);
+		ds5_reenum_entries[i].dev = NULL;
+	}
+	ds5_reenum_num_entries = 0;
+	ds5_reenum_pending = false;
+	mutex_unlock(&ds5_reenum_lock);
+}
+#endif
 
 static inline u16 ds5_rgb_ctrl_offset(struct ds5 *state, u16 d4xx_offset,
 				      u16 d58x_offset)
@@ -3079,7 +3371,8 @@ static int __ds5_hw_reset_with_recovery(struct ds5 *state)
 	if (d500_serdes_cold_reset) {
 		ret = ds5_d500_serdes_recover(state);
 		if (ret)
-			return ret;
+			return ds5_reenumerate_after_reset_failure(state,
+				d500_serdes_cold_reset, ret);
 
 		/*
 		 * Camera I2C was unreachable until the alias was restored. Give the
@@ -3097,7 +3390,12 @@ static int __ds5_hw_reset_with_recovery(struct ds5 *state)
 				"%s(): Device isn't ready after %d ms (last control-status: 0x%04x, i2c ret: %d)\n",
 				__func__, jiffies_to_msecs(jiffies - ts), ready_status, ret);
 
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+			return ds5_reenumerate_after_reset_failure(state,
+				d500_serdes_cold_reset, -ETIMEDOUT);
+#else
 			return -ETIMEDOUT;
+#endif
 		}
 
 		ret = ds5_read_poll(state, ready_reg, &ready_status);
@@ -3141,7 +3439,12 @@ static int __ds5_hw_reset_with_recovery(struct ds5 *state)
 		dev_err(&state->client->dev,
 			"%s(): device type not ready after reset (ret=%d, val=0x%x)\n",
 			__func__, ret, dev_type);
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+		return ds5_reenumerate_after_reset_failure(state,
+			d500_serdes_cold_reset, ret);
+#else
 		return ret;
+#endif
 	}
 	dev_info(&state->client->dev,
 		"%s(): GMSL link recovered (device type 0x%04x)\n",
@@ -3152,14 +3455,24 @@ static int __ds5_hw_reset_with_recovery(struct ds5 *state)
 	if (ret < 0) {
 		dev_err(&state->client->dev,
 			"%s(): Failed to read firmware version: %d\n", __func__, ret);
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+		return ds5_reenumerate_after_reset_failure(state,
+			d500_serdes_cold_reset, ret);
+#else
 		return ret;
+#endif
 	}
 
 	ret = ds5_read(state, DS5_FW_BUILD, &state->fw_build);
 	if (ret < 0) {
 		dev_err(&state->client->dev,
 			"%s(): Failed to read firmware build: %d\n", __func__, ret);
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+		return ds5_reenumerate_after_reset_failure(state,
+			d500_serdes_cold_reset, ret);
+#else
 		return ret;
+#endif
 	}
 
 	dev_info(&state->client->dev,
@@ -7601,6 +7914,9 @@ static int ds5_probe(struct i2c_client *c
 		state->dfu_dev.dfu_state_flag = DS5_DFU_RECOVERY;
 		/* Override I2C drvdata with state for use in remove function */
 		i2c_set_clientdata(c, state);
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+		ds5_reenum_register_member(state);
+#endif
 		return 0;
 	}
 
@@ -7636,6 +7952,9 @@ static int ds5_probe(struct i2c_client *c
 	/* create the sysfs file group */
 	err = sysfs_create_group(&state->client->dev.kobj, &ds5_attr_group);
 #endif
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+	ds5_reenum_register_member(state);
+#endif
 	return 0;
 
 e_chardev:
@@ -7667,6 +7986,7 @@ static void ds5_remove(struct i2c_client *c)
 	}
 
 #ifdef CONFIG_VIDEO_D4XX_SERDES
+	ds5_reenum_unregister_member(state);
 	if (state->ser_primary) {
 		int ret;
 		bool do_cleanup = false;
@@ -7753,7 +8073,22 @@ static struct i2c_driver ds5_i2c_driver = {
 	.id_table	= ds5_id,
 };
 
-module_i2c_driver(ds5_i2c_driver);
+static int __init ds5_driver_init(void)
+{
+	ds5_init_global_slots_once();
+	return i2c_add_driver(&ds5_i2c_driver);
+}
+
+static void __exit ds5_driver_exit(void)
+{
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+	ds5_cancel_reenumeration();
+#endif
+	i2c_del_driver(&ds5_i2c_driver);
+}
+
+module_init(ds5_driver_init);
+module_exit(ds5_driver_exit);
 
 MODULE_DESCRIPTION("RealSense D4XX and D5XX MIPI Camera Driver");
 MODULE_AUTHOR("Guennadi Liakhovetski <guennadi.liakhovetski@intel.com>,\n\

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -727,7 +727,7 @@ struct ds5_reenum_entry {
 };
 
 #define DS5_REENUM_MAX_DEVICES (MAX_DS5_NUM * DS5_REENUM_ROLE_COUNT)
-#define DS5_REENUM_DELAY_MS 1000
+#define DS5_REENUM_DELAY_MS 5000
 #define DS5_REENUM_ATTACH_RETRIES 3
 #define DS5_REENUM_ATTACH_RETRY_MS 500
 
@@ -735,6 +735,9 @@ static DEFINE_MUTEX(ds5_reenum_lock);
 static struct delayed_work ds5_reenum_work;
 static struct ds5_reenum_entry ds5_reenum_entries[DS5_REENUM_MAX_DEVICES];
 static unsigned int ds5_reenum_num_entries;
+static struct device *ds5_reenum_dser_dev;
+static struct device *ds5_reenum_ser_devs[MAX_DS5_NUM];
+static unsigned int ds5_reenum_num_ser_devs;
 static bool ds5_reenum_pending;
 
 static void ds5_reenum_work_fn(struct work_struct *work);
@@ -811,7 +814,6 @@ static const struct dser_interface max96724_interface = {
 	.reset_oneshot = max96724_reset_oneshot,
 	.retrigger_datapath = max96724_retrigger_datapath,
 	.setup_link = max96724_setup_link,
-	.recover_link = max96724_recover_link,
 	.setup_control = max96724_setup_control,
 	.reset_control = max96724_reset_control,
 	.setup_fsync = max96724_setup_fsync,
@@ -964,16 +966,21 @@ static void ds5_reenum_work_fn(struct work_struct *work)
 {
 	bool group_ready[MAX_DS5_NUM] = { false };
 	unsigned int num_entries;
+	unsigned int num_ser_devs;
+	struct device *dser_dev;
+	int ret;
 	int role;
 	int pass;
 	int i;
 
 	mutex_lock(&ds5_reenum_lock);
 	num_entries = ds5_reenum_num_entries;
+	num_ser_devs = ds5_reenum_num_ser_devs;
+	dser_dev = ds5_reenum_dser_dev;
 	mutex_unlock(&ds5_reenum_lock);
 
-	pr_warn("d4xx: D500 recovery rebinding %u I2C functions\n",
-		num_entries);
+	pr_warn("d4xx: D500 recovery rebinding deserializer, %u serializers and %u I2C functions\n",
+		num_ser_devs, num_entries);
 
 	/* Match a complete module removal: remove peers before the function
 	 * which owns the serializer/deserializer registration.
@@ -988,13 +995,35 @@ static void ds5_reenum_work_fn(struct work_struct *work)
 		}
 	}
 
+	/* modprobe -r also drops now-unused SerDes dependencies.  Reproduce
+	 * that lifecycle so their devm state and cached link_setup/poc_enabled
+	 * flags cannot survive the remote power loss.
+	 */
+	for (i = (int)num_ser_devs - 1; i >= 0; i--)
+		device_release_driver(ds5_reenum_ser_devs[i]);
+	device_release_driver(dser_dev);
+
+	ret = ds5_reenum_attach_device(dser_dev);
+	if (ret) {
+		dev_err(dser_dev,
+			"D500 recovery failed to reattach deserializer (%d)\n", ret);
+		goto put_refs;
+	}
+
+	for (i = 0; i < num_ser_devs; i++) {
+		ret = ds5_reenum_attach_device(ds5_reenum_ser_devs[i]);
+		if (ret)
+			dev_err(ds5_reenum_ser_devs[i],
+				"D500 recovery failed to reattach serializer (%d)\n",
+				ret);
+	}
+
 	/* Depth must claim each camera slot first.  Its probe performs the full
 	 * serializer address assignment and, for the first camera, deserializer
 	 * power/setup.  Only then may the peer functions share that setup.
 	 */
 	for (i = 0; i < num_entries; i++) {
 		struct ds5_reenum_entry *entry = &ds5_reenum_entries[i];
-		int ret;
 
 		if (entry->role != DS5_REENUM_DEPTH)
 			continue;
@@ -1011,7 +1040,6 @@ static void ds5_reenum_work_fn(struct work_struct *work)
 	for (role = DS5_REENUM_RGB; role < DS5_REENUM_ROLE_COUNT; role++) {
 		for (i = 0; i < num_entries; i++) {
 			struct ds5_reenum_entry *entry = &ds5_reenum_entries[i];
-			int ret;
 
 			if (entry->role != role || !group_ready[entry->group])
 				continue;
@@ -1024,12 +1052,20 @@ static void ds5_reenum_work_fn(struct work_struct *work)
 		}
 	}
 
+put_refs:
 	mutex_lock(&ds5_reenum_lock);
 	for (i = 0; i < ds5_reenum_num_entries; i++) {
 		put_device(ds5_reenum_entries[i].dev);
 		ds5_reenum_entries[i].dev = NULL;
 	}
 	ds5_reenum_num_entries = 0;
+	for (i = 0; i < ds5_reenum_num_ser_devs; i++) {
+		put_device(ds5_reenum_ser_devs[i]);
+		ds5_reenum_ser_devs[i] = NULL;
+	}
+	ds5_reenum_num_ser_devs = 0;
+	put_device(ds5_reenum_dser_dev);
+	ds5_reenum_dser_dev = NULL;
 	ds5_reenum_pending = false;
 	mutex_unlock(&ds5_reenum_lock);
 
@@ -1040,6 +1076,7 @@ static int ds5_schedule_reenumeration(struct ds5 *state)
 {
 	struct dser_control *target_dser;
 	unsigned int count = 0;
+	unsigned int ser_count = 0;
 	bool have_depth = false;
 	int i;
 	int role;
@@ -1066,6 +1103,16 @@ static int ds5_schedule_reenumeration(struct ds5 *state)
 			continue;
 		}
 
+		if (ds5_inited[i].ds5_primary &&
+		    ds5_inited[i].ds5_primary->ser_dev &&
+		    ser_count < MAX_DS5_NUM) {
+			struct device *ser_dev =
+				ds5_inited[i].ds5_primary->ser_dev;
+
+			if (get_device(ser_dev))
+				ds5_reenum_ser_devs[ser_count++] = ser_dev;
+		}
+
 		for (role = 0; role < DS5_REENUM_ROLE_COUNT; role++) {
 			struct device *dev = ds5_inited[i].reenum_members[role];
 
@@ -1088,21 +1135,26 @@ static int ds5_schedule_reenumeration(struct ds5 *state)
 		mutex_unlock(&ds5_inited[i].lock);
 	}
 
-	if (!count || !have_depth) {
+	if (!count || !have_depth || !ser_count ||
+	    !get_device(state->dser_dev)) {
 		while (count)
 			put_device(ds5_reenum_entries[--count].dev);
+		while (ser_count)
+			put_device(ds5_reenum_ser_devs[--ser_count]);
 		mutex_unlock(&ds5_reenum_lock);
 		return -ENODEV;
 	}
 
 	ds5_reenum_num_entries = count;
+	ds5_reenum_num_ser_devs = ser_count;
+	ds5_reenum_dser_dev = state->dser_dev;
 	ds5_reenum_pending = true;
 	schedule_delayed_work(&ds5_reenum_work,
 		msecs_to_jiffies(DS5_REENUM_DELAY_MS));
 	mutex_unlock(&ds5_reenum_lock);
 
 	dev_warn(&state->client->dev,
-		"D500 serializer power loss: scheduled driver-core re-enumeration of %u I2C functions\n",
+		"D500 serializer power loss: scheduled full SerDes and %u-function re-enumeration\n",
 		count);
 	return 0;
 }
@@ -1144,6 +1196,15 @@ static void ds5_cancel_reenumeration(void)
 		ds5_reenum_entries[i].dev = NULL;
 	}
 	ds5_reenum_num_entries = 0;
+	for (i = 0; i < ds5_reenum_num_ser_devs; i++) {
+		put_device(ds5_reenum_ser_devs[i]);
+		ds5_reenum_ser_devs[i] = NULL;
+	}
+	ds5_reenum_num_ser_devs = 0;
+	if (ds5_reenum_dser_dev) {
+		put_device(ds5_reenum_dser_dev);
+		ds5_reenum_dser_dev = NULL;
+	}
 	ds5_reenum_pending = false;
 	mutex_unlock(&ds5_reenum_lock);
 }
@@ -3138,97 +3199,6 @@ static int ds5_set_ser_esync_tunneling(struct ds5 *state, bool enable)
 #endif
 }
 
-#ifdef CONFIG_VIDEO_D4XX_SERDES
-#define DS5_D500_SERDES_RECOVERY_RETRIES 2
-
-/*
- * D500 HW reset also removes serializer power. Rebuild only the remote link
- * and serializer state; the deserializer stays powered and must not be globally
- * reset because it may be shared with other cameras.
- */
-static int ds5_d500_serdes_recover(struct ds5 *state)
-{
-	struct ds5 *primary;
-	int attempt;
-	int ret = -ENODEV;
-
-	mutex_lock(&state->ds5_dev->lock);
-	primary = state->ds5_dev->ds5_primary;
-	mutex_unlock(&state->ds5_dev->lock);
-
-	if (!primary || !primary->ser_dev || !primary->dser_dev ||
-	    !primary->ser_ops || !primary->dser_ops) {
-		dev_err(&state->client->dev,
-			"%s(): missing primary SERDES context\n", __func__);
-		return -ENODEV;
-	}
-
-	if (!primary->dser_ops->recover_link) {
-		dev_err(&state->client->dev,
-			"%s(): %s has no serializer power-cycle recovery\n",
-			__func__, primary->dser_ops->name);
-		return -EOPNOTSUPP;
-	}
-
-	/*
-	 * Exclude stream pipe programming while the serializer is temporarily at
-	 * its default address and the deserializer is in exclusive-link mode.
-	 */
-	mutex_lock(&serdes_lock__);
-	for (attempt = 1; attempt <= DS5_D500_SERDES_RECOVERY_RETRIES;
-	     attempt++) {
-		dev_info(&state->client->dev,
-			 "%s(): D500 cold SERDES recovery attempt %d/%d\n",
-			 __func__, attempt, DS5_D500_SERDES_RECOVERY_RETRIES);
-
-		ret = primary->dser_ops->recover_link(primary->dser_dev,
-						     &primary->client->dev);
-		if (ret) {
-			dev_warn(&state->client->dev,
-				 "%s(): %s link recovery failed (%d)\n",
-				 __func__, primary->dser_ops->name, ret);
-			goto retry;
-		}
-
-		/*
-		 * Serializer power loss clears both the camera I2C alias and all
-		 * MIPI/tunnel registers. Restore them in the same order as probe.
-		 */
-		ret = primary->ser_ops->setup_control(primary->ser_dev);
-		if (ret) {
-			dev_warn(&state->client->dev,
-				 "%s(): %s I2C alias restore failed (%d)\n",
-				 __func__, primary->ser_ops->name, ret);
-			goto retry;
-		}
-
-		ret = primary->ser_ops->init_settings(primary->ser_dev);
-		if (!ret)
-			break;
-
-		dev_warn(&state->client->dev,
-			 "%s(): %s settings restore failed (%d)\n",
-			 __func__, primary->ser_ops->name, ret);
-
-retry:
-		if (attempt < DS5_D500_SERDES_RECOVERY_RETRIES)
-			msleep(100);
-	}
-	mutex_unlock(&serdes_lock__);
-
-	if (ret)
-		dev_err(&state->client->dev,
-			"%s(): D500 cold SERDES recovery failed (%d)\n",
-			__func__, ret);
-	else
-		dev_info(&state->client->dev,
-			 "%s(): D500 serializer link and I2C alias restored\n",
-			 __func__);
-
-	return ret;
-}
-#endif
-
 /*
  * ds5_hw_reset_with_recovery - Perform hardware reset with readiness polling
  * @state: Driver state structure
@@ -3369,16 +3339,15 @@ static int __ds5_hw_reset_with_recovery(struct ds5 *state)
 
 #ifdef CONFIG_VIDEO_D4XX_SERDES
 	if (d500_serdes_cold_reset) {
-		ret = ds5_d500_serdes_recover(state);
+		ret = ds5_schedule_reenumeration(state);
 		if (ret)
-			return ds5_reenumerate_after_reset_failure(state,
-				d500_serdes_cold_reset, ret);
+			return ret;
 
-		/*
-		 * Camera I2C was unreachable until the alias was restored. Give the
-		 * normal FW-readiness handshake its full timeout from this point.
+		/* Do not touch the recovering GMSL link from this ioctl context.
+		 * The delayed worker gives HKR and the serializer a quiet boot window,
+		 * then reproduces the complete module remove/probe lifecycle.
 		 */
-		ts = jiffies;
+		return 0;
 	}
 #endif
 

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -65,6 +65,11 @@ struct dser_interface {
 
 	/* Setup and control */
 	int (*setup_link)(struct device *dev, struct device *s_dev);
+	/*
+	 * Re-establish a link after the remote serializer lost power. Optional:
+	 * only products whose HW reset power-cycles the serializer need it.
+	 */
+	int (*recover_link)(struct device *dev, struct device *s_dev);
 	int (*setup_control)(struct device *dev, struct device *s_dev);
 	int (*reset_control)(struct device *dev, struct device *s_dev);
 	int (*setup_fsync)(struct device *dev, u32 fps);
@@ -625,6 +630,11 @@ struct ds5 {
 
 struct ds5_dev {
 	struct mutex lock;
+	/*
+	 * Serialize HW reset/recovery across the four I2C instances which expose
+	 * one physical camera (Depth, RGB, IR and IMU).
+	 */
+	struct mutex reset_lock;
 
 	/*
 	* Per-camera reset generation counter.
@@ -693,8 +703,10 @@ static void ds5_init_global_slots_once(void)
 		return;
 	}
 
-	for (i = 0; i < MAX_DS5_NUM; i++)
+	for (i = 0; i < MAX_DS5_NUM; i++) {
 		mutex_init(&ds5_inited[i].lock);
+		mutex_init(&ds5_inited[i].reset_lock);
+	}
 
 	for (i = 0; i < MAX_DSER_NUM; i++)
 		mutex_init(&dser_inited[i].lock);
@@ -735,6 +747,7 @@ static const struct dser_interface max96712_interface = {
 	.reset_oneshot = max96712_reset_oneshot,
 	.reset_oneshot_link = max96712_reset_oneshot_link,
 	.setup_link = max96712_setup_link,
+	.recover_link = max96712_setup_link,
 	.setup_control = max96712_setup_control,
 	.reset_control = max96712_reset_control,
 	.sdev_register = max96712_sdev_register,
@@ -753,6 +766,7 @@ static const struct dser_interface max96724_interface = {
 	.reset_oneshot = max96724_reset_oneshot,
 	.retrigger_datapath = max96724_retrigger_datapath,
 	.setup_link = max96724_setup_link,
+	.recover_link = max96724_recover_link,
 	.setup_control = max96724_setup_control,
 	.reset_control = max96724_reset_control,
 	.setup_fsync = max96724_setup_fsync,
@@ -812,6 +826,7 @@ static void ds5_init_global_slots_once(void)
 	mutex_lock(&ds5_slots_lock__);
 	if (!ds5_slots_inited) {
 		mutex_init(&ds5_inited[0].lock);
+		mutex_init(&ds5_inited[0].reset_lock);
 		ds5_slots_inited = true;
 	}
 	mutex_unlock(&ds5_slots_lock__);
@@ -2826,6 +2841,97 @@ static int ds5_set_ser_esync_tunneling(struct ds5 *state, bool enable)
 #endif
 }
 
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+#define DS5_D500_SERDES_RECOVERY_RETRIES 2
+
+/*
+ * D500 HW reset also removes serializer power. Rebuild only the remote link
+ * and serializer state; the deserializer stays powered and must not be globally
+ * reset because it may be shared with other cameras.
+ */
+static int ds5_d500_serdes_recover(struct ds5 *state)
+{
+	struct ds5 *primary;
+	int attempt;
+	int ret = -ENODEV;
+
+	mutex_lock(&state->ds5_dev->lock);
+	primary = state->ds5_dev->ds5_primary;
+	mutex_unlock(&state->ds5_dev->lock);
+
+	if (!primary || !primary->ser_dev || !primary->dser_dev ||
+	    !primary->ser_ops || !primary->dser_ops) {
+		dev_err(&state->client->dev,
+			"%s(): missing primary SERDES context\n", __func__);
+		return -ENODEV;
+	}
+
+	if (!primary->dser_ops->recover_link) {
+		dev_err(&state->client->dev,
+			"%s(): %s has no serializer power-cycle recovery\n",
+			__func__, primary->dser_ops->name);
+		return -EOPNOTSUPP;
+	}
+
+	/*
+	 * Exclude stream pipe programming while the serializer is temporarily at
+	 * its default address and the deserializer is in exclusive-link mode.
+	 */
+	mutex_lock(&serdes_lock__);
+	for (attempt = 1; attempt <= DS5_D500_SERDES_RECOVERY_RETRIES;
+	     attempt++) {
+		dev_info(&state->client->dev,
+			 "%s(): D500 cold SERDES recovery attempt %d/%d\n",
+			 __func__, attempt, DS5_D500_SERDES_RECOVERY_RETRIES);
+
+		ret = primary->dser_ops->recover_link(primary->dser_dev,
+						     &primary->client->dev);
+		if (ret) {
+			dev_warn(&state->client->dev,
+				 "%s(): %s link recovery failed (%d)\n",
+				 __func__, primary->dser_ops->name, ret);
+			goto retry;
+		}
+
+		/*
+		 * Serializer power loss clears both the camera I2C alias and all
+		 * MIPI/tunnel registers. Restore them in the same order as probe.
+		 */
+		ret = primary->ser_ops->setup_control(primary->ser_dev);
+		if (ret) {
+			dev_warn(&state->client->dev,
+				 "%s(): %s I2C alias restore failed (%d)\n",
+				 __func__, primary->ser_ops->name, ret);
+			goto retry;
+		}
+
+		ret = primary->ser_ops->init_settings(primary->ser_dev);
+		if (!ret)
+			break;
+
+		dev_warn(&state->client->dev,
+			 "%s(): %s settings restore failed (%d)\n",
+			 __func__, primary->ser_ops->name, ret);
+
+retry:
+		if (attempt < DS5_D500_SERDES_RECOVERY_RETRIES)
+			msleep(100);
+	}
+	mutex_unlock(&serdes_lock__);
+
+	if (ret)
+		dev_err(&state->client->dev,
+			"%s(): D500 cold SERDES recovery failed (%d)\n",
+			__func__, ret);
+	else
+		dev_info(&state->client->dev,
+			 "%s(): D500 serializer link and I2C alias restored\n",
+			 __func__);
+
+	return ret;
+}
+#endif
+
 /*
  * ds5_hw_reset_with_recovery - Perform hardware reset with readiness polling
  * @state: Driver state structure
@@ -2839,7 +2945,7 @@ static int ds5_set_ser_esync_tunneling(struct ds5 *state, bool enable)
  *
  * Returns 0 on success, negative error code on failure.
  */
-static int ds5_hw_reset_with_recovery(struct ds5 *state)
+static int __ds5_hw_reset_with_recovery(struct ds5 *state)
 {
 	int ret;
 	int retry;
@@ -2851,11 +2957,22 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	bool rgb_streaming;
 	bool ir_streaming;
 	bool imu_streaming;
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+	bool d500_serdes_cold_reset;
+#endif
 	unsigned long ds5_last_reset_jiffies = READ_ONCE(state->ds5_dev->last_reset_jiffies);
 	unsigned long ts, timeout;
 
 	dev_info(&state->client->dev, "%s(): Initiating HW reset with recovery\n",
 		__func__);
+
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+	/*
+	 * Capture the product family before cached_device_type is invalidated
+	 * below. Only D500 power-cycles its serializer as part of camera reset.
+	 */
+	d500_serdes_cold_reset = ds5_is_d58x(state);
+#endif
 
 	/* 0. Reset cooldown — prevent rapid consecutive resets.
 	 *    Repeated HW resets without sufficient recovery time
@@ -2952,6 +3069,20 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	/* 5. Delay to allow reset to complete */
 	ts = jiffies;
 	msleep(DS5_HW_RESET_INITIAL_DELAY_MS);
+
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+	if (d500_serdes_cold_reset) {
+		ret = ds5_d500_serdes_recover(state);
+		if (ret)
+			return ret;
+
+		/*
+		 * Camera I2C was unreachable until the alias was restored. Give the
+		 * normal FW-readiness handshake its full timeout from this point.
+		 */
+		ts = jiffies;
+	}
+#endif
 
 	/* 6. Poll for control-status defaults to confirm reset completion. */
 	for (retry = 0, timeout = ts + msecs_to_jiffies(DS5_HW_RESET_TIMEOUT_MS);
@@ -3053,6 +3184,17 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	WRITE_ONCE(state->ds5_dev->last_reset_jiffies, jiffies);
 
 	return 0;
+}
+
+static int ds5_hw_reset_with_recovery(struct ds5 *state)
+{
+	int ret;
+
+	mutex_lock(&state->ds5_dev->reset_lock);
+	ret = __ds5_hw_reset_with_recovery(state);
+	mutex_unlock(&state->ds5_dev->reset_lock);
+
+	return ret;
 }
 
 static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on);

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -121,6 +121,11 @@ struct ser_interface {
 #define GMSL_CSI_DT_EMBED 0x12
 #endif
 
+/* NVIDIA's JP6.2/JP7.1 gmsl-link.h does not define the RAW16 CSI-2 DT. */
+#ifndef GMSL_CSI_DT_RAW_16
+#define GMSL_CSI_DT_RAW_16 0x2E
+#endif
+
 /* D40x FW CSI-PT mode selector for the OV9782 (not a MIPI wire DT). */
 #define DS5_FW_CSI_PT	0x2E
 

--- a/nvidia-oot/max96724.c
+++ b/nvidia-oot/max96724.c
@@ -609,8 +609,7 @@ static int max96724_enable_links(struct device *dev, u8 link_mask,
 	 * before polling lock or accessing the serializer.
 	 */
 	msleep(20);
-	err = max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
-				 MAX96724_ONESHOT_ALL);
+	err = max96724_write_reg(dev, MAX96724_ONESHOT_ADDR, link_mask);
 	if (!err)
 		msleep(100);
 
@@ -680,6 +679,151 @@ static int max96724_assign_serializer_addresses(struct device *dev)
 
 	return err;
 }
+
+int max96724_recover_link(struct device *dev, struct device *s_dev)
+{
+	struct max96724 *priv;
+	struct max96724_source_ctx *source;
+	unsigned int source_idx;
+	unsigned int reg_val = 0;
+	unsigned int link;
+	u8 source_link_mask;
+	u8 target_addr;
+	int restore_err;
+	int err;
+
+	if (!dev || !s_dev)
+		return -EINVAL;
+
+	priv = dev_get_drvdata(dev);
+	if (!priv)
+		return -ENODEV;
+
+	mutex_lock(&priv->lock);
+
+	err = max96724_get_sdev_idx_locked(priv, s_dev, &source_idx);
+	if (err) {
+		dev_err(dev, "%s: no source found for %s\n",
+			__func__, dev_name(s_dev));
+		goto out;
+	}
+
+	source = &priv->sources[source_idx];
+	if (!source->g_ctx) {
+		err = -EINVAL;
+		goto out;
+	}
+
+	/*
+	 * gmsl-link.h represents the link as a one-hot value (A=BIT(0),
+	 * B=BIT(1)). Convert it to the MAX96724 link index and reject malformed
+	 * source descriptions before touching the shared deserializer.
+	 */
+	source_link_mask = (u8)source->serdes_csi_link;
+	if (!source_link_mask ||
+	    (source_link_mask & (source_link_mask - 1)) ||
+	    (source_link_mask & ~((u8)GENMASK(MAX96724_MAX_LINKS - 1, 0)))) {
+		dev_err(dev, "%s: invalid source link 0x%x\n",
+			__func__, source->serdes_csi_link);
+		err = -EINVAL;
+		goto out;
+	}
+
+	for (link = 0; link < MAX96724_MAX_LINKS; link++)
+		if (source_link_mask & BIT(link))
+			break;
+
+	if (!(priv->link_mask & BIT(link))) {
+		dev_err(dev, "%s: link %c is not enabled (mask 0x%x)\n",
+			__func__, 'A' + link, priv->link_mask);
+		err = -EINVAL;
+		goto out;
+	}
+
+	target_addr = (u8)source->g_ctx->ser_reg;
+	if (!target_addr || target_addr > 0x7f) {
+		dev_err(dev, "%s: invalid serializer address 0x%x\n",
+			__func__, source->g_ctx->ser_reg);
+		err = -EINVAL;
+		goto out;
+	}
+
+	dev_info(dev,
+		 "%s: recovering GMSL link %c serializer at 0x%02x\n",
+		 __func__, 'A' + link, target_addr);
+
+	/*
+	 * Isolate the affected link while accessing the serializer's default
+	 * address. This avoids an address collision with a healthy link-A
+	 * serializer when a serializer on link B/C/D returns to 0x40.
+	 */
+	err = max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR, 0x00);
+	if (err)
+		goto out;
+
+	err = max96724_enable_links(dev, BIT(link), true);
+	if (err)
+		goto restore;
+
+	err = max96724_wait_link_lock(dev, link);
+	if (err)
+		goto restore;
+
+	/* Link lock may precede the remote I2C port becoming usable. */
+	msleep(20);
+	err = max96724_read_slave_reg(priv, target_addr,
+					 MAX96717_DEV_ADDR, &reg_val);
+	if (!err && reg_val == target_addr << 1) {
+		dev_dbg(dev, "%s: serializer already responds at 0x%02x\n",
+			__func__, target_addr);
+		goto restore;
+	}
+
+	err = max96724_write_slave_reg(priv, MAX96717_DEFAULT_ADDR,
+					  MAX96717_DEV_ADDR,
+					  target_addr << 1);
+	if (err)
+		goto restore;
+
+	msleep(20);
+	err = max96724_read_slave_reg(priv, target_addr,
+					 MAX96717_DEV_ADDR, &reg_val);
+	if (err || reg_val != target_addr << 1) {
+		dev_err(dev,
+			"%s: serializer address restore failed on link %c (reg 0x%x, err %d)\n",
+			__func__, 'A' + link, reg_val, err);
+		if (!err)
+			err = -ENODEV;
+		goto restore;
+	}
+
+	dev_info(dev, "%s: serializer address 0x%02x restored on link %c\n",
+		 __func__, target_addr, 'A' + link);
+
+restore:
+	/*
+	 * Restore every configured link even on failure. The deserializer itself
+	 * did not lose power, so its CSI mappings remain valid; only force the
+	 * next stream start to re-arm the tunnel datapath.
+	 */
+	restore_err = max96724_enable_links(dev, priv->link_mask, true);
+	if (!err)
+		err = restore_err;
+	restore_err = max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
+					 MAX96724_BACKTOP_CSIB_EN);
+	if (!err)
+		err = restore_err;
+	if (!err)
+		err = max96724_wait_link_lock(dev, link);
+
+	priv->datapath_retriggered = false;
+	priv->retriggered_pipe_mask = 0;
+
+out:
+	mutex_unlock(&priv->lock);
+	return err;
+}
+EXPORT_SYMBOL(max96724_recover_link);
 
 int max96724_setup_link(struct device *dev, struct device *s_dev)
 {

--- a/nvidia-oot/max96724.h
+++ b/nvidia-oot/max96724.h
@@ -58,6 +58,21 @@ void max96724_retrigger_datapath(struct device *dev);
 int max96724_setup_link(struct device *dev, struct device *s_dev);
 
 /**
+ * @brief Re-trains one GMSL link after its serializer lost power.
+ *
+ * Unlike max96724_setup_link(), this function deliberately ignores the
+ * cached link_setup state. It waits for the selected link to lock and restores
+ * the serializer's assigned I2C address if the serializer returned to its
+ * default address after a remote power cycle.
+ *
+ * @param  [in]  dev          The deserializer device handle.
+ * @param  [in]  s_dev        The registered sensor device for the link.
+ *
+ * @return  0 for success, or negative error code.
+ */
+int max96724_recover_link(struct device *dev, struct device *s_dev);
+
+/**
  * @brief  Sets up the deserializer link's control pipeline.
  *
  * Configures I2C pass-through and enables tunnel-mode pipe routing


### PR DESCRIPTION
## Summary

- serialize reset recovery across the I2C functions of one physical camera
- detect D500 before reset invalidates the cached device type
- after a D500 HW reset, leave the GMSL link untouched for a 5-second HKR/serializer boot window
- asynchronously reproduce the complete dependency lifecycle for the affected deserializer: remove d4xx peers before primaries, release serializer and deserializer devices, then attach deserializer, serializer, Depth, RGB, IR and IMU in order
- cancel pending recovery work safely during module removal
- remove the obsolete runtime dependency on max96724_recover_link
- keep the D400 reset path unchanged
- define the RAW16 CSI data type missing from NVIDIA JP6.2 headers

## Root cause

D58X HW reset causes HKR to power down the remote GMSL serializer. Host-side d4xx instances and SerDes driver state must be rebuilt after HKR restores remote power.

Hardware validation also exposed an HKR-side requirement: current HKR FW logs GMSL power disabled, negotiation state 0 and auto-deinit complete after HW reset, but does not automatically re-enable GPIO_81. The Orin has no HKR UART or reset-GPIO sideband, so host-driver re-probe alone cannot recover a serializer that remains physically powered off. HKR FW must auto-init GMSL after reset, or the platform must provide a UART/GPIO sideband reset.

## Validation

- JP6.2 focused NVIDIA OOT module build with the L4T cross compiler: passed
- checkpatch on the final d4xx diff: 0 errors, 0 warnings
- D500 reset with host-only rebind: expected failure while HKR leaves GMSL power disabled; MAX96724 link A remains 0x16 and times out
- D500 reset plus HKR UART reboot plus automatic driver rebind: passed twice without rebooting Orin
- after recovery: one D585 enumerated, all 4 d4xx I2C functions bound, 7 video nodes
- post-recovery stream probe: 90 framesets, valid Depth and Color frames, exit 0

## Platform requirement

This PR provides the host re-enumeration half of recovery. Autonomous recovery additionally requires HKR FW to restart its GMSL state machine, or a platform sideband capable of rebooting HKR.