### PR TITLE
dfu: retry transient 0xFFFF/0xFF status polls in ds5_dfu_wait_for_get_dfu_status

### DIFF
--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -286,6 +286,12 @@ enum ds5_mux_pad {
 
 #define DFU_WAIT_RET_LEN 6
 
+/* Length/status reads (0x5004, 0x4e00) can briefly return 0xFFFF/0xFF while D58x
+ * is between manifest sub-states or under I2C contention; retry a bounded number
+ * of times before declaring the poll a failure. */
+#define DFU_STATUS_RETRY_MAX	5
+#define DFU_STATUS_RETRY_MS	20
+
 #define DS5_START_POLL_TIME	10
 #define DS5_START_MAX_TIME	2000
 #define DS5_START_MAX_COUNT	(DS5_START_MAX_TIME / DS5_START_POLL_TIME)
@@ -6650,13 +6656,31 @@ static int ds5_dfu_wait_for_get_dfu_status(struct ds5 *state,
 
 		} while (status);
 
-		ds5_read_with_check(state, 0x5004, &dfu_state_len);
+		/* Retry on transient garbage: length 0xFFFF or status 0xFF happens
+		 * when the read hits the D58x manifest-reset window or an I2C glitch;
+		 * a healthy poll returns on the first read. */
+		{
+			int retries;
+
+			for (retries = 0; retries < DFU_STATUS_RETRY_MAX; retries++) {
+				if (retries)
+					msleep_range(DFU_STATUS_RETRY_MS);
+				if (ds5_read_poll(state, 0x5004, &dfu_state_len))
+					continue;
+				if (dfu_state_len != DFU_WAIT_RET_LEN)
+					continue;
+				if (regmap_raw_read(state->regmap, 0x4e00,
+						dfu_asw_buf, DFU_WAIT_RET_LEN))
+					continue;
+				if (dfu_asw_buf[0] == 0)
+					break;
+			}
+		}
 		if (dfu_state_len != DFU_WAIT_RET_LEN) {
 			dev_err(&state->client->dev,
 					"%s(): Wrong answer len (%d)\n", __func__, dfu_state_len);
 			return -EINVAL;
 		}
-		ds5_raw_read_with_check(state, 0x4e00, &dfu_asw_buf, DFU_WAIT_RET_LEN);
 		if (dfu_asw_buf[0]) {
 			dev_err(&state->client->dev,
 					"%s(): Wrong dfu_status (%d)\n", __func__, dfu_asw_buf[0]);


### PR DESCRIPTION
## Summary
`ds5_dfu_wait_for_get_dfu_status()` currently bails hard when the length register at `0x5004` returns anything other than `DFU_WAIT_RET_LEN` (6), or when the status byte at `0x4e00[0]` is non-zero. Under D58x GMSL, both reads can transiently return the I2C-glitch sentinel (`0xFFFF` / `0xFF`) — typically when the poll hits the manifest-reset window or when the shared bus is contended by a userspace process running in parallel with the DFU. That transient bombs the whole DFU with `-EINVAL`, even though a millisecond later the FW would have answered cleanly.

Behaviour today:
- `cat rvp-flash-dfu.img > /dev/d4xx-dfu-*` from a bare shell: works (nothing else on the bus).
- `rs-fw-update` CLI: works (single-threaded, DFU on main thread).
- `realsense-viewer`: intermittent `Wrong answer len (65535)` / `Wrong dfu_status (255)` — user-visible DFU failure even though the write path is correct end-to-end.

## Change
Small, self-contained. In `ds5_dfu_wait_for_get_dfu_status()`, wrap the length + status reads in a bounded retry loop that only retries on the transient-garbage patterns. Uses `ds5_read_poll()` (single-shot regmap read, no built-in retry / log spam — per the polling-loop convention already documented in `CLAUDE.md`) for the length read, and `regmap_raw_read()` for the payload, both directly so the retry loop owns the whole reply.

- Retries: 5, spaced 20 ms — worst-case adds ~100 ms before we surface the pre-existing error paths.
- Happy path is one read (no msleep, no extra syscalls). No observable difference for anything that works today.
- Error messages, control flow after the reads, and the outer `dfuDNBUSY` transition loop are unchanged.

## Impact scope
Only `ds5_dfu_wait_for_get_dfu_status()` is touched. That function is called only from the DFU chardev write path (`ds5_dfu_device_write`) and the DFU detach path. Streaming / options / calibration / probe are not affected.

## Test plan
- [ ] Manual `cat rvp-flash-dfu.img > /dev/d4xx-dfu-0` on D58x GMSL still completes cleanly (regression check).
- [ ] `rs-fw-update` CLI DFU on D58x GMSL still completes cleanly.
- [ ] `realsense-viewer` DFU on D58x GMSL — was intermittently failing pre-patch, expected to complete cleanly post-patch.
- [ ] `dmesg` shows no `Wrong answer len` / `Wrong dfu_status` on any of the above.
- [ ] D4xx GMSL DFU unchanged (patch is family-agnostic; D4xx path never hits the transient in practice).

## Related
Extension of the D58x manifest-state handling introduced in #564.