### PR TITLE
[D585][GMSL] Deliver reviewed tunnel lane-rate change to dev

### DIFF
--- a/hardware/realsense/tegra234-camera-d4xx-overlay-fg24-4ch-d5xx.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-fg24-4ch-d5xx.dts
@@ -127,7 +127,7 @@
 				status = "okay";
 				compatible = "nvidia, tegra-camera-platform";
 				num_csi_lanes = <4>;
-				max_lane_speed = <2000000>;
+				max_lane_speed = <1500000>;
 				min_bits_per_pixel = <10>;
 				vi_peak_byte_per_pixel = <2>;
 				vi_bw_margin_pct = <25>;
@@ -334,7 +334,9 @@
 							reg = <0x27>;
 							compatible = "adi,max96724";
 							csi-mode = "2x4";
+							csi-lane-count = <4>;
 							max-src = <1>;
+							csi-lane-rate-mbps = <1500>;
 							link-mask = <0x1>;
 							gmsl-link-speed = <6>;
 						};
@@ -364,6 +366,7 @@
 							compatible = "realsense,d5xx";
 							use_sensor_mode_id = "true";
 							cam-type = "IMU";
+							mipi-lane-rate-mbps = <1300>;
 							nvidia,gmsl-ser-device = <&ser_a>;
 							nvidia,gmsl-dser-device = <&dser>;
 
@@ -392,9 +395,11 @@
 								phy_mode = "DPHY";
 								discontinuous_clk = "no";
 								cil_settletime = "0";
+								deskew_initial_enable = "false";
+								deskew_periodic_enable = "false";
 								mclk_khz = "24000";
-								pix_clk_hz = "1000000000";
-								serdes_pix_clk_hz = "1000000000";
+								pix_clk_hz = "700000000";
+								serdes_pix_clk_hz = "750000000";
 								line_length = "640";
 								embedded_metadata_height = "0";
 							};
@@ -422,6 +427,7 @@
 							compatible = "realsense,d5xx";
 							use_sensor_mode_id = "true";
 							cam-type = "Y8";
+							mipi-lane-rate-mbps = <1300>;
 							nvidia,gmsl-ser-device = <&ser_a>;
 							nvidia,gmsl-dser-device = <&dser>;
 
@@ -451,9 +457,11 @@
 								phy_mode = "DPHY";
 								discontinuous_clk = "no";
 								cil_settletime = "0";
+								deskew_initial_enable = "false";
+								deskew_periodic_enable = "false";
 								mclk_khz = "24000";
-								pix_clk_hz = "1000000000";
-								serdes_pix_clk_hz = "1000000000";
+								pix_clk_hz = "700000000";
+								serdes_pix_clk_hz = "750000000";
 								line_length = "1280";
 								embedded_metadata_height = "1";
 							};
@@ -469,11 +477,11 @@
 								phy_mode = "DPHY";
 								discontinuous_clk = "no";
 								cil_settletime = "0";
-								deskew_initial_enable = "true";
-								deskew_periodic_enable = "true";
+								deskew_initial_enable = "false";
+								deskew_periodic_enable = "false";
 								mclk_khz = "24000";
-								pix_clk_hz = "500000000";
-								serdes_pix_clk_hz = "500000000";
+								pix_clk_hz = "350000000";
+								serdes_pix_clk_hz = "375000000";
 								line_length = "1280";
 								embedded_metadata_height = "1";
 							};
@@ -501,6 +509,7 @@
 							compatible = "realsense,d5xx";
 							use_sensor_mode_id = "true";
 							cam-type = "RGB";
+							mipi-lane-rate-mbps = <1300>;
 							nvidia,gmsl-ser-device = <&ser_a>;
 							nvidia,gmsl-dser-device = <&dser>;
 
@@ -529,11 +538,11 @@
 								phy_mode = "DPHY";
 								discontinuous_clk = "no";
 								cil_settletime = "0";
-								deskew_initial_enable = "true";
-								deskew_periodic_enable = "true";
+								deskew_initial_enable = "false";
+								deskew_periodic_enable = "false";
 								mclk_khz = "24000";
-								pix_clk_hz = "500000000";
-								serdes_pix_clk_hz = "500000000";
+								pix_clk_hz = "350000000";
+								serdes_pix_clk_hz = "375000000";
 								line_length = "1920";
 								embedded_metadata_height = "1";
 							};
@@ -560,6 +569,7 @@
 							compatible = "realsense,d5xx";
 							use_sensor_mode_id = "true";
 							cam-type = "Depth";
+							mipi-lane-rate-mbps = <1300>;
 							nvidia,gmsl-ser-device = <&ser_a>;
 							nvidia,gmsl-dser-device = <&dser>;
 
@@ -578,26 +588,8 @@
 								};
 							};
 
-							/*
-							 * Pixel clock reference for mixed-VC tunnel mode:
-							 *   pix_clk_hz = lane_rate_bps * lane_count / bits_per_pixel
-							 *
-							 * The MAX96724->Orin D-PHY output is configured to
-							 * 2.0Gbps/lane over 4 lanes, so the payload budget is
-							 * 2,000,000,000 * 4 = 8,000,000,000 bits/s.
-							 *
-							 * Tunnel mode carries each source packet as-is. There is
-							 * no single rewritten DES-side BPP when VC0-3 run
-							 * concurrently, so each Orin mode uses its own
-							 * csi_pixel_bit_depth:
-							 *   16-bit modes: 8,000,000,000 / 16 = 500,000,000 Hz
-							 *   8-bit modes:  8,000,000,000 /  8 = 1,000,000,000 Hz
-							 *
-							 * Aggregate bandwidth closure is still checked against
-							 * the shared 4-lane physical link and the 6Gbps GMSL2
-							 * forward link; pix_clk_hz here is the per-mode parser
-							 * clock NVIDIA uses for VI/NVCSI bandwidth setup.
-							 */
+							/* 1.5Gbps/lane x4 gives a 375MHz SerDes pixel clock at
+							 * 16bpp and 750MHz at 8bpp in mixed-VC tunnel mode. */
 							mode0 {
 								pixel_t = "yuv_uyvy16";
 								num_lanes = "4";
@@ -608,11 +600,11 @@
 								phy_mode = "DPHY";
 								discontinuous_clk = "no";
 								cil_settletime = "0";
-								deskew_initial_enable = "true";
-								deskew_periodic_enable = "true";
+								deskew_initial_enable = "false";
+								deskew_periodic_enable = "false";
 								mclk_khz = "24000";
-								pix_clk_hz = "500000000";
-								serdes_pix_clk_hz = "500000000";
+								pix_clk_hz = "350000000";
+								serdes_pix_clk_hz = "375000000";
 								line_length = "1280";
 								embedded_metadata_height = "1";
 							};

--- a/hardware/realsense/tegra234-camera-d4xx-overlay-fg24-4ch-d5xx.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-fg24-4ch-d5xx.dts
@@ -35,6 +35,17 @@
  *   MAX96717 ser:    0x40 (default), 0x60 (aliased)
  *   HKR camera SoC:  0x10 (def-addr)
  *   Sensor aliases:   0x1a (Depth), 0x1b (RGB), 0x1c (IR), 0x1d (IMU)
+ *
+ * CSI lane properties:
+ *   mipi-lane-rate-mbps = HKR-to-MAX96717 input rate per lane
+ *   csi-lane-rate-mbps  = MAX96724-to-Orin output rate per lane
+ *   csi-lane-count      = MAX96724 output width; only 4 lanes are supported
+ *
+ * ADI specifies a fixed 6 Gbps GMSL2 forward rate and up to 2.5 Gbps per
+ * D-PHY lane. This single-link topology uses 4 x 1500 Mbps on the CSI output,
+ * matching the 6 Gbps input-link ceiling; 4 x 2000 Mbps adds D-PHY headroom
+ * but cannot increase sustained input-limited throughput. The generic driver
+ * keeps its legacy 2000 Mbps default for other, potentially 2-lane, boards.
  */
 
 /dts-v1/;
@@ -398,7 +409,7 @@
 								deskew_initial_enable = "false";
 								deskew_periodic_enable = "false";
 								mclk_khz = "24000";
-								pix_clk_hz = "700000000";
+								pix_clk_hz = "650000000";
 								serdes_pix_clk_hz = "750000000";
 								line_length = "640";
 								embedded_metadata_height = "0";
@@ -460,7 +471,7 @@
 								deskew_initial_enable = "false";
 								deskew_periodic_enable = "false";
 								mclk_khz = "24000";
-								pix_clk_hz = "700000000";
+								pix_clk_hz = "650000000";
 								serdes_pix_clk_hz = "750000000";
 								line_length = "1280";
 								embedded_metadata_height = "1";
@@ -480,7 +491,7 @@
 								deskew_initial_enable = "false";
 								deskew_periodic_enable = "false";
 								mclk_khz = "24000";
-								pix_clk_hz = "350000000";
+								pix_clk_hz = "325000000";
 								serdes_pix_clk_hz = "375000000";
 								line_length = "1280";
 								embedded_metadata_height = "1";
@@ -541,7 +552,7 @@
 								deskew_initial_enable = "false";
 								deskew_periodic_enable = "false";
 								mclk_khz = "24000";
-								pix_clk_hz = "350000000";
+								pix_clk_hz = "325000000";
 								serdes_pix_clk_hz = "375000000";
 								line_length = "1920";
 								embedded_metadata_height = "1";
@@ -588,8 +599,11 @@
 								};
 							};
 
-							/* 1.5Gbps/lane x4 gives a 375MHz SerDes pixel clock at
-							 * 16bpp and 750MHz at 8bpp in mixed-VC tunnel mode. */
+							/*
+							 * At 1.5Gbps/lane, SerDes pixel clock is
+							 * 375MHz at 16bpp and 750MHz at 8bpp in
+							 * mixed-VC tunnel mode.
+							 */
 							mode0 {
 								pixel_t = "yuv_uyvy16";
 								num_lanes = "4";
@@ -603,7 +617,7 @@
 								deskew_initial_enable = "false";
 								deskew_periodic_enable = "false";
 								mclk_khz = "24000";
-								pix_clk_hz = "350000000";
+								pix_clk_hz = "325000000";
 								serdes_pix_clk_hz = "375000000";
 								line_length = "1280";
 								embedded_metadata_height = "1";

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -6208,9 +6208,8 @@ static int ds5_hw_init(struct i2c_client *c, struct ds5 *state)
 {
 	struct v4l2_subdev *sd = &state->mux.sd.subdev;
 	u16 mipi_status, n_lanes, phy, drate_min, drate_max;
-	u16 lane_rate, default_lane_rate;
+	u16 lane_rate;
 	u32 dt_lane_rate;
-	bool mipi_caps_valid;
 	bool is_d58x = ds5_is_d58x(state);
 	int ret = ds5_read(state, DS5_MIPI_SUPPORT_LINES, &n_lanes);
 	if (!ret)
@@ -6222,36 +6221,37 @@ static int ds5_hw_init(struct i2c_client *c, struct ds5 *state)
 	if (!ret)
 		ret = ds5_read(state, DS5_MIPI_DATARATE_MAX, &drate_max);
 
-	mipi_caps_valid = !ret;
 	if (!ret)
 		dev_dbg(sd->dev, "%s(): %d: %u lanes, phy %x, data rate %u-%u\n",
 			 __func__, __LINE__, n_lanes, phy, drate_min, drate_max);
 
-	/* D58x board/link overlays may override the product default.
-	 * D4xx keeps its existing 1000 Mbps rate. */
-	default_lane_rate = is_d58x ? MIPI_LANE_RATE_HKR : MIPI_LANE_RATE_DS5;
-	lane_rate = default_lane_rate;
-	if (is_d58x && sd->dev->of_node &&
-	    !of_property_read_u32(sd->dev->of_node,
-				  "mipi-lane-rate-mbps", &dt_lane_rate)) {
-		if (!mipi_caps_valid) {
-			dev_warn(sd->dev,
-				 "FW MIPI caps unavailable, ignoring DT rate %u; using %u Mbps\n",
-				 dt_lane_rate, default_lane_rate);
-		} else if (!dt_lane_rate || dt_lane_rate > U16_MAX) {
-			dev_warn(sd->dev,
-				 "invalid DT MIPI lane rate %u, using %u Mbps\n",
-				 dt_lane_rate, default_lane_rate);
-		} else {
-			lane_rate = dt_lane_rate;
+	/*
+	 * Product defaults remain in-driver. A board/link overlay may request a
+	 * different input rate, but an explicit rate must match the FW-reported
+	 * capabilities so the camera and serializer cannot silently drift.
+	 */
+	lane_rate = is_d58x ? MIPI_LANE_RATE_HKR : MIPI_LANE_RATE_DS5;
+	if (sd->dev->of_node &&
+	    of_find_property(sd->dev->of_node, "mipi-lane-rate-mbps", NULL)) {
+		if (ret) {
+			dev_err(sd->dev,
+				"cannot validate DT MIPI lane rate: FW caps unavailable\n");
+			return ret;
 		}
-	}
-	if (mipi_caps_valid &&
-	    (lane_rate < drate_min || lane_rate > drate_max)) {
-		dev_warn(sd->dev,
-			 "MIPI lane rate %u outside FW range %u-%u, using %u Mbps\n",
-			 lane_rate, drate_min, drate_max, default_lane_rate);
-		lane_rate = default_lane_rate;
+		ret = of_property_read_u32(sd->dev->of_node,
+					   "mipi-lane-rate-mbps", &dt_lane_rate);
+		if (ret) {
+			dev_err(sd->dev, "invalid mipi-lane-rate-mbps property\n");
+			return ret;
+		}
+		if (!dt_lane_rate || dt_lane_rate > U16_MAX ||
+		    dt_lane_rate < drate_min || dt_lane_rate > drate_max) {
+			dev_err(sd->dev,
+				"DT MIPI lane rate %u outside FW range %u-%u\n",
+				dt_lane_rate, drate_min, drate_max);
+			return -EINVAL;
+		}
+		lane_rate = dt_lane_rate;
 	}
 
 #ifdef CONFIG_TEGRA_CAMERA_PLATFORM

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -6208,6 +6208,9 @@ static int ds5_hw_init(struct i2c_client *c, struct ds5 *state)
 {
 	struct v4l2_subdev *sd = &state->mux.sd.subdev;
 	u16 mipi_status, n_lanes, phy, drate_min, drate_max;
+	u16 lane_rate, default_lane_rate;
+	u32 dt_lane_rate;
+	bool mipi_caps_valid;
 	bool is_d58x = ds5_is_d58x(state);
 	int ret = ds5_read(state, DS5_MIPI_SUPPORT_LINES, &n_lanes);
 	if (!ret)
@@ -6219,9 +6222,37 @@ static int ds5_hw_init(struct i2c_client *c, struct ds5 *state)
 	if (!ret)
 		ret = ds5_read(state, DS5_MIPI_DATARATE_MAX, &drate_max);
 
+	mipi_caps_valid = !ret;
 	if (!ret)
 		dev_dbg(sd->dev, "%s(): %d: %u lanes, phy %x, data rate %u-%u\n",
 			 __func__, __LINE__, n_lanes, phy, drate_min, drate_max);
+
+	/* D58x board/link overlays may override the product default.
+	 * D4xx keeps its existing 1000 Mbps rate. */
+	default_lane_rate = is_d58x ? MIPI_LANE_RATE_HKR : MIPI_LANE_RATE_DS5;
+	lane_rate = default_lane_rate;
+	if (is_d58x && sd->dev->of_node &&
+	    !of_property_read_u32(sd->dev->of_node,
+				  "mipi-lane-rate-mbps", &dt_lane_rate)) {
+		if (!mipi_caps_valid) {
+			dev_warn(sd->dev,
+				 "FW MIPI caps unavailable, ignoring DT rate %u; using %u Mbps\n",
+				 dt_lane_rate, default_lane_rate);
+		} else if (!dt_lane_rate || dt_lane_rate > U16_MAX) {
+			dev_warn(sd->dev,
+				 "invalid DT MIPI lane rate %u, using %u Mbps\n",
+				 dt_lane_rate, default_lane_rate);
+		} else {
+			lane_rate = dt_lane_rate;
+		}
+	}
+	if (mipi_caps_valid &&
+	    (lane_rate < drate_min || lane_rate > drate_max)) {
+		dev_warn(sd->dev,
+			 "MIPI lane rate %u outside FW range %u-%u, using %u Mbps\n",
+			 lane_rate, drate_min, drate_max, default_lane_rate);
+		lane_rate = default_lane_rate;
+	}
 
 #ifdef CONFIG_TEGRA_CAMERA_PLATFORM
 	n_lanes = state->mux.sd.numlanes;
@@ -6230,13 +6261,11 @@ static int ds5_hw_init(struct i2c_client *c, struct ds5 *state)
 #endif
 
 	ret = ds5_write(state, DS5_MIPI_LANE_NUMS, n_lanes - 1);
-	if (!ret) {
-		if (is_d58x) {
-			ret = ds5_write(state, DS5_MIPI_LANE_DATARATE, MIPI_LANE_RATE_HKR);
-		} else {
-			ret = ds5_write(state, DS5_MIPI_LANE_DATARATE, MIPI_LANE_RATE_DS5);
-		}
-	}
+	if (!ret)
+		ret = ds5_write(state, DS5_MIPI_LANE_DATARATE, lane_rate);
+	if (!ret)
+		dev_info(sd->dev, "MIPI TX configured: %u lanes at %u Mbps/lane\n",
+			 n_lanes, lane_rate);
 
 	if (!ret && state->d58x_pixel_mode) {
 		/* Tell HKR FW the deserializer runs in PIXEL mode so it

--- a/nvidia-oot/max96724.c
+++ b/nvidia-oot/max96724.c
@@ -92,7 +92,12 @@
 #define MAX96724_CSI_LANE_RATE_MIN_MBPS	100
 #define MAX96724_CSI_LANE_RATE_MAX_MBPS	2500
 #define MAX96724_CSI_LANE_RATE_STEP_MBPS	100
-#define MAX96724_CSI_LANE_RATE_DEFAULT_MBPS	1500
+/*
+ * Preserve the legacy rate for boards without an explicit DT setting.
+ * Single-link 4-lane boards may select 1500 Mbps/lane to match one 6 Gbps
+ * GMSL2 forward link without changing other MAX96724 topologies.
+ */
+#define MAX96724_CSI_LANE_RATE_DEFAULT_MBPS	2000
 #define MAX96724_CSI_LANE_COUNT_DEFAULT	4
 #define MAX96724_ONESHOT_ALL		0x0F
 #define MAX96724_PIPE_SEL0		0x62
@@ -1384,28 +1389,36 @@ static int max96724_parse_dt(struct max96724 *priv,
 	}
 	priv->link_mask = value;
 	priv->csi_lane_count = MAX96724_CSI_LANE_COUNT_DEFAULT;
-	err = of_property_read_u32(node, "csi-lane-count", &value);
-	if (!err) {
-		if (value != MAX96724_CSI_LANE_COUNT_DEFAULT) {
-			dev_warn(&client->dev,
-				 "unsupported csi-lane-count %u, using %u lanes\n",
-				 value, priv->csi_lane_count);
-		} else {
-			priv->csi_lane_count = value;
+	if (of_find_property(node, "csi-lane-count", NULL)) {
+		err = of_property_read_u32(node, "csi-lane-count", &value);
+		if (err) {
+			dev_err(&client->dev, "invalid csi-lane-count property\n");
+			return err;
 		}
+		if (value != MAX96724_CSI_LANE_COUNT_DEFAULT) {
+			dev_err(&client->dev,
+				"unsupported csi-lane-count %u (only %u lanes supported)\n",
+				value, MAX96724_CSI_LANE_COUNT_DEFAULT);
+			return -EINVAL;
+		}
+		priv->csi_lane_count = value;
 	}
 	priv->csi_lane_rate_mbps = MAX96724_CSI_LANE_RATE_DEFAULT_MBPS;
-	err = of_property_read_u32(node, "csi-lane-rate-mbps", &value);
-	if (!err) {
+	if (of_find_property(node, "csi-lane-rate-mbps", NULL)) {
+		err = of_property_read_u32(node, "csi-lane-rate-mbps", &value);
+		if (err) {
+			dev_err(&client->dev,
+				"invalid csi-lane-rate-mbps property\n");
+			return err;
+		}
 		if (value < MAX96724_CSI_LANE_RATE_MIN_MBPS ||
 		    value > MAX96724_CSI_LANE_RATE_MAX_MBPS ||
 		    value % MAX96724_CSI_LANE_RATE_STEP_MBPS) {
-			dev_warn(&client->dev,
-				 "invalid csi-lane-rate-mbps %u, using %u Mbps\n",
-				 value, priv->csi_lane_rate_mbps);
-		} else {
-			priv->csi_lane_rate_mbps = value;
+			dev_err(&client->dev,
+				"invalid csi-lane-rate-mbps %u\n", value);
+			return -EINVAL;
 		}
+		priv->csi_lane_rate_mbps = value;
 	}
 
 	priv->reset_gpio = devm_gpiod_get_optional(&client->dev, "reset",

--- a/nvidia-oot/max96724.c
+++ b/nvidia-oot/max96724.c
@@ -87,8 +87,13 @@
 #define MAX96724_CSI_OUT_EN_VAL		0x84
 #define MAX96724_CSI_PHY_EN_ALL		0xF0
 #define MAX96724_CSI_LANE_MAP_DEFAULT	0xE4
-#define MAX96724_LANE_CTRL_4LANE	0xC0
-#define MAX96724_DPLL_2000MBPS		0x34
+#define MAX96724_LANE_CTRL_NUM_LANES(n)	(((n) - 1) << 6)
+#define MAX96724_DPLL_FREQ_OVERRIDE	BIT(5)
+#define MAX96724_CSI_LANE_RATE_MIN_MBPS	100
+#define MAX96724_CSI_LANE_RATE_MAX_MBPS	2500
+#define MAX96724_CSI_LANE_RATE_STEP_MBPS	100
+#define MAX96724_CSI_LANE_RATE_DEFAULT_MBPS	1500
+#define MAX96724_CSI_LANE_COUNT_DEFAULT	4
 #define MAX96724_ONESHOT_ALL		0x0F
 #define MAX96724_PIPE_SEL0		0x62
 #define MAX96724_PIPE_SEL1		0xEA
@@ -143,6 +148,8 @@ struct max96724 {
 	struct pipe_ctx pipe[MAX96724_MAX_PIPES];
 	u8 csi_mode;
 	u8 lane_mp1;
+	u32 csi_lane_rate_mbps;
+	u32 csi_lane_count;
 	struct gpio_desc *reset_gpio;
 	int pw_ref;
 	struct regulator *vdd_cam_1v2;
@@ -364,7 +371,7 @@ static int max96724_configure_csi_port(struct device *dev,
 		u16 addr = MAX96724_LANE_CTRL0_ADDR + 0x40 * i;
 
 		err = max96724_write_reg(dev, addr,
-					 MAX96724_LANE_CTRL_4LANE);
+			MAX96724_LANE_CTRL_NUM_LANES(priv->csi_lane_count));
 	}
 
 	return err;
@@ -398,7 +405,11 @@ static int max96724_configure_datapath(struct device *dev, bool oneshot,
 {
 	struct max96724 *priv = dev_get_drvdata(dev);
 	unsigned int i;
+	u8 dpll_freq;
 	int err;
+
+	dpll_freq = MAX96724_DPLL_FREQ_OVERRIDE |
+		priv->csi_lane_rate_mbps / MAX96724_CSI_LANE_RATE_STEP_MBPS;
 
 	err = max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
 	err |= max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR,
@@ -410,9 +421,11 @@ static int max96724_configure_datapath(struct device *dev, bool oneshot,
 	for (i = 0; !err && i < MAX96724_MAX_PIPES; i++) {
 		u16 addr = MAX96724_DPLL_FREQ0_ADDR + 3 * i;
 
-		err = max96724_write_reg(dev, addr,
-					 MAX96724_DPLL_2000MBPS);
+		err = max96724_write_reg(dev, addr, dpll_freq);
 	}
+	if (!err)
+		dev_info(dev, "CSI TX configured at %u Mbps/lane, %u lanes\n",
+			 priv->csi_lane_rate_mbps, priv->csi_lane_count);
 
 	err |= max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR,
 				  MAX96724_MIPI_CTRL_SEL);
@@ -1370,6 +1383,30 @@ static int max96724_parse_dt(struct max96724 *priv,
 		return -EINVAL;
 	}
 	priv->link_mask = value;
+	priv->csi_lane_count = MAX96724_CSI_LANE_COUNT_DEFAULT;
+	err = of_property_read_u32(node, "csi-lane-count", &value);
+	if (!err) {
+		if (value != MAX96724_CSI_LANE_COUNT_DEFAULT) {
+			dev_warn(&client->dev,
+				 "unsupported csi-lane-count %u, using %u lanes\n",
+				 value, priv->csi_lane_count);
+		} else {
+			priv->csi_lane_count = value;
+		}
+	}
+	priv->csi_lane_rate_mbps = MAX96724_CSI_LANE_RATE_DEFAULT_MBPS;
+	err = of_property_read_u32(node, "csi-lane-rate-mbps", &value);
+	if (!err) {
+		if (value < MAX96724_CSI_LANE_RATE_MIN_MBPS ||
+		    value > MAX96724_CSI_LANE_RATE_MAX_MBPS ||
+		    value % MAX96724_CSI_LANE_RATE_STEP_MBPS) {
+			dev_warn(&client->dev,
+				 "invalid csi-lane-rate-mbps %u, using %u Mbps\n",
+				 value, priv->csi_lane_rate_mbps);
+		} else {
+			priv->csi_lane_rate_mbps = value;
+		}
+	}
 
 	priv->reset_gpio = devm_gpiod_get_optional(&client->dev, "reset",
 						   GPIOD_OUT_LOW);


### PR DESCRIPTION
## Recovery context

This PR delivers the exact reviewed head of #577 to `dev`.

PR #577 was approved and had entered the `dev` merge queue. Its base was changed to `dev_gmsl_merge` in error, after which GitHub merged it into that integration branch as `1521835f74062c06fa713d4d583156fa2fe58429`.

No code has changed since the approval: this PR uses the same head commit, `2157b5c488d565534ac1a1d6df4bd2364e5de8e8`. The original review and discussion remain available in #577. The same approving reviewer is requested here because GitHub does not transfer approvals between pull requests.

## Summary

- Configure the D5x FG24/MAX96724 tunnel path for 1300 Mbps/lane from D585 to MAX96717 and 1500 Mbps/lane from MAX96724 to Host, using four lanes on both CSI segments.
- Keep the device-tree lane rates, NVIDIA bandwidth value, and per-format pixel clocks consistent.
- Preserve the legacy MAX96724 2000 Mbps/lane default for overlays without an explicit output rate; the FG24 overlay explicitly selects 1500 Mbps/lane.
- Validate explicit camera input rates against firmware-reported capabilities while leaving D4xx behavior unchanged.

## Validation

- The head SHA and code diff are identical to the approved #577 revision.
- The original PR passed all JetPack 5.0.2 through 7.2 GitHub builds and the required external check.
- Hardware validation and detailed results are recorded in #577.
