### PR TITLE
dev_gmsl: [RSDEV-13503][RSDEV-13505][D585][GMSL] Add tunnel RGB-right on VC4

### DIFF
--- a/hardware/realsense/tegra234-camera-d4xx-overlay-fg24-4ch-d5xx.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-fg24-4ch-d5xx.dts
@@ -14,6 +14,7 @@
  *   VC1 = RGB    (YUY2, 1920x1080 @30fps)
  *   VC2 = IR     (Y8/Y8I/Y12I, 1280x720 @60fps)
  *   VC3 = IMU    (RAW8)
+ *   VC4 = RGB-right on D585 2C (same profiles as VC1)
  *
  * GMSL link:
  *   GMSL2 Tunnel Mode, 6 Gbps
@@ -34,7 +35,8 @@
  *   MAX96724 deser:  0x27
  *   MAX96717 ser:    0x40 (default), 0x60 (aliased)
  *   HKR camera SoC:  0x10 (def-addr)
- *   Sensor aliases:   0x1a (Depth), 0x1b (RGB), 0x1c (IR), 0x1d (IMU)
+ *   Sensor aliases:   0x1a (Depth), 0x1b (RGB), 0x1c (IR), 0x1d (IMU),
+ *                     0x1e (RGB-right)
  *
  * CSI lane properties:
  *   mipi-lane-rate-mbps = HKR-to-MAX96717 input rate per lane
@@ -66,7 +68,7 @@
 		target-path = "/";
 		__overlay__ {
 			tegra-capture-vi {
-				num-channels = <4>;
+				num-channels = <5>;
 				ports {
 					#address-cells = <1>;
 					#size-cells = <0>;
@@ -122,6 +124,19 @@
 							remote-endpoint = <&d5xx_csi_out3>;
 						};
 					};
+
+					/* VC4: RGB-right on D585 2C */
+					port@4 {
+						status = "okay";
+						reg = <4>;
+						d5xx_vi_in4: endpoint {
+							status = "okay";
+							vc-id = <4>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d5xx_csi_out4>;
+						};
+					};
 				};
 			};
 
@@ -131,8 +146,8 @@
 			 * tegra_camera_misc.parent == NULL. At STREAMON,
 			 * vi5_power_on() -> tegra_camera_emc_clk_enable() calls
 			 * dev_get_drvdata(NULL) -> NULL deref at offset 0x78 ->
-			 * kernel panic / instant reboot. The 4 modules below map
-			 * the 4 D5xx streams (Depth/RGB/IR/IMU) for bandwidth calc.
+			 * kernel panic / instant reboot. The modules below map the
+			 * D5xx streams for bandwidth calculation.
 			 */
 			tegra-camera-platform {
 				status = "okay";
@@ -183,13 +198,22 @@
 							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/d5xx@1d";
 						};
 					};
+					cam_module4: module4 {
+						badge = "d5xx_dualrgb_right";
+						position = "centerright";
+						orientation = "1";
+						cam_module4_drivernode0: drivernode0 {
+							pcl_id = "v4l2_sensor";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/d5xx@1e";
+						};
+					};
 				};
 			};
 
 			bus@0 {
 				host1x@13e00000 {
 					nvcsi@15a00000 {
-						num-channels = <4>;
+						num-channels = <5>;
 						#address-cells = <1>;
 						#size-cells = <0>;
 
@@ -308,6 +332,36 @@
 									d5xx_csi_out3: endpoint@7 {
 										status = "okay";
 										remote-endpoint = <&d5xx_vi_in3>;
+									};
+								};
+							};
+						};
+
+						/* NVCSI channel 4: RGB-right (VC4) */
+						channel@4 {
+							status = "okay";
+							reg = <4>;
+							ports {
+								status = "okay";
+								#address-cells = <1>;
+								#size-cells = <0>;
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d5xx_csi_in4: endpoint@8 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										vc-id = <4>;
+										remote-endpoint = <&d5xx_dualrgb_right_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d5xx_csi_out4: endpoint@9 {
+										status = "okay";
+										remote-endpoint = <&d5xx_vi_in4>;
 									};
 								};
 							};
@@ -565,6 +619,64 @@
 								csi-mode = "1x4";
 								st-vc = <1>;
 								vc-id = <1>;
+								num-lanes = <4>;
+							};
+						};
+
+						/* D585 2C RGB-right stream on VC4. */
+						d5xx_dualrgb_right: d5xx@1e {
+							status = "okay";
+							def-addr = <0x10>;
+							reg = <0x1e>;
+							override_reg = <0x1a>;
+							compatible = "realsense,d5xx";
+							use_sensor_mode_id = "true";
+							cam-type = "DUALRGB_RIGHT";
+							mipi-lane-rate-mbps = <1300>;
+							nvidia,gmsl-ser-device = <&ser_a>;
+							nvidia,gmsl-dser-device = <&dser>;
+
+							ports {
+								#address-cells = <1>;
+								#size-cells = <0>;
+
+								port@0 {
+									reg = <0>;
+									d5xx_dualrgb_right_out: endpoint {
+										vc-id = <4>;
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&d5xx_csi_in4>;
+									};
+								};
+							};
+
+							mode0 {
+								pixel_t = "yuv_yuyv16";
+								num_lanes = "4";
+								csi_pixel_bit_depth = "16";
+								active_w = "1920";
+								active_h = "1080";
+								tegra_sinterface = "serial_c";
+								phy_mode = "DPHY";
+								discontinuous_clk = "no";
+								cil_settletime = "0";
+								deskew_initial_enable = "false";
+								deskew_periodic_enable = "false";
+								mclk_khz = "24000";
+								pix_clk_hz = "325000000";
+								serdes_pix_clk_hz = "375000000";
+								line_length = "1920";
+								embedded_metadata_height = "1";
+							};
+
+							gmsl-link {
+								src-csi-port = "a";
+								dst-csi-port = "a";
+								serdes-csi-link = "a";
+								csi-mode = "1x4";
+								st-vc = <4>;
+								vc-id = <4>;
 								num-lanes = <4>;
 							};
 						};

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -143,6 +143,10 @@ struct ser_interface {
 /* GVD response payload size per product line */
 #define DS5_GVD_LEN_D4XX		276
 #define DS5_GVD_LEN_D5XX		606
+#define DS5_D585_DUAL_RGB_PID		0x0C07
+#define DS5_DUAL_RGB_MAX_OUTPUT_FPS	30
+/* 4-byte HWM opcode + 8-byte GVD header + skuComponent + USBVID. */
+#define DS5_GVD_USB_PID_OFFSET		0x12
 
 #define DS5_MIPI_LANE_NUMS		0x0400
 #define DS5_MIPI_LANE_DATARATE		0x0402
@@ -153,11 +157,13 @@ struct ser_interface {
 #define DS5_DEPTH_STREAM_STATUS		0x1004
 #define DS5_RGB_STREAM_STATUS		0x1008
 #define DS5_IMU_STREAM_STATUS		0x100C
+#define DS5_DUALRGB_RIGHT_STREAM_STATUS	0x1010
 #define DS5_IR_STREAM_STATUS		0x1014
 
 #define DS5_STREAM_DEPTH		0x0
 #define DS5_STREAM_RGB			0x1
 #define DS5_STREAM_IMU			0x2
+#define DS5_STREAM_DUALRGB_RIGHT		0x3
 #define DS5_STREAM_IR			0x4
 #define DS5_STREAM_STOP			0x100
 #define DS5_STREAM_START		0x200
@@ -179,6 +185,14 @@ struct ser_interface {
 #define DS5_RGB_FPS				0x402C
 #define DS5_RGB_CONTROL_STATUS 	0x402E
 #define DS5_RGB_OVERRIDE		0x403C
+
+#define DS5_DUALRGB_RIGHT_STREAM_DT	0x4060
+#define DS5_DUALRGB_RIGHT_STREAM_MD	0x4062
+#define DS5_DUALRGB_RIGHT_RES_WIDTH	0x4064
+#define DS5_DUALRGB_RIGHT_RES_HEIGHT	0x4068
+#define DS5_DUALRGB_RIGHT_FPS		0x406C
+#define DS5_DUALRGB_RIGHT_OVERRIDE	0x407C
+#define DS5_DUALRGB_RIGHT_CONTROL_STATUS	0x407E
 
 /* SerDes startup I2C readiness polling (defer probe if not responsive) */
 #define DS5_SERDES_STARTUP_TIMEOUT_MS 2000
@@ -254,6 +268,7 @@ struct ser_interface {
 #define DS5_DEPTH_CONFIG_STATUS		0x4800
 #define DS5_RGB_CONFIG_STATUS		0x4802
 #define DS5_IMU_CONFIG_STATUS		0x4804
+#define DS5_DUALRGB_RIGHT_CONFIG_STATUS	0x4806
 #define DS5_IR_CONFIG_STATUS		0x4808
 
 #define DS5_STATUS_STREAMING		0x1
@@ -599,7 +614,7 @@ struct ds5 {
 	struct regmap *regmap;
 	struct regulator *vcc;
 	const struct ds5_variant *variant;
-	int is_depth, is_y8, is_rgb, is_imu;
+	int is_depth, is_y8, is_rgb, is_dualrgb_right, is_imu;
 	bool metadata_enabled;
 	int aggregated;
 	int reset_ref_ds5;
@@ -645,6 +660,8 @@ struct ds5_dev {
 	* read still returns 0.
 	*/
 	u16 cached_device_type;
+	u16 product_pid;
+	bool product_pid_valid;
 
 	/* Timestamp (jiffies) of last completed HW reset.
 	* Used to enforce DS5_HW_RESET_COOLDOWN_MS between consecutive resets
@@ -669,8 +686,27 @@ struct ds5_dev {
 	bool depth_streaming;
 	bool ir_streaming;
 	bool rgb_streaming;
+	bool dualrgb_right_streaming;
 	bool imu_streaming;
 };
+
+static bool ds5_is_dual_rgb_2c(const struct ds5 *state)
+{
+	return state->ds5_dev &&
+		READ_ONCE(state->ds5_dev->product_pid_valid) &&
+		READ_ONCE(state->ds5_dev->product_pid) == DS5_D585_DUAL_RGB_PID;
+}
+
+static bool ds5_is_dual_rgb_tdm_image(const struct ds5 *state)
+{
+	return ds5_is_dual_rgb_2c(state) &&
+		(state->is_depth || state->is_y8 || state->is_rgb);
+}
+
+static bool ds5_is_dualrgb_left(const struct ds5 *state)
+{
+	return state->is_rgb && !state->is_dualrgb_right;
+}
 
 #ifdef CONFIG_VIDEO_D4XX_SERDES
 static DEFINE_MUTEX(serdes_lock__);
@@ -748,6 +784,7 @@ static const struct dser_interface max96712_interface = {
 
 static const struct dser_interface max96724_interface = {
 	.get_available_pipe_id = max96724_get_available_pipe_id,
+	.get_multi_vc_pipe_id = max96724_get_multi_vc_pipe_id,
 	.bind_ser_to_dser_pipe = max96724_bind_ser_to_dser_pipe,
 	.set_pipe = max96724_set_pipe,
 	.release_pipe = max96724_release_pipe,
@@ -1786,6 +1823,9 @@ static const char *ds5_get_sensor_name(struct ds5 *state)
 	static const char *sensor_name[] = {"unknown", "RGB", "DEPTH", "Y8", "IMU"};
 	int sensor_id = state->is_rgb * 1 + state->is_depth * 2 + \
 			state->is_y8 * 3 + state->is_imu * 4;
+
+	if (state->is_dualrgb_right)
+		return "DUALRGB_RIGHT";
 	if (sensor_id >= (sizeof(sensor_name)/sizeof(*sensor_name)))
 		sensor_id = 0;
 
@@ -1906,6 +1946,7 @@ static int ds5_sensor_enum_frame_interval(struct v4l2_subdev *sd,
 #endif
 		struct v4l2_subdev_frame_interval_enum *fie)
 {
+	struct ds5 *ds5_state = v4l2_get_subdevdata(sd);
 	struct ds5_sensor *sensor = container_of(sd, struct ds5_sensor, sd);
 	const struct ds5_format *fmt;
 	const struct ds5_resolution *res;
@@ -1926,6 +1967,9 @@ static int ds5_sensor_enum_frame_interval(struct v4l2_subdev *sd,
 		return -EINVAL;
 
 	if (fie->index >= res->n_framerates)
+		return -EINVAL;
+	if (ds5_is_dual_rgb_tdm_image(ds5_state) &&
+	    res->framerates[fie->index] > DS5_DUAL_RGB_MAX_OUTPUT_FPS)
 		return -EINVAL;
 
 	fie->interval.numerator = 1;
@@ -2223,6 +2267,14 @@ static int ds5_configure(struct ds5 *state)
 		fps_addr = DS5_DEPTH_FPS;
 		width_addr = DS5_DEPTH_RES_WIDTH;
 		height_addr = DS5_DEPTH_RES_HEIGHT;
+	} else if (state->is_dualrgb_right) {
+		sensor = &state->rgb.sensor;
+		dt_addr = DS5_DUALRGB_RIGHT_STREAM_DT;
+		md_addr = DS5_DUALRGB_RIGHT_STREAM_MD;
+		override_addr = DS5_DUALRGB_RIGHT_OVERRIDE;
+		fps_addr = DS5_DUALRGB_RIGHT_FPS;
+		width_addr = DS5_DUALRGB_RIGHT_RES_WIDTH;
+		height_addr = DS5_DUALRGB_RIGHT_RES_HEIGHT;
 	} else if (state->is_rgb) {
 		sensor = &state->rgb.sensor;
 		dt_addr = DS5_RGB_STREAM_DT;
@@ -2329,7 +2381,8 @@ static int ds5_configure(struct ds5 *state)
 				sensor->pipe_id, data_type1, data_type2, vc_id);
 	}
 #else /* Non-SERDES configuration */
-	vc_id = (state->is_depth) ? 0 : (state->is_rgb) ? 1 : (state->is_y8) ? 2 : 3;
+	vc_id = state->is_depth ? 0 : state->is_dualrgb_right ? 4 :
+		state->is_rgb ? 1 : state->is_y8 ? 2 : 3;
 #endif
 
 	/* Determine desired data-type (special cases for depth/IR), then write
@@ -2448,6 +2501,7 @@ static int ds5_sensor_s_frame_interval(struct v4l2_subdev *sd,
 #endif
 		struct v4l2_subdev_frame_interval *fi)
 {
+	struct ds5 *ds5_state = v4l2_get_subdevdata(sd);
 	struct ds5_sensor *sensor = container_of(sd, struct ds5_sensor, sd);
 	u16 framerate = 1;
 
@@ -2455,6 +2509,9 @@ static int ds5_sensor_s_frame_interval(struct v4l2_subdev *sd,
 		return -EINVAL;
 
 	framerate = fi->interval.denominator / fi->interval.numerator;
+	if (ds5_is_dual_rgb_tdm_image(ds5_state) &&
+	    framerate > DS5_DUAL_RGB_MAX_OUTPUT_FPS)
+		return -EINVAL;
 	framerate = __ds5_probe_framerate(sensor->config.resolution, framerate);
 	sensor->config.framerate = framerate;
 	fi->interval.numerator = 1;
@@ -2823,6 +2880,7 @@ static void ds5_reset_streaming_flags(struct ds5_dev *ds5_dev)
 	ds5_dev->depth_streaming = false;
 	ds5_dev->ir_streaming = false;
 	ds5_dev->rgb_streaming = false;
+	ds5_dev->dualrgb_right_streaming = false;
 	ds5_dev->imu_streaming = false;
 	mutex_unlock(&ds5_dev->lock);
 }
@@ -2895,6 +2953,7 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	struct hwm_cmd reset_cmd;
 	bool depth_streaming;
 	bool rgb_streaming;
+	bool dualrgb_right_streaming;
 	bool ir_streaming;
 	bool imu_streaming;
 	unsigned long ds5_last_reset_jiffies = READ_ONCE(state->ds5_dev->last_reset_jiffies);
@@ -2936,6 +2995,7 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	mutex_lock(&state->ds5_dev->lock);
 	depth_streaming = state->ds5_dev->depth_streaming;
 	rgb_streaming = state->ds5_dev->rgb_streaming;
+	dualrgb_right_streaming = state->ds5_dev->dualrgb_right_streaming;
 	ir_streaming = state->ds5_dev->ir_streaming;
 	imu_streaming = state->ds5_dev->imu_streaming;
 	mutex_unlock(&state->ds5_dev->lock);
@@ -2944,6 +3004,9 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 		ds5_write(state, DS5_START_STOP_STREAM,	DS5_STREAM_STOP | DS5_STREAM_DEPTH);
 	if (rgb_streaming)
 		ds5_write(state, DS5_START_STOP_STREAM,	DS5_STREAM_STOP | DS5_STREAM_RGB);
+	if (dualrgb_right_streaming)
+		ds5_write(state, DS5_START_STOP_STREAM,
+			  DS5_STREAM_STOP | DS5_STREAM_DUALRGB_RIGHT);
 	if (ir_streaming)
 		ds5_write(state, DS5_START_STOP_STREAM,	DS5_STREAM_STOP | DS5_STREAM_IR);
 	if (imu_streaming)
@@ -3609,6 +3672,48 @@ static int ds5_gvd(struct ds5 *state, unsigned char *data, u32 buf_len)
 	ds5_raw_read_with_check(state, DS5_HWMC_DATA, data, length); /* Read response data */
 
 	return 0;
+}
+
+static int ds5_cache_product_pid(struct ds5 *state)
+{
+	unsigned char *data;
+	u16 pid;
+	int ret = 0;
+
+	if (READ_ONCE(state->ds5_dev->product_pid_valid))
+		return 0;
+
+	data = kzalloc(DS5_GVD_LEN_D5XX, GFP_KERNEL);
+	if (!data)
+		return -ENOMEM;
+
+	mutex_lock(&state->ds5_dev->lock);
+	if (state->ds5_dev->product_pid_valid)
+		goto unlock;
+
+	ret = ds5_gvd(state, data, DS5_GVD_LEN_D5XX);
+	if (ret)
+		goto unlock;
+	if (data[0] != 0x10 || data[1] || data[2] || data[3]) {
+		ret = -EPROTO;
+		goto unlock;
+	}
+
+	pid = data[DS5_GVD_USB_PID_OFFSET] |
+		((u16)data[DS5_GVD_USB_PID_OFFSET + 1] << 8);
+	if (!pid) {
+		ret = -ENODATA;
+		goto unlock;
+	}
+
+	state->ds5_dev->product_pid = pid;
+	state->ds5_dev->product_pid_valid = true;
+	dev_info(&state->client->dev, "D5xx GVD product PID: 0x%04x\n", pid);
+
+unlock:
+	mutex_unlock(&state->ds5_dev->lock);
+	kfree(data);
+	return ret;
 }
 
 static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
@@ -4361,6 +4466,8 @@ static void ds5_init_ds5_dev(struct ds5 *state, struct ds5_dev *ds5_dev)
 	ds5_dev->ds5_primary = state;
 	ds5_dev->serdes_setup_complete = false;
 	ds5_dev->cached_device_type = DS5_DEVICE_TYPE_UNKNOWN;
+	ds5_dev->product_pid = 0;
+	ds5_dev->product_pid_valid = false;
 	mutex_unlock(&ds5_dev->lock);
 	ds5_reset_streaming_flags(ds5_dev);
 }
@@ -5332,6 +5439,7 @@ static int ds5_sensor_init(struct i2c_client *c, struct ds5 *state,
 	char suffix = dpdata->suffix;
 #endif
 	sensor->pipe_id = PIPE_NOT_CONFIGURED;
+	ds5_config_cache_clear(sensor);
 	v4l2_i2c_subdev_init(sd, c, ops);
 	// See tegracam_v4l2.c tegracam_v4l2subdev_register()
 	// Set owner to NULL so we can unload the driver module
@@ -5814,6 +5922,9 @@ static int ds5_mux_s_frame_interval(struct v4l2_subdev *sd,
 	sensor = ds5_state->mux.last_set;
 
 	framerate = fi->interval.denominator / fi->interval.numerator;
+	if (ds5_is_dual_rgb_tdm_image(ds5_state) &&
+	    framerate > DS5_DUAL_RGB_MAX_OUTPUT_FPS)
+		return -EINVAL;
 	framerate = __ds5_probe_framerate(sensor->config.resolution, framerate);
 	sensor->config.framerate = framerate;
 	fi->interval.numerator = 1;
@@ -5884,6 +5995,12 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		stream_id = DS5_STREAM_DEPTH;
 		vc_id = 0;
 		streaming_flag = &state->ds5_dev->depth_streaming;
+	} else if (state->is_dualrgb_right) {
+		config_status_base = DS5_DUALRGB_RIGHT_CONFIG_STATUS;
+		stream_status_base = DS5_DUALRGB_RIGHT_STREAM_STATUS;
+		stream_id = DS5_STREAM_DUALRGB_RIGHT;
+		vc_id = 4;
+		streaming_flag = &state->ds5_dev->dualrgb_right_streaming;
 	} else if (state->is_rgb) {
 		config_status_base = DS5_RGB_CONFIG_STATUS;
 		stream_status_base = DS5_RGB_STREAM_STATUS;
@@ -5994,6 +6111,7 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 	 * so the flush cannot truncate a sibling's in-flight frames. */
 	if (on && !(state->ds5_dev->depth_streaming ||
 		    state->ds5_dev->rgb_streaming ||
+		    state->ds5_dev->dualrgb_right_streaming ||
 		    state->ds5_dev->ir_streaming ||
 		    state->ds5_dev->imu_streaming))
 		state->ds5_dev->link_flush_pending = true;
@@ -6404,7 +6522,7 @@ static int ds5_mux_init(struct i2c_client *c, struct ds5 *state)
 #endif
 		state->mux.last_set = &state->depth.sensor;
 	}
-	else if (state->is_rgb) {
+	else if (ds5_is_dualrgb_left(state)) {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 20, 0)
 		v4l2_ctrl_add_handler(&state->ctrls.handler,
 					&state->ctrls.handler_rgb, NULL);
@@ -6414,6 +6532,8 @@ static int ds5_mux_init(struct i2c_client *c, struct ds5 *state)
 #endif
 		state->mux.last_set = &state->rgb.sensor;
 	}
+	else if (state->is_dualrgb_right)
+		state->mux.last_set = &state->rgb.sensor;
 	else if (state->is_y8) {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 20, 0)
 		v4l2_ctrl_add_handler(&state->ctrls.handler,
@@ -7462,6 +7582,7 @@ static int ds5_probe(struct i2c_client *c
 	state->is_depth = 0;
 	state->is_y8 = 0;
 	state->is_rgb = 0;
+	state->is_dualrgb_right = 0;
 	state->is_imu = 0;
 #ifdef CONFIG_OF
 	ret = of_property_read_string(c->dev.of_node, "cam-type", &str);
@@ -7475,10 +7596,13 @@ static int ds5_probe(struct i2c_client *c
 		state->control_base = DS5_DEPTH_CONTROL_BASE;
 		state->control_status_reg = DS5_DEPTH_CONTROL_STATUS;
 	}
-	if (!ret && !strncmp(str, "RGB", strlen("RGB"))) {
+	if (!ret && (!strncmp(str, "RGB", strlen("RGB")) ||
+		     !strncmp(str, "DUALRGB_", strlen("DUALRGB_")))) {
 		state->is_rgb = 1;
+		state->is_dualrgb_right = !strcmp(str, "DUALRGB_RIGHT");
 		state->control_base = DS5_RGB_CONTROL_BASE;
-		state->control_status_reg = DS5_RGB_CONTROL_STATUS;
+		state->control_status_reg = state->is_dualrgb_right ?
+			DS5_DUALRGB_RIGHT_CONTROL_STATUS : DS5_RGB_CONTROL_STATUS;
 	}
 	if (!ret && !strncmp(str, "IMU", strlen("IMU"))) {
 		state->is_imu = 1;
@@ -7545,6 +7669,20 @@ static int ds5_probe(struct i2c_client *c
 		dev_err(&c->dev,
 			"%s(): device type is not valid: %d (last val 0x%x)\n",
 			__func__, ret, rec_state);
+		goto e_chardev;
+	}
+
+	if (rec_state == DS5_DEVICE_TYPE_D58X) {
+		ret = ds5_cache_product_pid(state);
+		if (ret < 0)
+			dev_warn(&c->dev, "%s(): failed to read product PID: %d\n",
+				 __func__, ret);
+	}
+	if (state->is_dualrgb_right &&
+	    (ret < 0 || !ds5_is_dual_rgb_2c(state))) {
+		dev_info(&c->dev, "%s(): RGB-right is not present on this product\n",
+			 __func__);
+		ret = -ENODEV;
 		goto e_chardev;
 	}
 

--- a/nvidia-oot/max96724.c
+++ b/nvidia-oot/max96724.c
@@ -973,6 +973,23 @@ int max96724_get_available_pipe_id(struct device *dev, int vc_id)
 }
 EXPORT_SYMBOL(max96724_get_available_pipe_id);
 
+int max96724_get_multi_vc_pipe_id(struct device *dev, int vc_id)
+{
+	struct max96724 *priv = dev_get_drvdata(dev);
+
+	if (vc_id < 0 || vc_id >= 8)
+		return -EINVAL;
+
+	/* This driver exposes the single Link-A tunnel used by D5x. The tunnel
+	 * preserves every VC in one packet stream, so logical VCs share PIPE_X. */
+	mutex_lock(&priv->lock);
+	priv->pipe[MAX96724_PIPE_X].st_count++;
+	mutex_unlock(&priv->lock);
+
+	return MAX96724_PIPE_X;
+}
+EXPORT_SYMBOL(max96724_get_multi_vc_pipe_id);
+
 int max96724_release_pipe(struct device *dev, int pipe_id)
 {
 	struct max96724 *priv = dev_get_drvdata(dev);
@@ -982,7 +999,15 @@ int max96724_release_pipe(struct device *dev, int pipe_id)
 		return -EINVAL;
 
 	mutex_lock(&priv->lock);
-	priv->pipe[pipe_id].st_count = 0;
+	if (!priv->pipe[pipe_id].st_count) {
+		mutex_unlock(&priv->lock);
+		return -EINVAL;
+	}
+	priv->pipe[pipe_id].st_count--;
+	if (priv->pipe[pipe_id].st_count) {
+		mutex_unlock(&priv->lock);
+		return 0;
+	}
 	priv->retriggered_pipe_mask &= ~BIT(pipe_id);
 	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
 		if (priv->pipe[i].st_count)
@@ -1145,16 +1170,6 @@ void max96724_retrigger_datapath(struct device *dev)
 		msleep(20);
 	}
 
-	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
-		struct pipe_ctx *pipe = &priv->pipe[i];
-
-		if (!(retrigger_mask & BIT(i)) || !pipe->st_count ||
-		    !pipe->map_configured)
-			continue;
-		err |= __max96724_set_pipe(dev, i, pipe->dt_type,
-					   pipe->dt_type2, pipe->vc_id);
-	}
-
 	if (!err) {
 		if (full_retrigger)
 			err = max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR,
@@ -1206,7 +1221,7 @@ EXPORT_SYMBOL(max96724_init_settings);
 int max96724_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
 				   int ser_pipe_id, u32 vc_id)
 {
-	/* In Tunnel Mode, pipe mapping is 1:1 (each camera → one pipe) */
+	/* Tunnel mode forwards the complete CSI packet stream unchanged. */
 	return 0;
 }
 EXPORT_SYMBOL(max96724_bind_ser_to_dser_pipe);
@@ -1214,11 +1229,7 @@ EXPORT_SYMBOL(max96724_bind_ser_to_dser_pipe);
 int max96724_set_pipe(struct device *dev, int pipe_id,
 		      u8 data_type1, u8 data_type2, u32 vc_id)
 {
-	struct max96724 *priv = dev_get_drvdata(dev);
-	int err = 0;
-
-	if (pipe_id < 0 || pipe_id >= MAX96724_MAX_PIPES ||
-	    vc_id >= MAX96724_MAX_PIPES) {
+	if (pipe_id < 0 || pipe_id >= MAX96724_MAX_PIPES) {
 		dev_info(dev, "%s: input pipe_id: %d exceeds max96724 max pipes\n",
 			 __func__, pipe_id);
 		return -EINVAL;
@@ -1226,14 +1237,7 @@ int max96724_set_pipe(struct device *dev, int pipe_id,
 
 	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
 		__func__, pipe_id, data_type1, data_type2, vc_id);
-
-	mutex_lock(&priv->lock);
-
-	err = __max96724_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
-
-	mutex_unlock(&priv->lock);
-
-	return err;
+	return 0;
 }
 EXPORT_SYMBOL(max96724_set_pipe);
 

--- a/nvidia-oot/max96724.h
+++ b/nvidia-oot/max96724.h
@@ -41,6 +41,7 @@
  */
 
 int max96724_get_available_pipe_id(struct device *dev, int vc_id);
+int max96724_get_multi_vc_pipe_id(struct device *dev, int vc_id);
 int max96724_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
 		      u8 data_type2, u32 vc_id);
 int max96724_release_pipe(struct device *dev, int pipe_id);


### PR DESCRIPTION
## Summary

Port the D5x tunnel-mode RGB-right support from #576 onto `dev_gmsl_merge`.

- add the D585 2C RGB-right control path and expose it on CSI VC4
- keep the existing VC0 Depth, VC1 RGB, VC2 IR, and VC3 IMU mapping unchanged
- gate RGB-right by the D585 2C product PID so 3C products do not expose or fall back to a second RGB stream
- enforce the 2C image-stream ceiling of 30 FPS in the kernel-enumerated profiles
- allow the MAX96724 Link-A tunnel to share one physical pipe across logical VCs with reference-counted lifetime
- append the VC4 VI/NVCSI endpoint only in the D5x FG24 tunnel overlay

The change does not modify the MAX96712 path, pixel-mode overlays, or generic VI/NVCSI implementation.

## Compatibility

The branch is based directly on `dev_gmsl_merge`. A three-way merge check against PR #592 reports a clean automatic merge; stacking is not required.

On the Jetson67 3C device (PID `0x0c08`), the deployed driver rejected the `DUALRGB_RIGHT` instance with `-ENODEV` and preserved the existing node mapping:

| Stream | VC | Live node |
| --- | ---: | --- |
| Depth | 0 | `/dev/video0` |
| Depth metadata | 0 | `/dev/video1` |
| RGB | 1 | `/dev/video2` |
| RGB metadata | 1 | `/dev/video3` |
| IR | 2 | `/dev/video4` |
| IR metadata | 2 | `/dev/video5` |
| IMU | 3 | `/dev/video6` |

For D585 2C, RGB-right is added on VC4 after the existing channels. Numeric `/dev/videoN` values are registration-order details rather than a stable userspace ABI; userspace should resolve the stable RealSense links or media entities.

## Validation

- JP6.2.2 full clean build passed for kernel `5.15.185-tegra`
- full rootfs package built from commit `6ca0568`
- deployed to Jetson67 and rebooted successfully
- `orin-gmsl verify --require-loaded` passed
- installed Image, DTB, D5x DTBO, and module hashes match the package
- `d4xx`, `max96717`, and `max96724` loaded with matching vermagic
- 3C live probe registered only Depth, RGB, IR, and IMU; RGB-right was not exposed
