### PR TITLE
dev_gmsl: [D585][GMSL] Receive tunnel calibration （RGB + IR） over User Defined carrier

### DIFF
--- a/kernel/kernel-5.10/5.0.2/0005-Add-Realsense-NV12-User-Defined-media-bus-format.patch
+++ b/kernel/kernel-5.10/5.0.2/0005-Add-Realsense-NV12-User-Defined-media-bus-format.patch
@@ -2,10 +2,13 @@ diff --git a/include/uapi/linux/media-bus-format.h b/include/uapi/linux/media-bu
 index b2362999fd3d..2327f0a740aa 100644
 --- a/include/uapi/linux/media-bus-format.h
 +++ b/include/uapi/linux/media-bus-format.h
-@@ -159,4 +159,6 @@
+@@ -159,4 +159,9 @@
  #define MEDIA_BUS_FMT_S5C_UYVY_JPEG_1X8		0x5001
 -
-+/* RealSense flat NV12 bytes carried over CSI-2 DT 0x32 (UD32) */
++/* RealSense byte surfaces carried over CSI-2 User Defined data types */
++#define MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10	0x5002
++#define MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16	0x5003
++#define MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8		0x5005
 +#define MEDIA_BUS_FMT_RS_NV12_UD32_1X8		0x5008
 +
  /* HSV - next is	0x6002 */

--- a/kernel/kernel-5.10/5.1.2/0003-Add-Realsense-NV12-User-Defined-media-bus-format.patch
+++ b/kernel/kernel-5.10/5.1.2/0003-Add-Realsense-NV12-User-Defined-media-bus-format.patch
@@ -2,10 +2,13 @@ diff --git a/include/uapi/linux/media-bus-format.h b/include/uapi/linux/media-bu
 index b2362999fd3d..2327f0a740aa 100644
 --- a/include/uapi/linux/media-bus-format.h
 +++ b/include/uapi/linux/media-bus-format.h
-@@ -159,4 +159,6 @@
+@@ -159,4 +159,9 @@
  #define MEDIA_BUS_FMT_S5C_UYVY_JPEG_1X8		0x5001
 -
-+/* RealSense flat NV12 bytes carried over CSI-2 DT 0x32 (UD32) */
++/* RealSense byte surfaces carried over CSI-2 User Defined data types */
++#define MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10	0x5002
++#define MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16	0x5003
++#define MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8		0x5005
 +#define MEDIA_BUS_FMT_RS_NV12_UD32_1X8		0x5008
 +
  /* HSV - next is	0x6002 */

--- a/kernel/kernel-jammy-src/6.0/0002-realsense-camera-formats-jammy-master.patch
+++ b/kernel/kernel-jammy-src/6.0/0002-realsense-camera-formats-jammy-master.patch
@@ -10,9 +10,9 @@ Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
  drivers/media/usb/uvc/uvc_driver.c   | 57 ++++++++++++++++++++++++++++
  drivers/media/usb/uvc/uvcvideo.h     | 34 +++++++++++++++++
  drivers/media/v4l2-core/v4l2-ioctl.c |  9 +++++
- include/uapi/linux/media-bus-format.h |  3 +++
+ include/uapi/linux/media-bus-format.h |  6 ++++++
  include/uapi/linux/videodev2.h       |  9 +++++
- 5 files changed, 112 insertions(+)
+ 5 files changed, 115 insertions(+)
 
 diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
 index 9a791d8ef200..205d524128da 100644
@@ -197,8 +197,11 @@ index 9260791b8438..fd50e9c34a0e 100644
 diff --git a/include/uapi/linux/media-bus-format.h b/include/uapi/linux/media-bus-format.h
 --- a/include/uapi/linux/media-bus-format.h
 +++ b/include/uapi/linux/media-bus-format.h
-@@ -162,1 +162,4 @@
-+/* RealSense flat NV12 bytes carried over CSI-2 DT 0x32 (UD32) */
+@@ -162,1 +162,7 @@
++/* RealSense byte surfaces carried over CSI-2 User Defined data types */
++#define MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10	0x5002
++#define MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16	0x5003
++#define MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8		0x5005
 +#define MEDIA_BUS_FMT_RS_NV12_UD32_1X8		0x5008
 +
  /* HSV - next is	0x6002 */

--- a/kernel/kernel-jammy-src/6.2.1/0002-realsense-camera-formats-jammy-master.patch
+++ b/kernel/kernel-jammy-src/6.2.1/0002-realsense-camera-formats-jammy-master.patch
@@ -10,9 +10,9 @@ Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
  drivers/media/usb/uvc/uvc_driver.c   | 57 ++++++++++++++++++++++++++++
  drivers/media/usb/uvc/uvcvideo.h     | 34 +++++++++++++++++
  drivers/media/v4l2-core/v4l2-ioctl.c |  9 +++++
- include/uapi/linux/media-bus-format.h |  3 +++
+ include/uapi/linux/media-bus-format.h |  6 ++++++
  include/uapi/linux/videodev2.h       |  9 +++++
- 5 files changed, 112 insertions(+)
+ 5 files changed, 115 insertions(+)
 
 diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
 index 9a791d8ef200..205d524128da 100644
@@ -197,8 +197,11 @@ index 9260791b8438..fd50e9c34a0e 100644
 diff --git a/include/uapi/linux/media-bus-format.h b/include/uapi/linux/media-bus-format.h
 --- a/include/uapi/linux/media-bus-format.h
 +++ b/include/uapi/linux/media-bus-format.h
-@@ -162,1 +162,4 @@
-+/* RealSense flat NV12 bytes carried over CSI-2 DT 0x32 (UD32) */
+@@ -162,1 +162,7 @@
++/* RealSense byte surfaces carried over CSI-2 User Defined data types */
++#define MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10	0x5002
++#define MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16	0x5003
++#define MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8		0x5005
 +#define MEDIA_BUS_FMT_RS_NV12_UD32_1X8		0x5008
 +
  /* HSV - next is	0x6002 */

--- a/kernel/kernel-jammy-src/6.2/0002-realsense-camera-formats-jammy-master.patch
+++ b/kernel/kernel-jammy-src/6.2/0002-realsense-camera-formats-jammy-master.patch
@@ -10,9 +10,9 @@ Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
  drivers/media/usb/uvc/uvc_driver.c   | 57 ++++++++++++++++++++++++++++
  drivers/media/usb/uvc/uvcvideo.h     | 34 +++++++++++++++++
  drivers/media/v4l2-core/v4l2-ioctl.c |  9 +++++
- include/uapi/linux/media-bus-format.h |  3 +++
+ include/uapi/linux/media-bus-format.h |  6 ++++++
  include/uapi/linux/videodev2.h       |  9 +++++
- 5 files changed, 112 insertions(+)
+ 5 files changed, 115 insertions(+)
 
 diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
 index 9a791d8ef200..205d524128da 100644
@@ -197,8 +197,11 @@ index 9260791b8438..fd50e9c34a0e 100644
 diff --git a/include/uapi/linux/media-bus-format.h b/include/uapi/linux/media-bus-format.h
 --- a/include/uapi/linux/media-bus-format.h
 +++ b/include/uapi/linux/media-bus-format.h
-@@ -162,1 +162,4 @@
-+/* RealSense flat NV12 bytes carried over CSI-2 DT 0x32 (UD32) */
+@@ -162,1 +162,7 @@
++/* RealSense byte surfaces carried over CSI-2 User Defined data types */
++#define MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10	0x5002
++#define MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16	0x5003
++#define MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8		0x5005
 +#define MEDIA_BUS_FMT_RS_NV12_UD32_1X8		0x5008
 +
  /* HSV - next is	0x6002 */

--- a/kernel/kernel-noble-src/7.0/0002-realsense-camera-formats-jammy-master.patch
+++ b/kernel/kernel-noble-src/7.0/0002-realsense-camera-formats-jammy-master.patch
@@ -10,9 +10,9 @@ Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
  drivers/media/common/uvc.c   | 57 ++++++++++++++++++++++++++++
  drivers/include/linux/usb/uvc.h     | 34 +++++++++++++++++
  drivers/media/v4l2-core/v4l2-ioctl.c |  9 +++++
- include/uapi/linux/media-bus-format.h |  3 +++
+ include/uapi/linux/media-bus-format.h |  6 ++++++
  include/uapi/linux/videodev2.h       |  9 +++++
- 5 files changed, 112 insertions(+)
+ 5 files changed, 115 insertions(+)
 
 diff --git a/drivers/media/common/uvc.c b/drivers/media/common/uvc.c
 index 9a791d8ef200..205d524128da 100644
@@ -193,8 +193,11 @@ index 9260791b8438..fd50e9c34a0e 100644
 diff --git a/include/uapi/linux/media-bus-format.h b/include/uapi/linux/media-bus-format.h
 --- a/include/uapi/linux/media-bus-format.h
 +++ b/include/uapi/linux/media-bus-format.h
-@@ -162,1 +162,4 @@
-+/* RealSense flat NV12 bytes carried over CSI-2 DT 0x32 (UD32) */
+@@ -162,1 +162,7 @@
++/* RealSense byte surfaces carried over CSI-2 User Defined data types */
++#define MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10	0x5002
++#define MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16	0x5003
++#define MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8		0x5005
 +#define MEDIA_BUS_FMT_RS_NV12_UD32_1X8		0x5008
 +
  /* HSV - next is	0x6002 */

--- a/kernel/kernel-noble-src/7.1/0002-realsense-camera-formats-jammy-master.patch
+++ b/kernel/kernel-noble-src/7.1/0002-realsense-camera-formats-jammy-master.patch
@@ -10,9 +10,9 @@ Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
  drivers/media/common/uvc.c   | 57 ++++++++++++++++++++++++++++
  drivers/include/linux/usb/uvc.h     | 34 +++++++++++++++++
  drivers/media/v4l2-core/v4l2-ioctl.c |  9 +++++
- include/uapi/linux/media-bus-format.h |  3 +++
+ include/uapi/linux/media-bus-format.h |  6 ++++++
  include/uapi/linux/videodev2.h       |  9 +++++
- 5 files changed, 112 insertions(+)
+ 5 files changed, 115 insertions(+)
 
 diff --git a/drivers/media/common/uvc.c b/drivers/media/common/uvc.c
 index 9a791d8ef200..205d524128da 100644
@@ -193,8 +193,11 @@ index 9260791b8438..fd50e9c34a0e 100644
 diff --git a/include/uapi/linux/media-bus-format.h b/include/uapi/linux/media-bus-format.h
 --- a/include/uapi/linux/media-bus-format.h
 +++ b/include/uapi/linux/media-bus-format.h
-@@ -162,1 +162,4 @@
-+/* RealSense flat NV12 bytes carried over CSI-2 DT 0x32 (UD32) */
+@@ -162,1 +162,7 @@
++/* RealSense byte surfaces carried over CSI-2 User Defined data types */
++#define MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10	0x5002
++#define MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16	0x5003
++#define MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8		0x5005
 +#define MEDIA_BUS_FMT_RS_NV12_UD32_1X8		0x5008
 +
  /* HSV - next is	0x6002 */

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -1675,6 +1675,44 @@ static const struct ds5_format ds5_y_formats_d58x[] = {
 	},
 };
 
+#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10
+#define MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10	0x5002
+#endif
+
+#ifndef MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16
+#define MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16	0x5003
+#endif
+
+#ifndef MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8
+#define MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8		0x5005
+#endif
+
+#define DS5_D58X_NV12_SOURCE_DT		0x18
+#define DS5_D58X_RGB_PACKED_SOURCE_DT	0x2b
+#define DS5_D58X_CALIB_SOURCE_DT		0x2e
+#define DS5_D58X_UDP8_CARRIER_DT		0x32
+
+static const struct ds5_format ds5_y_formats_d58x_tunnel[] = {
+	{
+		/* First format: default */
+		.data_type = GMSL_CSI_DT_RAW_8,		/* Y8 */
+		.mbus_code = MEDIA_BUS_FMT_Y8_1X8,
+		.n_resolutions = ARRAY_SIZE(d58x_y8_sizes),
+		.resolutions = d58x_y8_sizes,
+	}, {
+		.data_type = GMSL_CSI_DT_YUV422_8,	/* Y8I */
+		.mbus_code = MEDIA_BUS_FMT_VYUY8_1X16,
+		.n_resolutions = ARRAY_SIZE(d58x_y8_sizes),
+		.resolutions = d58x_y8_sizes,
+	}, {
+		.data_type = DS5_D58X_CALIB_SOURCE_DT,
+		.override_data_type = DS5_D58X_UDP8_CARRIER_DT,
+		.mbus_code = MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8,
+		.n_resolutions = ARRAY_SIZE(d58x_calibration_sizes),
+		.resolutions = d58x_calibration_sizes,
+	},
+};
+
 static const struct ds5_format ds5_rgb_formats_d58x[] = {
 	{
 		/* First format: default */
@@ -1693,9 +1731,6 @@ static const struct ds5_format ds5_rgb_formats_d58x[] = {
 	},
 };
 
-#define DS5_D58X_NV12_SOURCE_DT		0x18
-#define DS5_D58X_NV12_CARRIER_DT	0x32
-
 /* Keep shared YUYV and calibration entries aligned with the base table. */
 static const struct ds5_format ds5_rgb_formats_d58x_tunnel[] = {
 	{
@@ -1705,18 +1740,24 @@ static const struct ds5_format ds5_rgb_formats_d58x_tunnel[] = {
 		.n_resolutions = ARRAY_SIZE(d58x_rgb_sizes),
 		.resolutions = d58x_rgb_sizes,
 	}, {
-		/* Flat NV12 bytes use UD32 as an opaque 8-bit CSI carrier. */
+		/* Flat NV12 bytes use the UDP8 carrier as an opaque byte stream. */
 		.data_type = DS5_D58X_NV12_SOURCE_DT,
-		.override_data_type = DS5_D58X_NV12_CARRIER_DT,
+		.override_data_type = DS5_D58X_UDP8_CARRIER_DT,
 		.mbus_code = MEDIA_BUS_FMT_RS_NV12_UD32_1X8,
 		.n_resolutions = ARRAY_SIZE(d58x_rgb_sizes),
 		.resolutions = d58x_rgb_sizes,
 	}, {
-		/* RGB calibration: unpacked GRBG10, one little-endian
-		 * 10-bit sample per 16-bit container, 2 bytes/pixel.
-		 */
-		.data_type = GMSL_CSI_DT_RAW_16,
-		.mbus_code = MEDIA_BUS_FMT_SGRBG16_1X16,
+		/* Unpacked GRBG10 keeps one sample in each 16-bit container. */
+		.data_type = DS5_D58X_CALIB_SOURCE_DT,
+		.override_data_type = DS5_D58X_UDP8_CARRIER_DT,
+		.mbus_code = MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16,
+		.n_resolutions = ARRAY_SIZE(d58x_calibration_sizes),
+		.resolutions = d58x_calibration_sizes,
+	}, {
+		/* Packed GRBG10 keeps the native HKR cache-line byte layout. */
+		.data_type = DS5_D58X_RGB_PACKED_SOURCE_DT,
+		.override_data_type = DS5_D58X_UDP8_CARRIER_DT,
+		.mbus_code = MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10,
 		.n_resolutions = ARRAY_SIZE(d58x_calibration_sizes),
 		.resolutions = d58x_calibration_sizes,
 	},
@@ -2367,8 +2408,9 @@ static int ds5_configure(struct ds5 *state)
 		/* D58x tunnel uses an explicit per-format carrier contract, including
 		 * zero to clear a previous override. Preserve the existing D4xx
 		 * depth/IR override values. */
-		if (state->is_rgb && ds5_is_d58x(state) &&
-		    !state->d58x_pixel_mode)
+		if (ds5_is_d58x(state) && !state->d58x_pixel_mode &&
+		    (state->is_rgb ||
+		     sensor->config.format->override_data_type))
 			dt_value = sensor->config.format->override_data_type;
 		else
 			dt_value = sensor->config.format->data_type;
@@ -5477,8 +5519,15 @@ static int ds5_mux_enum_mbus_code(struct v4l2_subdev *sd,
 	}
 
 	tmp.pad = 0;
-	if (state->is_rgb)
+	if (state->is_rgb) {
 		remote_sd = &state->rgb.sensor.sd;
+		/* The external-pad aggregation above offsets indexes after the IR
+		 * format count. D58x tunnel RGB has more entries than IR, so keep
+		 * the RGB sensor's original index to expose its final format.
+		 */
+		if (ds5_is_d58x(state) && !state->d58x_pixel_mode)
+			tmp.index = mce->index;
+	}
 	if (state->is_depth)
 		remote_sd = &state->depth.sensor.sd;
 	if (state->is_y8)
@@ -6530,8 +6579,13 @@ static int ds5_fixed_configuration(struct i2c_client *client, struct ds5 *state)
 		sensor->n_formats = ARRAY_SIZE(ds5_y_formats_45x);
 		break;
 	case DS5_DEVICE_TYPE_D58X:
-		sensor->formats = ds5_y_formats_d58x;
-		sensor->n_formats = ARRAY_SIZE(ds5_y_formats_d58x);
+		if (!state->d58x_pixel_mode) {
+			sensor->formats = ds5_y_formats_d58x_tunnel;
+			sensor->n_formats = ARRAY_SIZE(ds5_y_formats_d58x_tunnel);
+		} else {
+			sensor->formats = ds5_y_formats_d58x;
+			sensor->n_formats = ARRAY_SIZE(ds5_y_formats_d58x);
+		}
 		break;
 	default:
 		sensor->formats = state->variant->formats;

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -36,6 +36,7 @@
 #include <media/v4l2-device.h>
 #include <media/v4l2-subdev.h>
 #include <media/v4l2-mediabus.h>
+#include <media/gmsl-link.h>
 
 #ifdef CONFIG_VIDEO_D4XX_SERDES
 #include <media/max9295.h>
@@ -108,12 +109,6 @@ struct ser_interface {
 	const char *name;
 };
 
-#else
-#include <media/gmsl-link.h>
-#define GMSL_CSI_DT_YUV422_8 0x1E
-#define GMSL_CSI_DT_RGB_888 0x24
-#define GMSL_CSI_DT_RAW_8 0x2A
-#define GMSL_CSI_DT_EMBED 0x12
 #endif
 
 /* D40x FW CSI-PT mode selector for the OV9782 (not a MIPI wire DT). */
@@ -1675,23 +1670,6 @@ static const struct ds5_format ds5_y_formats_d58x[] = {
 	},
 };
 
-#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10
-#define MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10	0x5002
-#endif
-
-#ifndef MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16
-#define MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16	0x5003
-#endif
-
-#ifndef MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8
-#define MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8		0x5005
-#endif
-
-#define DS5_D58X_NV12_SOURCE_DT		0x18
-#define DS5_D58X_RGB_PACKED_SOURCE_DT	0x2b
-#define DS5_D58X_CALIB_SOURCE_DT		0x2e
-#define DS5_D58X_UDP8_CARRIER_DT		0x32
-
 static const struct ds5_format ds5_y_formats_d58x_tunnel[] = {
 	{
 		/* First format: default */
@@ -1705,8 +1683,8 @@ static const struct ds5_format ds5_y_formats_d58x_tunnel[] = {
 		.n_resolutions = ARRAY_SIZE(d58x_y8_sizes),
 		.resolutions = d58x_y8_sizes,
 	}, {
-		.data_type = DS5_D58X_CALIB_SOURCE_DT,
-		.override_data_type = DS5_D58X_UDP8_CARRIER_DT,
+		.data_type = GMSL_CSI_DT_RAW_16,
+		.override_data_type = GMSL_CSI_DT_UED_U3,
 		.mbus_code = MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8,
 		.n_resolutions = ARRAY_SIZE(d58x_calibration_sizes),
 		.resolutions = d58x_calibration_sizes,
@@ -1741,22 +1719,22 @@ static const struct ds5_format ds5_rgb_formats_d58x_tunnel[] = {
 		.resolutions = d58x_rgb_sizes,
 	}, {
 		/* Flat NV12 bytes use the UDP8 carrier as an opaque byte stream. */
-		.data_type = DS5_D58X_NV12_SOURCE_DT,
-		.override_data_type = DS5_D58X_UDP8_CARRIER_DT,
+		.data_type = GMSL_CSI_DT_YUV420_8,
+		.override_data_type = GMSL_CSI_DT_UED_U3,
 		.mbus_code = MEDIA_BUS_FMT_RS_NV12_UD32_1X8,
 		.n_resolutions = ARRAY_SIZE(d58x_rgb_sizes),
 		.resolutions = d58x_rgb_sizes,
 	}, {
 		/* Unpacked GRBG10 keeps one sample in each 16-bit container. */
-		.data_type = DS5_D58X_CALIB_SOURCE_DT,
-		.override_data_type = DS5_D58X_UDP8_CARRIER_DT,
+		.data_type = GMSL_CSI_DT_RAW_16,
+		.override_data_type = GMSL_CSI_DT_UED_U3,
 		.mbus_code = MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16,
 		.n_resolutions = ARRAY_SIZE(d58x_calibration_sizes),
 		.resolutions = d58x_calibration_sizes,
 	}, {
 		/* Packed GRBG10 keeps the native HKR cache-line byte layout. */
-		.data_type = DS5_D58X_RGB_PACKED_SOURCE_DT,
-		.override_data_type = DS5_D58X_UDP8_CARRIER_DT,
+		.data_type = GMSL_CSI_DT_RAW_10,
+		.override_data_type = GMSL_CSI_DT_UED_U3,
 		.mbus_code = MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10,
 		.n_resolutions = ARRAY_SIZE(d58x_calibration_sizes),
 		.resolutions = d58x_calibration_sizes,

--- a/nvidia-oot/6.0/0013-Receive-flat-NV12-over-User-Defined.patch
+++ b/nvidia-oot/6.0/0013-Receive-flat-NV12-over-User-Defined.patch
@@ -1,24 +1,21 @@
-From 168b4e389da3ab461252c9d3be806edfe0bba51e Mon Sep 17 00:00:00 2001
+From bb746747ecfe8817ec05dec322ff9b445edabf0d Mon Sep 17 00:00:00 2001
 From: zhou <shengyong.zhou@realsenseai.com>
-Date: Mon, 17 Aug 2026 10:25:24 +0800
-Subject: [PATCH] media: tegra: receive flat NV12 over UD32
+Date: Tue, 18 Aug 2026 12:51:58 +0800
+Subject: [PATCH] media: tegra: receive D5x tunnel UDP8 byte surfaces
 
-Add a private media-bus tuple that matches UD32 while DMAing an opaque
-T_R8 surface. Apply the RAW8 receive-parser override only to the current
-capture descriptor, expand the transport height to H*3/2, and expose the
-resulting byte-identical surface through the standard NV12 V4L2 ABI.
+Map the selected User Defined packet DT to T_R8 only for the D5x NV12 and calibration tuples. Preserve each payload byte while exposing NV12, Y16I, RW16, and GR0P through their existing V4L2 ABIs.
+Filter duplicate FourCC tuples against the active subdevice formats so D4x and Pixel Mode continue to select their standard mappings.
 
-Scope NV12 buffer sizing and channel-format lookup to the private tuple,
-while preserving legacy lookup behavior for every other FourCC.
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
 ---
- .../media/platform/tegra/camera/vi/channel.c  |  9 +++++++++
- drivers/media/platform/tegra/camera/vi/core.c | 16 ++++++++++++++--
- .../media/platform/tegra/camera/vi/vi5_fops.c | 12 +++++++
- .../platform/tegra/camera/vi/vi5_formats.h    | 32 +++++++++++++++++++
- 4 files changed, 67 insertions(+), 2 deletions(-)
+ .../media/platform/tegra/camera/vi/channel.c  |  9 +++
+ drivers/media/platform/tegra/camera/vi/core.c | 43 ++++++++++-
+ .../media/platform/tegra/camera/vi/vi5_fops.c | 16 +++-
+ .../platform/tegra/camera/vi/vi5_formats.h    | 76 +++++++++++++++++++
+ 4 files changed, 141 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
-index ac5e0e9c..9eee67ba 100644
+index 83946acb..f2fd9814 100644
 --- a/drivers/media/platform/tegra/camera/vi/channel.c
 +++ b/drivers/media/platform/tegra/camera/vi/channel.c
 @@ -295,6 +295,9 @@ static void tegra_channel_update_format(struct tegra_channel *chan,
@@ -31,7 +28,7 @@ index ac5e0e9c..9eee67ba 100644
  }
  
  static void tegra_channel_fmts_bitmap_init(struct tegra_channel *chan)
-@@ -2126,8 +2129,14 @@ __tegra_channel_try_format(struct tegra_channel *chan,
+@@ -2129,6 +2132,12 @@ __tegra_channel_try_format(struct tegra_channel *chan,
  				&pix->width, &pix->height, &pix->bytesperline);
  	pix->sizeimage = get_aligned_buffer_size(chan,
  			pix->bytesperline, pix->height);
@@ -44,10 +41,8 @@ index ac5e0e9c..9eee67ba 100644
  	if (chan->fmtinfo->fourcc == V4L2_PIX_FMT_NV16)
  		pix->sizeimage *= 2;
  
- 	return ret;
- }
 diff --git a/drivers/media/platform/tegra/camera/vi/core.c b/drivers/media/platform/tegra/camera/vi/core.c
-index f0bde35a..e3ca4a64 100644
+index f0bde35a..daa8e182 100644
 --- a/drivers/media/platform/tegra/camera/vi/core.c
 +++ b/drivers/media/platform/tegra/camera/vi/core.c
 @@ -6,6 +6,7 @@
@@ -58,15 +53,42 @@ index f0bde35a..e3ca4a64 100644
  #include <linux/kernel.h>
  #include <linux/of.h>
  #include <linux/nospec.h>
-@@ -26,6 +27,15 @@ static const struct tegra_video_format tegra_default_format[] = {
+@@ -26,6 +27,42 @@ static const struct tegra_video_format tegra_default_format[] = {
  	},
  };
  
++#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10
++#define MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10	0x5002
++#endif
++
++#ifndef MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16
++#define MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16	0x5003
++#endif
++
++#ifndef MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8
++#define MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8		0x5005
++#endif
++
++static bool tegra_core_format_needs_subdev_match(u32 code)
++{
++	switch (code) {
++	case MEDIA_BUS_FMT_ARGB8888_1X32:
++	case MEDIA_BUS_FMT_SGRBG16_1X16:
++	case MEDIA_BUS_FMT_RS_NV12_UD32_1X8:
++	case MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8:
++	case MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16:
++	case MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10:
++		return true;
++	default:
++		return false;
++	}
++}
++
 +static bool tegra_core_format_is_available(struct tegra_channel *chan,
 +		unsigned int index)
 +{
-+	return chan->video_formats[index]->code !=
-+		MEDIA_BUS_FMT_RS_NV12_UD32_1X8 ||
++	return !tegra_core_format_needs_subdev_match(
++			chan->video_formats[index]->code) ||
 +		bitmap_empty(chan->fmts_bitmap, MAX_FORMAT_NUM) ||
 +		test_bit(index, chan->fmts_bitmap);
 +}
@@ -74,7 +96,7 @@ index f0bde35a..e3ca4a64 100644
  /* -----------------------------------------------------------------------------
   * Helper functions
   */
-@@ -96,7 +104,8 @@ int tegra_core_get_code_by_fourcc(struct tegra_channel *chan,
+@@ -96,7 +133,8 @@ int tegra_core_get_code_by_fourcc(struct tegra_channel *chan,
  	unsigned int i;
  
  	for (i = offset; i < chan->num_video_formats; ++i) {
@@ -84,7 +106,7 @@ index f0bde35a..e3ca4a64 100644
  			return chan->video_formats[i]->code;
  	}
  	spec_bar();
-@@ -156,7 +165,8 @@ tegra_core_get_format_by_fourcc(struct tegra_channel *chan, u32 fourcc)
+@@ -156,7 +194,8 @@ tegra_core_get_format_by_fourcc(struct tegra_channel *chan, u32 fourcc)
  	unsigned int i;
  
  	for (i = 0; i < chan->num_video_formats; ++i) {
@@ -95,7 +117,7 @@ index f0bde35a..e3ca4a64 100644
  	}
  	spec_bar();
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-index c05f5f8f..f1282282 100644
+index 489567ac..cbf6c23e 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 @@ -67,6 +67,8 @@ static const struct capture_descriptor capture_template = {
@@ -116,9 +138,14 @@ index c05f5f8f..f1282282 100644
  	u32 nvcsi_stream = chan->port[vi_port];
  	struct capture_descriptor_memoryinfo *desc_memoryinfo =
  		&chan->tegra_vi_channel[vi_port]->
-@@ -413,6 +417,9 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -411,8 +415,13 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	 * However, GMSL caps at 24bpp, so we alias it to RAW16, and the de-facto
+ 	 * width should be double the requested size
  	 */
- 	if (chan->fmtinfo->fourcc == V4L2_PIX_FMT_Y16I)
+-	if (chan->fmtinfo->fourcc == V4L2_PIX_FMT_Y16I)
++	if (surface_override && surface_override->use_bytesperline_width)
++		width = bpl;
++	else if (chan->fmtinfo->fourcc == V4L2_PIX_FMT_Y16I)
  		width *= 2;
 +	if (surface_override)
 +		height = height * surface_override->height_numerator /
@@ -126,7 +153,7 @@ index c05f5f8f..f1282282 100644
  
  	memcpy(desc, &capture_template, sizeof(capture_template));
  	memset(desc_memoryinfo, 0, sizeof(*desc_memoryinfo));
-@@ -424,6 +431,11 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -424,6 +433,11 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  	desc->ch_cfg.frame.frame_y = height;
  	desc->ch_cfg.match.datatype = data_type;
  	desc->ch_cfg.match.datatype_mask = 0x3f;
@@ -139,18 +166,35 @@ index c05f5f8f..f1282282 100644
  	desc->ch_cfg.pixfmt.format = format;
  
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-index 3db81c7c..96d4ff90 100644
+index 307f398f..186fdfa5 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-@@ -76,6 +76,36 @@ enum tegra_image_format {
+@@ -82,6 +82,74 @@ enum tegra_image_format {
  	TEGRA_IMAGE_FORMAT_T_DPCM_RAW20,
  };
  
++#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10
++#define MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10	0x5002
++#endif
++
++#ifndef MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16
++#define MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16	0x5003
++#endif
++
++#ifndef MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8
++#define MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8		0x5005
++#endif
++
++#ifndef V4L2_PIX_FMT_RS_SGRBG10P
++#define V4L2_PIX_FMT_RS_SGRBG10P v4l2_fourcc('G', 'R', '0', 'P')
++#endif
++
 +struct tegra_vi_surface_override {
 +	u32 code;
 +	u8 dt_override;
 +	u8 height_numerator;
 +	u8 height_denominator;
++	bool use_bytesperline_width;
 +};
 +
 +static const struct tegra_vi_surface_override
@@ -160,6 +204,27 @@ index 3db81c7c..96d4ff90 100644
 +		.dt_override = TEGRA_IMAGE_DT_RAW8,
 +		.height_numerator = 3,
 +		.height_denominator = 2,
++	},
++	{
++		.code = MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8,
++		.dt_override = TEGRA_IMAGE_DT_RAW8,
++		.height_numerator = 1,
++		.height_denominator = 1,
++		.use_bytesperline_width = true,
++	},
++	{
++		.code = MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16,
++		.dt_override = TEGRA_IMAGE_DT_RAW8,
++		.height_numerator = 1,
++		.height_denominator = 1,
++		.use_bytesperline_width = true,
++	},
++	{
++		.code = MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10,
++		.dt_override = TEGRA_IMAGE_DT_RAW8,
++		.height_numerator = 1,
++		.height_denominator = 1,
++		.use_bytesperline_width = true,
 +	},
 +};
 +
@@ -179,14 +244,21 @@ index 3db81c7c..96d4ff90 100644
  static const struct tegra_video_format vi5_video_formats[] = {
  	/* RAW 6: TODO */
  
-@@ -153,6 +183,8 @@ static const struct tegra_video_format vi5_video_formats[] = {
+@@ -169,6 +237,14 @@ static const struct tegra_video_format vi5_video_formats[] = {
  				RAW16, Y16I, "Y16I 32"),
  	TEGRA_VIDEO_FORMAT(RAW16, 16, SGRBG16_1X16, 2, 1, T_R16,
  				RAW16, RW16, "RW16 16"),
 +	TEGRA_VIDEO_FORMAT(RAW8, 8, RS_NV12_UD32_1X8, 1, 1, T_R8,
 +				USER_3, NV12, "YUV 4:2:0 NV12 UD32"),
++	TEGRA_VIDEO_FORMAT(RAW12, 12, RS_Y12I_UDP8_4X8, 4, 1, T_R8,
++				USER_3, Y16I, "Y12I in UDP8 byte containers"),
++	TEGRA_VIDEO_FORMAT(RAW10, 10, RS_SGRBG10_UDP8_1X16, 2, 1, T_R8,
++				USER_3, RW16, "GRBG10 in UDP8 RW16 containers"),
++	TEGRA_VIDEO_FORMAT(RAW10, 10, RS_SGRBG10P_UDP8_1X10, 32, 25, T_R8,
++				USER_3, RS_SGRBG10P, "RealSense GRBG10P UDP8 CL64"),
  
  };
  
 -- 
 2.34.1
+

--- a/nvidia-oot/6.0/0013-Receive-flat-NV12-over-User-Defined.patch
+++ b/nvidia-oot/6.0/0013-Receive-flat-NV12-over-User-Defined.patch
@@ -1,18 +1,21 @@
-From bb746747ecfe8817ec05dec322ff9b445edabf0d Mon Sep 17 00:00:00 2001
+From cac88803a254fbb167f7e0b5e3d6e0fcf0d4d0c5 Mon Sep 17 00:00:00 2001
 From: zhou <shengyong.zhou@realsenseai.com>
-Date: Tue, 18 Aug 2026 12:51:58 +0800
+Date: Tue, 18 Aug 2026 18:44:16 +0800
 Subject: [PATCH] media: tegra: receive D5x tunnel UDP8 byte surfaces
 
 Map the selected User Defined packet DT to T_R8 only for the D5x NV12 and calibration tuples. Preserve each payload byte while exposing NV12, Y16I, RW16, and GR0P through their existing V4L2 ABIs.
+
+Keep private media-bus identifiers in the patched kernel UAPI and shared CSI data types in gmsl-link.h.
 Filter duplicate FourCC tuples against the active subdevice formats so D4x and Pixel Mode continue to select their standard mappings.
 
 Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
 ---
  .../media/platform/tegra/camera/vi/channel.c  |  9 +++
- drivers/media/platform/tegra/camera/vi/core.c | 43 ++++++++++-
- .../media/platform/tegra/camera/vi/vi5_fops.c | 16 +++-
- .../platform/tegra/camera/vi/vi5_formats.h    | 76 +++++++++++++++++++
- 4 files changed, 141 insertions(+), 3 deletions(-)
+ drivers/media/platform/tegra/camera/vi/core.c | 31 ++++++++-
+ .../media/platform/tegra/camera/vi/vi5_fops.c | 16 ++++-
+ .../platform/tegra/camera/vi/vi5_formats.h    | 64 +++++++++++++++++++
+ include/media/gmsl-link.h                     |  3 +
+ 5 files changed, 120 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
 index 83946acb..f2fd9814 100644
@@ -42,7 +45,7 @@ index 83946acb..f2fd9814 100644
  		pix->sizeimage *= 2;
  
 diff --git a/drivers/media/platform/tegra/camera/vi/core.c b/drivers/media/platform/tegra/camera/vi/core.c
-index f0bde35a..daa8e182 100644
+index f0bde35a..b05d2fb8 100644
 --- a/drivers/media/platform/tegra/camera/vi/core.c
 +++ b/drivers/media/platform/tegra/camera/vi/core.c
 @@ -6,6 +6,7 @@
@@ -53,22 +56,10 @@ index f0bde35a..daa8e182 100644
  #include <linux/kernel.h>
  #include <linux/of.h>
  #include <linux/nospec.h>
-@@ -26,6 +27,42 @@ static const struct tegra_video_format tegra_default_format[] = {
+@@ -26,6 +27,30 @@ static const struct tegra_video_format tegra_default_format[] = {
  	},
  };
  
-+#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10
-+#define MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10	0x5002
-+#endif
-+
-+#ifndef MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16
-+#define MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16	0x5003
-+#endif
-+
-+#ifndef MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8
-+#define MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8		0x5005
-+#endif
-+
 +static bool tegra_core_format_needs_subdev_match(u32 code)
 +{
 +	switch (code) {
@@ -96,7 +87,7 @@ index f0bde35a..daa8e182 100644
  /* -----------------------------------------------------------------------------
   * Helper functions
   */
-@@ -96,7 +133,8 @@ int tegra_core_get_code_by_fourcc(struct tegra_channel *chan,
+@@ -96,7 +121,8 @@ int tegra_core_get_code_by_fourcc(struct tegra_channel *chan,
  	unsigned int i;
  
  	for (i = offset; i < chan->num_video_formats; ++i) {
@@ -106,7 +97,7 @@ index f0bde35a..daa8e182 100644
  			return chan->video_formats[i]->code;
  	}
  	spec_bar();
-@@ -156,7 +194,8 @@ tegra_core_get_format_by_fourcc(struct tegra_channel *chan, u32 fourcc)
+@@ -156,7 +182,8 @@ tegra_core_get_format_by_fourcc(struct tegra_channel *chan, u32 fourcc)
  	unsigned int i;
  
  	for (i = 0; i < chan->num_video_formats; ++i) {
@@ -166,25 +157,13 @@ index 489567ac..cbf6c23e 100644
  	desc->ch_cfg.pixfmt.format = format;
  
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-index 307f398f..186fdfa5 100644
+index 307f398f..829a4b0d 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-@@ -82,6 +82,74 @@ enum tegra_image_format {
+@@ -82,6 +82,62 @@ enum tegra_image_format {
  	TEGRA_IMAGE_FORMAT_T_DPCM_RAW20,
  };
  
-+#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10
-+#define MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10	0x5002
-+#endif
-+
-+#ifndef MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16
-+#define MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16	0x5003
-+#endif
-+
-+#ifndef MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8
-+#define MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8		0x5005
-+#endif
-+
 +#ifndef V4L2_PIX_FMT_RS_SGRBG10P
 +#define V4L2_PIX_FMT_RS_SGRBG10P v4l2_fourcc('G', 'R', '0', 'P')
 +#endif
@@ -244,7 +223,7 @@ index 307f398f..186fdfa5 100644
  static const struct tegra_video_format vi5_video_formats[] = {
  	/* RAW 6: TODO */
  
-@@ -169,6 +237,14 @@ static const struct tegra_video_format vi5_video_formats[] = {
+@@ -169,6 +225,14 @@ static const struct tegra_video_format vi5_video_formats[] = {
  				RAW16, Y16I, "Y16I 32"),
  	TEGRA_VIDEO_FORMAT(RAW16, 16, SGRBG16_1X16, 2, 1, T_R16,
  				RAW16, RW16, "RW16 16"),
@@ -259,6 +238,21 @@ index 307f398f..186fdfa5 100644
  
  };
  
+diff --git a/include/media/gmsl-link.h b/include/media/gmsl-link.h
+index 48939537..4db8ea7e 100644
+--- a/include/media/gmsl-link.h
++++ b/include/media/gmsl-link.h
+@@ -37,8 +37,11 @@
+ #define GMSL_SERDES_CSI_LINK_B 0x2
+ 
+ /* Didn't find kernel defintions, for now adding here */
++#define GMSL_CSI_DT_YUV420_8 0x18
++#define GMSL_CSI_DT_RAW_10 0x2B
+ #define GMSL_CSI_DT_RAW_12 0x2C
+ #define GMSL_CSI_DT_UED_U1 0x30
++#define GMSL_CSI_DT_UED_U3 0x32
+ #define GMSL_CSI_DT_EMBED 0x12
+ #define GMSL_CSI_DT_YUV422_8 0x1E
+ #define GMSL_CSI_DT_RGB_888 0x24
 -- 
 2.34.1
-

--- a/nvidia-oot/7.0/0013-Receive-flat-NV12-over-User-Defined.patch
+++ b/nvidia-oot/7.0/0013-Receive-flat-NV12-over-User-Defined.patch
@@ -1,24 +1,25 @@
-From 20605b9516690c71693022c8d427061740b5e85b Mon Sep 17 00:00:00 2001
+From 001448ef6f9ce920722401844281a3bf069890a2 Mon Sep 17 00:00:00 2001
 From: zhou <shengyong.zhou@realsenseai.com>
-Date: Tue, 18 Aug 2026 12:53:44 +0800
+Date: Tue, 18 Aug 2026 18:13:46 +0800
 Subject: [PATCH] media: tegra: receive D5x tunnel UDP8 byte surfaces
 
-Map the selected User Defined packet DT to T_R8 only for the D5x NV12 and calibration tuples. Preserve each payload byte while exposing NV12, Y16I, RW16, and GR0P through their existing V4L2 ABIs.
-Filter duplicate FourCC tuples against the active subdevice formats so D4x and Pixel Mode continue to select their standard mappings.
+Map selected User Defined packet data types to T_R8 for D5x NV12 and
+calibration tuples while preserving the existing V4L2 surface layouts.
+Filter private duplicate FourCC tuples by the active subdevice format.
 
 Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
 ---
  .../media/platform/tegra/camera/vi/channel.c  | 14 ++++
- drivers/media/platform/tegra/camera/vi/core.c | 43 +++++++++-
- .../media/platform/tegra/camera/vi/vi5_fops.c | 21 +++++
- .../platform/tegra/camera/vi/vi5_formats.h    | 80 +++++++++++++++++++
- 4 files changed, 156 insertions(+), 2 deletions(-)
+ drivers/media/platform/tegra/camera/vi/core.c | 43 ++++++++++-
+ .../media/platform/tegra/camera/vi/vi5_fops.c | 16 +++-
+ .../platform/tegra/camera/vi/vi5_formats.h    | 76 +++++++++++++++++++
+ 4 files changed, 146 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
-index 88cf075b..131f4e7b 100644
+index da4a1c71..39cbdf76 100644
 --- a/drivers/media/platform/tegra/camera/vi/channel.c
 +++ b/drivers/media/platform/tegra/camera/vi/channel.c
-@@ -329,6 +329,9 @@ static void tegra_channel_update_format(struct tegra_channel *chan,
+@@ -338,6 +338,9 @@ static void tegra_channel_update_format(struct tegra_channel *chan,
  
  	if (fourcc == V4L2_PIX_FMT_NV16)
  		chan->format.sizeimage *= 2;
@@ -28,7 +29,7 @@ index 88cf075b..131f4e7b 100644
  }
  
  static void tegra_channel_fmts_bitmap_init(struct tegra_channel *chan)
-@@ -2219,6 +2222,17 @@ __tegra_channel_try_format(struct tegra_channel *chan,
+@@ -2235,6 +2238,17 @@ __tegra_channel_try_format(struct tegra_channel *chan,
  				&pix->width, &pix->height, &pix->bytesperline);
  	pix->sizeimage = get_aligned_buffer_size(chan,
  			pix->bytesperline, pix->height);
@@ -122,10 +123,10 @@ index 30ed1307..898282fa 100644
  	}
  	spec_bar();
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-index ee8dfd3d..9de8c061 100644
+index 459a3d82..54dcba51 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -57,6 +57,8 @@ static const struct capture_descriptor capture_template = {
+@@ -58,6 +58,8 @@ static const struct capture_descriptor capture_template = {
  	,
  
  	.ch_cfg = {
@@ -134,7 +135,7 @@ index ee8dfd3d..9de8c061 100644
  		.pixfmt_enable = 0,		/* no output */
  		.match = {
  			.stream = 0,		/* one-hot bit encoding */
-@@ -391,6 +393,8 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -393,6 +395,8 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  	u32 format = chan->fmtinfo->img_fmt;
  	u32 bpl = chan->format.bytesperline;
  	u32 data_type = chan->fmtinfo->img_dt;
@@ -143,26 +144,22 @@ index ee8dfd3d..9de8c061 100644
  	u32 nvcsi_stream = chan->port[vi_port];
  	unsigned int range = 0;
  	struct capture_descriptor_memoryinfo *desc_memoryinfo =
-@@ -419,6 +423,18 @@ static void vi5_setup_surface(struct tegra_channel *chan,
- 		}
- 	}
- 
-+	/* Y16I: one 32bpp L/R column pair per V4L2 pixel.
-+	 * However, GMSL caps at 24bpp, so we alias it to RAW16, and the de-facto
-+	 * width should be double the requested size
-+	 */
+@@ -425,8 +429,13 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	 * However, GMSL caps at 24bpp, so we alias it to RAW16, and the de-facto
+ 	 * width should be double the requested size
+ 	 */
+-	if (chan->fmtinfo->fourcc == V4L2_PIX_FMT_Y16I)
 +	if (surface_override && surface_override->use_bytesperline_width)
 +		width = bpl;
 +	else if (chan->fmtinfo->fourcc == V4L2_PIX_FMT_Y16I)
-+		width *= 2;
+ 		width *= 2;
 +	if (surface_override)
 +		height = height * surface_override->height_numerator /
 +			surface_override->height_denominator;
-+
+ 
  	memcpy(desc, &capture_template, sizeof(capture_template));
  	memset(desc_memoryinfo, 0, sizeof(*desc_memoryinfo));
- 
-@@ -429,6 +445,11 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -438,6 +447,11 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  	desc->ch_cfg.frame.frame_y = height;
  	desc->ch_cfg.match.datatype = data_type;
  	desc->ch_cfg.match.datatype_mask = 0x3f;
@@ -175,7 +172,7 @@ index ee8dfd3d..9de8c061 100644
  	desc->ch_cfg.pixfmt.format = format;
  
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-index 4e50e780..186fdfa5 100644
+index ecf547ac..128760b1 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 @@ -82,6 +82,74 @@ enum tegra_image_format {
@@ -253,14 +250,10 @@ index 4e50e780..186fdfa5 100644
  static const struct tegra_video_format vi5_video_formats[] = {
  	/* RAW 6: TODO */
  
-@@ -165,6 +233,18 @@ static const struct tegra_video_format vi5_video_formats[] = {
- 	// R[7:3]R[3:0] | L[3:0]R[11:8] | L[11:8]L[7:4] | ALIGN[7:0]
- 	TEGRA_VIDEO_FORMAT(RGB888, 24, RGB888_1X24, 4, 1, T_A8R8G8B8,
- 				RGB888, Y12I, "Y12I 24"),
-+	TEGRA_VIDEO_FORMAT(RAW16, 16, ARGB8888_1X32, 4, 1, T_R16,
-+				RAW16, Y16I, "Y16I 32"),
-+	TEGRA_VIDEO_FORMAT(RAW16, 16, SGRBG16_1X16, 2, 1, T_R16,
-+				RAW16, RW16, "RW16 16"),
+@@ -179,6 +247,14 @@ static const struct tegra_video_format vi5_video_formats[] = {
+ 				RAW16, Y16I, "Y16I 32"),
+ 	TEGRA_VIDEO_FORMAT(RAW16, 16, SGRBG16_1X16, 2, 1, T_R16,
+ 				RAW16, RW16, "RW16 16"),
 +	TEGRA_VIDEO_FORMAT(RAW8, 8, RS_NV12_UD32_1X8, 1, 1, T_R8,
 +				USER_3, NV12, "YUV 4:2:0 NV12 UD32"),
 +	TEGRA_VIDEO_FORMAT(RAW12, 12, RS_Y12I_UDP8_4X8, 4, 1, T_R8,
@@ -272,6 +265,3 @@ index 4e50e780..186fdfa5 100644
  
  };
  
--- 
-2.34.1
-

--- a/nvidia-oot/7.0/0013-Receive-flat-NV12-over-User-Defined.patch
+++ b/nvidia-oot/7.0/0013-Receive-flat-NV12-over-User-Defined.patch
@@ -1,24 +1,21 @@
-From 84728655e3f873dd6615045613a6f84fd60cf74d Mon Sep 17 00:00:00 2001
+From 20605b9516690c71693022c8d427061740b5e85b Mon Sep 17 00:00:00 2001
 From: zhou <shengyong.zhou@realsenseai.com>
-Date: Mon, 17 Aug 2026 10:25:24 +0800
-Subject: [PATCH] media: tegra: receive flat NV12 over UD32
+Date: Tue, 18 Aug 2026 12:53:44 +0800
+Subject: [PATCH] media: tegra: receive D5x tunnel UDP8 byte surfaces
 
-Add a private media-bus tuple that matches UD32 while DMAing an opaque
-T_R8 surface. Apply the RAW8 receive-parser override only to the current
-capture descriptor, expand the transport height to H*3/2, and expose the
-resulting byte-identical surface through the standard NV12 V4L2 ABI.
+Map the selected User Defined packet DT to T_R8 only for the D5x NV12 and calibration tuples. Preserve each payload byte while exposing NV12, Y16I, RW16, and GR0P through their existing V4L2 ABIs.
+Filter duplicate FourCC tuples against the active subdevice formats so D4x and Pixel Mode continue to select their standard mappings.
 
-Scope NV12 buffer sizing and channel-format lookup to the private tuple,
-while preserving legacy lookup behavior for every other FourCC.
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
 ---
- .../media/platform/tegra/camera/vi/channel.c  | 14 ++++++++++++++
- drivers/media/platform/tegra/camera/vi/core.c | 16 ++++++++++++++--
- .../media/platform/tegra/camera/vi/vi5_fops.c | 12 +++++++
- .../platform/tegra/camera/vi/vi5_formats.h    | 32 +++++++++++++++++++
- 4 files changed, 72 insertions(+), 2 deletions(-)
+ .../media/platform/tegra/camera/vi/channel.c  | 14 ++++
+ drivers/media/platform/tegra/camera/vi/core.c | 43 +++++++++-
+ .../media/platform/tegra/camera/vi/vi5_fops.c | 21 +++++
+ .../platform/tegra/camera/vi/vi5_formats.h    | 80 +++++++++++++++++++
+ 4 files changed, 156 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
-index 993db7bd..0405886e 100644
+index 88cf075b..131f4e7b 100644
 --- a/drivers/media/platform/tegra/camera/vi/channel.c
 +++ b/drivers/media/platform/tegra/camera/vi/channel.c
 @@ -329,6 +329,9 @@ static void tegra_channel_update_format(struct tegra_channel *chan,
@@ -31,7 +28,7 @@ index 993db7bd..0405886e 100644
  }
  
  static void tegra_channel_fmts_bitmap_init(struct tegra_channel *chan)
-@@ -2219,12 +2222,23 @@ __tegra_channel_try_format(struct tegra_channel *chan,
+@@ -2219,6 +2222,17 @@ __tegra_channel_try_format(struct tegra_channel *chan,
  				&pix->width, &pix->height, &pix->bytesperline);
  	pix->sizeimage = get_aligned_buffer_size(chan,
  			pix->bytesperline, pix->height);
@@ -49,14 +46,8 @@ index 993db7bd..0405886e 100644
  	if (chan->fmtinfo->fourcc == V4L2_PIX_FMT_NV16) {
  		if (__builtin_umul_overflow(pix->sizeimage, 2, &pix->sizeimage)) {
  			dev_err(chan->vi->dev, "%s: update size image failed due to an overflow\n",
- 			__func__);
- 			return -EOVERFLOW;
- 		}
- 	}
- 
- 	return ret;
 diff --git a/drivers/media/platform/tegra/camera/vi/core.c b/drivers/media/platform/tegra/camera/vi/core.c
-index 30ed1307..63c8b7ca 100644
+index 30ed1307..898282fa 100644
 --- a/drivers/media/platform/tegra/camera/vi/core.c
 +++ b/drivers/media/platform/tegra/camera/vi/core.c
 @@ -6,6 +6,7 @@
@@ -67,15 +58,42 @@ index 30ed1307..63c8b7ca 100644
  #include <linux/kernel.h>
  #include <linux/of.h>
  #include <linux/nospec.h>
-@@ -26,6 +27,15 @@ static const struct tegra_video_format tegra_default_format[] = {
+@@ -26,6 +27,42 @@ static const struct tegra_video_format tegra_default_format[] = {
  	},
  };
  
++#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10
++#define MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10	0x5002
++#endif
++
++#ifndef MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16
++#define MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16	0x5003
++#endif
++
++#ifndef MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8
++#define MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8		0x5005
++#endif
++
++static bool tegra_core_format_needs_subdev_match(u32 code)
++{
++	switch (code) {
++	case MEDIA_BUS_FMT_ARGB8888_1X32:
++	case MEDIA_BUS_FMT_SGRBG16_1X16:
++	case MEDIA_BUS_FMT_RS_NV12_UD32_1X8:
++	case MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8:
++	case MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16:
++	case MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10:
++		return true;
++	default:
++		return false;
++	}
++}
++
 +static bool tegra_core_format_is_available(struct tegra_channel *chan,
 +		unsigned int index)
 +{
-+	return chan->video_formats[index]->code !=
-+		MEDIA_BUS_FMT_RS_NV12_UD32_1X8 ||
++	return !tegra_core_format_needs_subdev_match(
++			chan->video_formats[index]->code) ||
 +		bitmap_empty(chan->fmts_bitmap, MAX_FORMAT_NUM) ||
 +		test_bit(index, chan->fmts_bitmap);
 +}
@@ -83,7 +101,7 @@ index 30ed1307..63c8b7ca 100644
  /* -----------------------------------------------------------------------------
   * Helper functions
   */
-@@ -106,7 +114,8 @@ int tegra_core_get_code_by_fourcc(struct tegra_channel *chan,
+@@ -106,7 +143,8 @@ int tegra_core_get_code_by_fourcc(struct tegra_channel *chan,
  	unsigned int i;
  
  	for (i = offset; i < chan->num_video_formats; ++i) {
@@ -93,7 +111,7 @@ index 30ed1307..63c8b7ca 100644
  			return chan->video_formats[i]->code;
  	}
  	spec_bar();
-@@ -166,7 +175,8 @@ tegra_core_get_format_by_fourcc(struct tegra_channel *chan, u32 fourcc)
+@@ -166,7 +204,8 @@ tegra_core_get_format_by_fourcc(struct tegra_channel *chan, u32 fourcc)
  	unsigned int i;
  
  	for (i = 0; i < chan->num_video_formats; ++i) {
@@ -104,10 +122,10 @@ index 30ed1307..63c8b7ca 100644
  	}
  	spec_bar();
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-index 9b8be688..df21fdfe 100644
+index ee8dfd3d..9de8c061 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -58,6 +58,8 @@ static const struct capture_descriptor capture_template = {
+@@ -57,6 +57,8 @@ static const struct capture_descriptor capture_template = {
  	,
  
  	.ch_cfg = {
@@ -116,7 +134,7 @@ index 9b8be688..df21fdfe 100644
  		.pixfmt_enable = 0,		/* no output */
  		.match = {
  			.stream = 0,		/* one-hot bit encoding */
-@@ -393,6 +395,8 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -391,6 +393,8 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  	u32 format = chan->fmtinfo->img_fmt;
  	u32 bpl = chan->format.bytesperline;
  	u32 data_type = chan->fmtinfo->img_dt;
@@ -125,17 +143,26 @@ index 9b8be688..df21fdfe 100644
  	u32 nvcsi_stream = chan->port[vi_port];
  	unsigned int range = 0;
  	struct capture_descriptor_memoryinfo *desc_memoryinfo =
-@@ -427,6 +431,9 @@ static void vi5_setup_surface(struct tegra_channel *chan,
- 	 */
- 	if (chan->fmtinfo->fourcc == V4L2_PIX_FMT_Y16I)
- 		width *= 2;
+@@ -419,6 +423,18 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 		}
+ 	}
+ 
++	/* Y16I: one 32bpp L/R column pair per V4L2 pixel.
++	 * However, GMSL caps at 24bpp, so we alias it to RAW16, and the de-facto
++	 * width should be double the requested size
++	 */
++	if (surface_override && surface_override->use_bytesperline_width)
++		width = bpl;
++	else if (chan->fmtinfo->fourcc == V4L2_PIX_FMT_Y16I)
++		width *= 2;
 +	if (surface_override)
 +		height = height * surface_override->height_numerator /
 +			surface_override->height_denominator;
- 
++
  	memcpy(desc, &capture_template, sizeof(capture_template));
  	memset(desc_memoryinfo, 0, sizeof(*desc_memoryinfo));
-@@ -438,6 +445,11 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 
+@@ -429,6 +445,11 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  	desc->ch_cfg.frame.frame_y = height;
  	desc->ch_cfg.match.datatype = data_type;
  	desc->ch_cfg.match.datatype_mask = 0x3f;
@@ -148,18 +175,35 @@ index 9b8be688..df21fdfe 100644
  	desc->ch_cfg.pixfmt.format = format;
  
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-index 307f398f..0ae63202 100644
+index 4e50e780..186fdfa5 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-@@ -82,6 +82,36 @@ enum tegra_image_format {
+@@ -82,6 +82,74 @@ enum tegra_image_format {
  	TEGRA_IMAGE_FORMAT_T_DPCM_RAW20,
  };
  
++#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10
++#define MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10	0x5002
++#endif
++
++#ifndef MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16
++#define MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16	0x5003
++#endif
++
++#ifndef MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8
++#define MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8		0x5005
++#endif
++
++#ifndef V4L2_PIX_FMT_RS_SGRBG10P
++#define V4L2_PIX_FMT_RS_SGRBG10P v4l2_fourcc('G', 'R', '0', 'P')
++#endif
++
 +struct tegra_vi_surface_override {
 +	u32 code;
 +	u8 dt_override;
 +	u8 height_numerator;
 +	u8 height_denominator;
++	bool use_bytesperline_width;
 +};
 +
 +static const struct tegra_vi_surface_override
@@ -169,6 +213,27 @@ index 307f398f..0ae63202 100644
 +		.dt_override = TEGRA_IMAGE_DT_RAW8,
 +		.height_numerator = 3,
 +		.height_denominator = 2,
++	},
++	{
++		.code = MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8,
++		.dt_override = TEGRA_IMAGE_DT_RAW8,
++		.height_numerator = 1,
++		.height_denominator = 1,
++		.use_bytesperline_width = true,
++	},
++	{
++		.code = MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16,
++		.dt_override = TEGRA_IMAGE_DT_RAW8,
++		.height_numerator = 1,
++		.height_denominator = 1,
++		.use_bytesperline_width = true,
++	},
++	{
++		.code = MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10,
++		.dt_override = TEGRA_IMAGE_DT_RAW8,
++		.height_numerator = 1,
++		.height_denominator = 1,
++		.use_bytesperline_width = true,
 +	},
 +};
 +
@@ -188,14 +253,25 @@ index 307f398f..0ae63202 100644
  static const struct tegra_video_format vi5_video_formats[] = {
  	/* RAW 6: TODO */
  
-@@ -169,6 +199,8 @@ static const struct tegra_video_format vi5_video_formats[] = {
- 				RAW16, Y16I, "Y16I 32"),
- 	TEGRA_VIDEO_FORMAT(RAW16, 16, SGRBG16_1X16, 2, 1, T_R16,
- 				RAW16, RW16, "RW16 16"),
+@@ -165,6 +233,18 @@ static const struct tegra_video_format vi5_video_formats[] = {
+ 	// R[7:3]R[3:0] | L[3:0]R[11:8] | L[11:8]L[7:4] | ALIGN[7:0]
+ 	TEGRA_VIDEO_FORMAT(RGB888, 24, RGB888_1X24, 4, 1, T_A8R8G8B8,
+ 				RGB888, Y12I, "Y12I 24"),
++	TEGRA_VIDEO_FORMAT(RAW16, 16, ARGB8888_1X32, 4, 1, T_R16,
++				RAW16, Y16I, "Y16I 32"),
++	TEGRA_VIDEO_FORMAT(RAW16, 16, SGRBG16_1X16, 2, 1, T_R16,
++				RAW16, RW16, "RW16 16"),
 +	TEGRA_VIDEO_FORMAT(RAW8, 8, RS_NV12_UD32_1X8, 1, 1, T_R8,
 +				USER_3, NV12, "YUV 4:2:0 NV12 UD32"),
++	TEGRA_VIDEO_FORMAT(RAW12, 12, RS_Y12I_UDP8_4X8, 4, 1, T_R8,
++				USER_3, Y16I, "Y12I in UDP8 byte containers"),
++	TEGRA_VIDEO_FORMAT(RAW10, 10, RS_SGRBG10_UDP8_1X16, 2, 1, T_R8,
++				USER_3, RW16, "GRBG10 in UDP8 RW16 containers"),
++	TEGRA_VIDEO_FORMAT(RAW10, 10, RS_SGRBG10P_UDP8_1X10, 32, 25, T_R8,
++				USER_3, RS_SGRBG10P, "RealSense GRBG10P UDP8 CL64"),
  
  };
  
 -- 
 2.34.1
+

--- a/nvidia-oot/7.0/0013-Receive-flat-NV12-over-User-Defined.patch
+++ b/nvidia-oot/7.0/0013-Receive-flat-NV12-over-User-Defined.patch
@@ -1,19 +1,21 @@
-From 001448ef6f9ce920722401844281a3bf069890a2 Mon Sep 17 00:00:00 2001
+From 67004fd658deea6a9435da7dc8338d81375f3a45 Mon Sep 17 00:00:00 2001
 From: zhou <shengyong.zhou@realsenseai.com>
-Date: Tue, 18 Aug 2026 18:13:46 +0800
+Date: Tue, 18 Aug 2026 18:44:46 +0800
 Subject: [PATCH] media: tegra: receive D5x tunnel UDP8 byte surfaces
 
-Map selected User Defined packet data types to T_R8 for D5x NV12 and
-calibration tuples while preserving the existing V4L2 surface layouts.
+Map selected User Defined packet data types to T_R8 for D5x NV12 and calibration tuples while preserving the existing V4L2 surface layouts.
+
+Keep private media-bus identifiers in the patched kernel UAPI and shared CSI data types in gmsl-link.h.
 Filter private duplicate FourCC tuples by the active subdevice format.
 
 Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
 ---
  .../media/platform/tegra/camera/vi/channel.c  | 14 ++++
- drivers/media/platform/tegra/camera/vi/core.c | 43 ++++++++++-
- .../media/platform/tegra/camera/vi/vi5_fops.c | 16 +++-
- .../platform/tegra/camera/vi/vi5_formats.h    | 76 +++++++++++++++++++
- 4 files changed, 146 insertions(+), 3 deletions(-)
+ drivers/media/platform/tegra/camera/vi/core.c | 31 ++++++++-
+ .../media/platform/tegra/camera/vi/vi5_fops.c | 16 ++++-
+ .../platform/tegra/camera/vi/vi5_formats.h    | 64 +++++++++++++++++++
+ include/media/gmsl-link.h                     |  3 +
+ 5 files changed, 125 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
 index da4a1c71..39cbdf76 100644
@@ -48,7 +50,7 @@ index da4a1c71..39cbdf76 100644
  		if (__builtin_umul_overflow(pix->sizeimage, 2, &pix->sizeimage)) {
  			dev_err(chan->vi->dev, "%s: update size image failed due to an overflow\n",
 diff --git a/drivers/media/platform/tegra/camera/vi/core.c b/drivers/media/platform/tegra/camera/vi/core.c
-index 30ed1307..898282fa 100644
+index 30ed1307..89b6491b 100644
 --- a/drivers/media/platform/tegra/camera/vi/core.c
 +++ b/drivers/media/platform/tegra/camera/vi/core.c
 @@ -6,6 +6,7 @@
@@ -59,22 +61,10 @@ index 30ed1307..898282fa 100644
  #include <linux/kernel.h>
  #include <linux/of.h>
  #include <linux/nospec.h>
-@@ -26,6 +27,42 @@ static const struct tegra_video_format tegra_default_format[] = {
+@@ -26,6 +27,30 @@ static const struct tegra_video_format tegra_default_format[] = {
  	},
  };
  
-+#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10
-+#define MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10	0x5002
-+#endif
-+
-+#ifndef MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16
-+#define MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16	0x5003
-+#endif
-+
-+#ifndef MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8
-+#define MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8		0x5005
-+#endif
-+
 +static bool tegra_core_format_needs_subdev_match(u32 code)
 +{
 +	switch (code) {
@@ -102,7 +92,7 @@ index 30ed1307..898282fa 100644
  /* -----------------------------------------------------------------------------
   * Helper functions
   */
-@@ -106,7 +143,8 @@ int tegra_core_get_code_by_fourcc(struct tegra_channel *chan,
+@@ -106,7 +131,8 @@ int tegra_core_get_code_by_fourcc(struct tegra_channel *chan,
  	unsigned int i;
  
  	for (i = offset; i < chan->num_video_formats; ++i) {
@@ -112,7 +102,7 @@ index 30ed1307..898282fa 100644
  			return chan->video_formats[i]->code;
  	}
  	spec_bar();
-@@ -166,7 +204,8 @@ tegra_core_get_format_by_fourcc(struct tegra_channel *chan, u32 fourcc)
+@@ -166,7 +192,8 @@ tegra_core_get_format_by_fourcc(struct tegra_channel *chan, u32 fourcc)
  	unsigned int i;
  
  	for (i = 0; i < chan->num_video_formats; ++i) {
@@ -172,25 +162,13 @@ index 459a3d82..54dcba51 100644
  	desc->ch_cfg.pixfmt.format = format;
  
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-index ecf547ac..128760b1 100644
+index ecf547ac..ee88b378 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-@@ -82,6 +82,74 @@ enum tegra_image_format {
+@@ -82,6 +82,62 @@ enum tegra_image_format {
  	TEGRA_IMAGE_FORMAT_T_DPCM_RAW20,
  };
  
-+#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10
-+#define MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10	0x5002
-+#endif
-+
-+#ifndef MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16
-+#define MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16	0x5003
-+#endif
-+
-+#ifndef MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8
-+#define MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8		0x5005
-+#endif
-+
 +#ifndef V4L2_PIX_FMT_RS_SGRBG10P
 +#define V4L2_PIX_FMT_RS_SGRBG10P v4l2_fourcc('G', 'R', '0', 'P')
 +#endif
@@ -250,7 +228,7 @@ index ecf547ac..128760b1 100644
  static const struct tegra_video_format vi5_video_formats[] = {
  	/* RAW 6: TODO */
  
-@@ -179,6 +247,14 @@ static const struct tegra_video_format vi5_video_formats[] = {
+@@ -179,6 +235,14 @@ static const struct tegra_video_format vi5_video_formats[] = {
  				RAW16, Y16I, "Y16I 32"),
  	TEGRA_VIDEO_FORMAT(RAW16, 16, SGRBG16_1X16, 2, 1, T_R16,
  				RAW16, RW16, "RW16 16"),
@@ -265,3 +243,21 @@ index ecf547ac..128760b1 100644
  
  };
  
+diff --git a/include/media/gmsl-link.h b/include/media/gmsl-link.h
+index 48939537..4db8ea7e 100644
+--- a/include/media/gmsl-link.h
++++ b/include/media/gmsl-link.h
+@@ -37,8 +37,11 @@
+ #define GMSL_SERDES_CSI_LINK_B 0x2
+ 
+ /* Didn't find kernel defintions, for now adding here */
++#define GMSL_CSI_DT_YUV420_8 0x18
++#define GMSL_CSI_DT_RAW_10 0x2B
+ #define GMSL_CSI_DT_RAW_12 0x2C
+ #define GMSL_CSI_DT_UED_U1 0x30
++#define GMSL_CSI_DT_UED_U3 0x32
+ #define GMSL_CSI_DT_EMBED 0x12
+ #define GMSL_CSI_DT_YUV422_8 0x1E
+ #define GMSL_CSI_DT_RGB_888 0x24
+-- 
+2.34.1


### PR DESCRIPTION
## Summary

- Receive D58x tunnel-mode IR and RGB calibration surfaces through a CSI-2 User Defined carrier selected from the SerDes UDP8 class.
- Preserve each incoming byte layout with private T_R8 media-bus tuples and expose the existing V4L2 ABIs: Y16I, RW16, and GR0P.
- Keep the HKR source format selector separate from the final wire packet data type.

## Routes

| Product surface | HKR source selector | Host V4L2 FourCC | Buffer contract |
| --- | --- | --- | --- |
| IR Y12I unpacked | RAW16 | Y16I | 4 bytes per logical L/R pair; BPL 6400 |
| RGB GRBG10 unpacked | RAW16 | RW16 | 2-byte little-endian container per pixel; BPL 3200 |
| RGB GRBG10P packed | RAW10 | GR0P | Native 50-pixel / 64-byte cache-line layout; BPL 2048 |

UDP8 is the MAX96717/MAX96724 8-bit User Defined payload class. The selected member carries every CSI payload byte without adding pixel-format semantics. Tegra matches the exact private media-bus tuple, applies T_R8 only for that active tuple, and writes the original bytes directly into the V4L2 surface.

## Scope

- D58x tunnel mode only.
- Pixel Mode keeps its existing standard RAW16 tuples.
- D4xx format tables and selection are unchanged.
- No SerDes programming, DTS, application conversion, or build-system changes.
- Same-FourCC standard/private tuples are selected from the active subdevice media-bus bitmap.

## Stack and dependencies

- Stacked on https://github.com/realsenseai/realsense_mipi_platform_driver/pull/585
- HKR routing: https://github.com/RealSenseAI-Internal/soc-rs-soc-device-mgr/pull/471
- HKR HIF MIPI: https://github.com/RealSenseAI-Internal/soc-rs-soc-io-drivers/pull/548

## Verification

- JetPack 6.2.2 patch reset, full replay, clean full build, rootfs deployment, reboot, and loaded-artifact SHA256 check: PASS.
- V4L2 enumeration and TRY_FMT: Y16I 1600x1300 BPL 6400 size 8,320,000; RW16 BPL 3200 size 4,160,000; GR0P BPL 2048 size 2,662,400: PASS.
- Preview Y16I 1600x1300@15: 180 frames, zero sequence drops, decode PASS.
- Preview GR0P 1600x1300@25: 180 frames, zero sequence drops, decode PASS.
- RW16 1600x1300@25: 180 frames, 4,160,000 bytes used per frame, about 24.98 fps, STREAMON PASS.
- Stacked NV12 1280x960@60: 181 frames, zero sequence drops, decode PASS.
- Standard Depth Z16 + IR Y8I + RGB YUYV at 1280x720@60: concurrent preview PASS with zero sequence drops.

The legacy regression wrapper reports metadata-sidecar failures because its fixed metadata node mapping is stale on this deployment. The video portions of both calibration cases completed successfully; metadata is outside this PR scope.