### PR TITLE
[RSDEV-13973][D585][GMSL] Align MinZ with 7-field DPP control

### DIFF
--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -510,6 +510,7 @@ struct ds5_ctrls {
 		struct v4l2_ctrl *sync_mode;
 		struct v4l2_ctrl *device_mode;
 		struct v4l2_ctrl *dual_rgb_ae_policy;
+		struct v4l2_ctrl *minz;
 		/* RGB-only ISP controls. Only ae_priority needs a stored
 		 * pointer because it must be disabled per-SKU after probe
 		 * (D40X/D401 does not support it). The remaining controls
@@ -2621,6 +2622,167 @@ enum ds5_ae_type {
 	DS5_AE_TYPE_V2 = 1,
 };
 
+#define D500_CAMERA_CID_MINZ			(DS5_CAMERA_CID_BASE + 44)
+#define D500_CAMERA_CID_DECIMATION_ENABLE	(DS5_CAMERA_CID_BASE + 49)
+#define D500_CAMERA_CID_DECIMATION_MAGNITUDE	(DS5_CAMERA_CID_BASE + 50)
+#define D500_CAMERA_CID_TEMPORAL_ENABLE		(DS5_CAMERA_CID_BASE + 51)
+#define D500_CAMERA_CID_TEMPORAL_ALPHA		(DS5_CAMERA_CID_BASE + 52)
+#define D500_CAMERA_CID_TEMPORAL_DELTA		(DS5_CAMERA_CID_BASE + 53)
+#define D500_CAMERA_CID_TEMPORAL_PERSISTENCY	(DS5_CAMERA_CID_BASE + 54)
+#define D500_MINZ_XU_BASE		0x4500
+#define D500_DECIMATION_XU_BASE		0x4540
+#define D500_TEMPORAL_XU_BASE		0x4568
+#define D500_DPP_XU_VERSION		1
+#define D500_DPP_XU_DECIMATION_CONTROL_ID	BIT(0)
+#define D500_DPP_XU_TEMPORAL_CONTROL_ID		BIT(1)
+#define D500_DPP_XU_MINZ_CONTROL_ID	BIT(3)
+#define D500_DPP_XU_DECIMATION_PARAM_COUNT	2
+#define D500_DPP_XU_TEMPORAL_PARAM_COUNT	4
+#define D500_DPP_XU_MINZ_PARAM_COUNT	7
+#define D500_DPP_XU_INTEGER_PARAMS	0
+/* params[1] is a floating-point alpha encoded in milli-units by the XU ABI. */
+#define D500_DPP_XU_TEMPORAL_PARAM_TYPE	BIT(1)
+
+enum d500_minz_param_index {
+	D500_MINZ_ENABLE = 0,
+	D500_MINZ_FILTER_TYPE,
+	D500_MINZ_DOWNSCALE_RATIO,
+	D500_MINZ_SHIFT_MODE,
+	D500_MINZ_SHIFT_PIXELS,
+	D500_MINZ_THRESHOLD_MODE,
+	D500_MINZ_THRESHOLD_MM,
+};
+
+static const u32 d500_minz_min[D500_DPP_XU_MINZ_PARAM_COUNT] = {
+	0, 0, 1, 0, 0, 0, 0,
+};
+
+static const u32 d500_minz_max[D500_DPP_XU_MINZ_PARAM_COUNT] = {
+	1, 1, 2, 2, 256, 2, 65535,
+};
+
+struct d500_dpp_xu_header {
+	u8 version;
+	u8 flags;
+	__le16 control_id;
+} __packed;
+
+struct d500_dpp_xu_control {
+	struct d500_dpp_xu_header header;
+	u8 param_count;
+	u8 param_type;
+	__le32 params[8];
+} __packed;
+
+struct d500_dpp_ctrl_desc {
+	u16 base;
+	u16 control_id;
+	u8 param_count;
+	u8 param_type;
+	u8 param_index;
+	bool idle_only;
+};
+
+static int d500_dpp_xu_read(struct ds5 *state,
+			    const struct d500_dpp_ctrl_desc *desc,
+			    struct d500_dpp_xu_control *control)
+{
+	int ret;
+
+	ret = ds5_raw_read(state, desc->base, control,
+			   sizeof(*control));
+	if (ret)
+		return ret;
+	if (control->header.version != D500_DPP_XU_VERSION ||
+	    le16_to_cpu(control->header.control_id) !=
+		desc->control_id ||
+	    control->param_count != desc->param_count ||
+	    control->param_type != desc->param_type)
+		return -EBADMSG;
+	return 0;
+}
+
+static int d500_dpp_xu_write(struct ds5 *state,
+			     const struct d500_dpp_ctrl_desc *desc,
+			     const struct d500_dpp_xu_control *control)
+{
+	return ds5_raw_write(state, desc->base, control,
+			     sizeof(*control));
+}
+
+static const struct d500_dpp_ctrl_desc d500_minz_desc = {
+	.base = D500_MINZ_XU_BASE,
+	.control_id = D500_DPP_XU_MINZ_CONTROL_ID,
+	.param_count = D500_DPP_XU_MINZ_PARAM_COUNT,
+	.param_type = D500_DPP_XU_INTEGER_PARAMS,
+	.idle_only = true,
+};
+
+static bool d500_minz_params_valid(const u32 *params)
+{
+	u8 i;
+
+	for (i = 0; i < D500_DPP_XU_MINZ_PARAM_COUNT; i++)
+		if (params[i] < d500_minz_min[i] ||
+		    params[i] > d500_minz_max[i])
+			return false;
+	return true;
+}
+
+static int d500_dpp_ctrl_desc(u32 ctrl_id,
+			      struct d500_dpp_ctrl_desc *desc)
+{
+	memset(desc, 0, sizeof(*desc));
+	switch (ctrl_id) {
+	case D500_CAMERA_CID_DECIMATION_ENABLE:
+		desc->base = D500_DECIMATION_XU_BASE;
+		desc->control_id = D500_DPP_XU_DECIMATION_CONTROL_ID;
+		desc->param_count = D500_DPP_XU_DECIMATION_PARAM_COUNT;
+		desc->param_type = D500_DPP_XU_INTEGER_PARAMS;
+		desc->param_index = 0;
+		desc->idle_only = true;
+		return 0;
+	case D500_CAMERA_CID_DECIMATION_MAGNITUDE:
+		desc->base = D500_DECIMATION_XU_BASE;
+		desc->control_id = D500_DPP_XU_DECIMATION_CONTROL_ID;
+		desc->param_count = D500_DPP_XU_DECIMATION_PARAM_COUNT;
+		desc->param_type = D500_DPP_XU_INTEGER_PARAMS;
+		desc->param_index = 1;
+		desc->idle_only = true;
+		return 0;
+	case D500_CAMERA_CID_TEMPORAL_ENABLE:
+		desc->base = D500_TEMPORAL_XU_BASE;
+		desc->control_id = D500_DPP_XU_TEMPORAL_CONTROL_ID;
+		desc->param_count = D500_DPP_XU_TEMPORAL_PARAM_COUNT;
+		desc->param_type = D500_DPP_XU_TEMPORAL_PARAM_TYPE;
+		desc->param_index = 0;
+		return 0;
+	case D500_CAMERA_CID_TEMPORAL_ALPHA:
+		desc->base = D500_TEMPORAL_XU_BASE;
+		desc->control_id = D500_DPP_XU_TEMPORAL_CONTROL_ID;
+		desc->param_count = D500_DPP_XU_TEMPORAL_PARAM_COUNT;
+		desc->param_type = D500_DPP_XU_TEMPORAL_PARAM_TYPE;
+		desc->param_index = 1;
+		return 0;
+	case D500_CAMERA_CID_TEMPORAL_DELTA:
+		desc->base = D500_TEMPORAL_XU_BASE;
+		desc->control_id = D500_DPP_XU_TEMPORAL_CONTROL_ID;
+		desc->param_count = D500_DPP_XU_TEMPORAL_PARAM_COUNT;
+		desc->param_type = D500_DPP_XU_TEMPORAL_PARAM_TYPE;
+		desc->param_index = 2;
+		return 0;
+	case D500_CAMERA_CID_TEMPORAL_PERSISTENCY:
+		desc->base = D500_TEMPORAL_XU_BASE;
+		desc->control_id = D500_DPP_XU_TEMPORAL_CONTROL_ID;
+		desc->param_count = D500_DPP_XU_TEMPORAL_PARAM_COUNT;
+		desc->param_type = D500_DPP_XU_TEMPORAL_PARAM_TYPE;
+		desc->param_index = 3;
+		return 0;
+	default:
+		return -ENOENT;
+	}
+}
+
 #define DS5_HWMC_DATA			0x4900
 #define DS5_HWMC_STATUS			0x4904
 #define DS5_HWMC_RESP_LEN		0x4908
@@ -3251,6 +3413,7 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 					 ctrls.handler);
 	struct v4l2_subdev *sd = &state->mux.sd.subdev;
 	struct ds5_sensor *sensor = (struct ds5_sensor *)ctrl->priv;
+	struct d500_dpp_ctrl_desc dpp_desc;
 	int ret = -EINVAL;
 	u16 base;
 
@@ -3279,6 +3442,44 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 		__func__, ds5_get_sensor_name(state), ctrl->name, ctrl->val);
 
 	mutex_lock(&state->lock);
+	if (ctrl->id == D500_CAMERA_CID_MINZ) {
+		struct d500_dpp_xu_control control = {
+			.header.version = D500_DPP_XU_VERSION,
+			.header.control_id =
+				cpu_to_le16(D500_DPP_XU_MINZ_CONTROL_ID),
+			.param_count = D500_DPP_XU_MINZ_PARAM_COUNT,
+			.param_type = D500_DPP_XU_INTEGER_PARAMS,
+		};
+		u8 i;
+
+		if (sensor && sensor->streaming) {
+			ret = -EBUSY;
+			goto unlock;
+		}
+		if (!d500_minz_params_valid(ctrl->p_new.p_u32)) {
+			ret = -EINVAL;
+			goto unlock;
+		}
+		for (i = 0; i < D500_DPP_XU_MINZ_PARAM_COUNT; i++)
+			control.params[i] = cpu_to_le32(ctrl->p_new.p_u32[i]);
+		ret = d500_dpp_xu_write(state, &d500_minz_desc, &control);
+		goto unlock;
+	}
+	if (d500_dpp_ctrl_desc(ctrl->id, &dpp_desc) == 0) {
+		struct d500_dpp_xu_control control;
+
+		if (dpp_desc.idle_only && sensor && sensor->streaming) {
+			ret = -EBUSY;
+			goto unlock;
+		}
+		ret = d500_dpp_xu_read(state, &dpp_desc, &control);
+		if (!ret) {
+			control.params[dpp_desc.param_index] =
+				cpu_to_le32(ctrl->val);
+			ret = d500_dpp_xu_write(state, &dpp_desc, &control);
+		}
+		goto unlock;
+	}
 
 	switch (ctrl->id) {
 	case V4L2_CID_ANALOGUE_GAIN:
@@ -3665,6 +3866,7 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 		break;
 	}
 
+unlock:
 	mutex_unlock(&state->lock);
 
 	return ret;
@@ -3771,6 +3973,7 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 			ctrls.handler);
 			
 	u32 data;
+	struct d500_dpp_ctrl_desc dpp_desc;
 	int ret = 0;
 	struct ds5_sensor *sensor = (struct ds5_sensor *)ctrl->priv;
 	u16 base;
@@ -3798,6 +4001,27 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 
 	dev_dbg(&state->client->dev, "%s(): %s - ctrl: %s \n",
 		__func__, ds5_get_sensor_name(state), ctrl->name);
+
+	if (ctrl->id == D500_CAMERA_CID_MINZ) {
+		struct d500_dpp_xu_control control;
+		u8 i;
+
+		ret = d500_dpp_xu_read(state, &d500_minz_desc, &control);
+		if (ret)
+			return ret;
+		for (i = 0; i < D500_DPP_XU_MINZ_PARAM_COUNT; i++)
+			ctrl->p_new.p_u32[i] = le32_to_cpu(control.params[i]);
+		return 0;
+	}
+	if (d500_dpp_ctrl_desc(ctrl->id, &dpp_desc) == 0) {
+		struct d500_dpp_xu_control control;
+
+		ret = d500_dpp_xu_read(state, &dpp_desc, &control);
+		if (!ret)
+			ctrl->val =
+				le32_to_cpu(control.params[dpp_desc.param_index]);
+		return ret;
+	}
 
 	switch (ctrl->id) {
 
@@ -5244,6 +5468,42 @@ enum state_sid {
 	MUX_SID = -1
 };
 
+static struct v4l2_ctrl *
+d500_dpp_ctrl(struct v4l2_ctrl_handler *handler, u32 id,
+	      const char *name, s32 min, s32 max, s32 step, s32 def,
+	      struct ds5_sensor *sensor)
+{
+	const struct v4l2_ctrl_config config = {
+		.ops = &ds5_ctrl_ops,
+		.id = id,
+		.name = name,
+		.type = V4L2_CTRL_TYPE_INTEGER,
+		.min = min,
+		.max = max,
+		.step = step,
+		.def = def,
+		.flags = V4L2_CTRL_FLAG_VOLATILE |
+			 V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
+	};
+
+	return v4l2_ctrl_new_custom(handler, &config, sensor);
+}
+
+static const struct v4l2_ctrl_config d500_ctrl_minz = {
+	.ops = &ds5_ctrl_ops,
+	.id = D500_CAMERA_CID_MINZ,
+	.name = "MinZ Configuration",
+	.type = V4L2_CTRL_TYPE_U32,
+	.min = 0,
+	.max = U32_MAX,
+	.step = 1,
+	.def = 0,
+	.dims = { D500_DPP_XU_MINZ_PARAM_COUNT },
+	.elem_size = sizeof(u32),
+	.flags = V4L2_CTRL_FLAG_VOLATILE |
+		 V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
+};
+
 static int ds5_ctrl_init(struct ds5 *state, int sid)
 {
 	const struct v4l2_ctrl_ops *ops = &ds5_ctrl_ops;
@@ -5525,6 +5785,22 @@ static int ds5_ctrl_init(struct ds5 *state, int sid)
 			v4l2_ctrl_new_custom(hdl, &ds5_ctrl_projector_temperature,
 					     sensor);
 			v4l2_ctrl_new_custom(hdl, &ds5_ctrl_error_code, sensor);
+			ctrls->minz = v4l2_ctrl_new_custom(hdl, &d500_ctrl_minz, sensor);
+			d500_dpp_ctrl(hdl, D500_CAMERA_CID_DECIMATION_ENABLE,
+				      "D500 Decimation Enable", 0, 1, 1, 0, sensor);
+			d500_dpp_ctrl(hdl, D500_CAMERA_CID_DECIMATION_MAGNITUDE,
+				      "D500 Decimation Magnitude", 2, 4, 1, 4,
+				      sensor);
+			d500_dpp_ctrl(hdl, D500_CAMERA_CID_TEMPORAL_ENABLE,
+				      "D500 Temporal Enable", 0, 1, 1, 0, sensor);
+			d500_dpp_ctrl(hdl, D500_CAMERA_CID_TEMPORAL_ALPHA,
+				      "D500 Temporal Alpha x1000",
+				      0, 1000, 10, 400, sensor);
+			d500_dpp_ctrl(hdl, D500_CAMERA_CID_TEMPORAL_DELTA,
+				      "D500 Temporal Delta", 1, 100, 1, 20, sensor);
+			d500_dpp_ctrl(hdl, D500_CAMERA_CID_TEMPORAL_PERSISTENCY,
+				      "D500 Temporal Persistency", 0, 8, 1, 3,
+				      sensor);
 		} else {
 			v4l2_ctrl_new_custom(hdl, &ds5_ctrl_readout_shaping,
 					     sensor);


### PR DESCRIPTION
## Summary

- rebase the D585 GMSL DPP controls onto current `dev` (`f278f31d`)
- expose MinZ through one compound `V4L2_CTRL_TYPE_U32` control with `dims=[7]`
- keep the RSDEV-13973 field order: enable, filter type, downscale ratio, shift mode, shift pixels, threshold mode, and threshold mm
- execute one complete 38-byte XU read for GET and one complete XU write for SET; there are no per-field MinZ CIDs or driver-side read/modify/write transactions
- validate the heterogeneous range of every field before writing and reject MinZ writes while Depth is streaming
- keep the already-reviewed Decimation/Temporal CID values stable

## ABI

`minz_configuration` is one U32[7] payload at `D500_CAMERA_CID_MINZ` (`DS5_CAMERA_CID_BASE + 44`).

| Array index | Field | Valid range | Firmware default |
|---:|---|---:|---:|
| 0 | enable | 0..1 | 0 |
| 1 | filter_type | 0..1 | 0 |
| 2 | downscale_ratio | 1..2 | 1 |
| 3 | shift_mode | 0..2 | 0 |
| 4 | shift_pixels | 0..256 | 126 |
| 5 | threshold_mode | 0..2 | 1 |
| 6 | threshold_mm | 0..65535 | 0 |

The control-wide U32 metadata uses `0..U32_MAX`; the driver applies the per-index ranges above. This avoids V4L2 silently clipping an invalid element before the heterogeneous payload validator sees it.

Temporal alpha is semantically floating point. The DPP XU ABI marks `params[1]` with `param_type BIT(1)` and transports it as integer milli-units (`400` means `0.4`), matching the `D500 Temporal Alpha x1000` V4L2 control.

## Validation

### Static and build

- exactly one signed-off commit on current `dev`
- `git diff --check`: pass
- strict kernel checkpatch: **0 errors, 0 warnings, 0 checks**
- final `d4xx.ko` built with `-Werror` for `5.15.148-tegra` against the matching JP6.2.1 NVIDIA OOT/SerDes symbols
- final module SHA256: `11efb04a395ba301bf62b0d98e02afcc2ff6817f548af26aa664fcf0bcfecc59`
- final module srcversion: `99BE30D9DBCF1EF2DE50FCC`

### D585 GMSL bench

- camera: **D585 GMSL** on Pingquan's D585 bench
- Jetson Host: `5.15.148-tegra`; the exact final module above was loaded for the final run
- `v4l2-ctl` reports one `minz_configuration` U32 payload with `dims=[7]`; all seven former scalar MinZ control names are absent
- compound contract, all 18 valid boundary round trips, and all 14 invalid-range cases passed
- GMSL runtime command: `python3 minz_gmsl.py --device /dev/video-rs-depth-0 test --frames 60`
- runtime suite: **44/44 passed**
- eight MinZ semantic configurations each captured **60/60** 1280x720 Z16 frames at 28.0-28.6 measured FPS
- all eight configurations produced distinct scene fingerprints
- MinZ write during Depth streaming returned `EBUSY`; the stream remained live for 10/10 follow-up frames
- the original seven-field state was restored exactly after testing
- post-test stream-transition retries all recovered successfully; no fatal D4xx/MinZ failure was observed

This update is Host-driver-only. No HKR source, firmware image, DFU operation, or D585 firmware write was performed. The bench retained its existing firmware (`7.58.0.239`, BKC 14319).

The live GUI uses the same validated compound-control and capture path. The bench had no interactive `jetson` display session, so no GUI window was opened during this SSH run.

## Depends on

The matching firmware ABI is provided by the RSDEV-13973 common, IO, apps, Device Manager, and tests changes, including Device Manager PR realsenseai/RealSenseDeviceManager#492.
