### PR TITLE
dev_gmsl: [GMSL][Build] Reject stale generated patch trees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,8 @@ CI runs these three steps for each JetPack version (see `.github/workflows/build
 ```
 The `--one-cam`/`--dual-cam` options only apply to JetPack 5.0.2. The target version comes from the `jetpack_version` file (written by `setup_workspace.sh`), not an argv. **Non-interactive:** `apply_patches.sh` prompts via `read` when a sub-repo has local changes and, under `set -e`, aborts (rc=1) on EOF — pipe confirmations with `yes '' | ./apply_patches.sh [reset]` when running headless.
 
+The `sources_<version>` directories are generated trees tied to the current branch and patch inputs. Patch application records their fingerprint in `.rs-patch-state`, and `build_all.sh` verifies it before compiling. After a branch switch, PR checkout, rebase, or edit to a patch/shared driver input, run `./apply_patches.sh reset` followed by `./apply_patches.sh`. `build_all.sh --clean` removes build artifacts but does not replay patches, so it cannot refresh stale generated sources.
+
 ### Deploy to Jetson
 
 `scripts/deploy_kernel.sh` is the deploy path for **all** JetPack versions (there is no `deploy_kernel_6.2.sh`). It packages the modules, copies them to the target, updates `/boot/<REMOTE_BOOT_FOLDER>` and reboots:
@@ -128,6 +130,7 @@ The build system cross-compiles for ARM64. Toolchains vary by JetPack:
 
 - `master` — primary/release branch
 - `dev` — active development branch; **default target for all PRs**
+- `dev_gmsl_merge` — temporary GMSL integration baseline forked from `dev`; use it only when explicitly stacking independently reviewed GMSL changes for combined conflict detection and regression before promotion to `dev`
 - CI builds run on pushes to `master` and `dev`, and on all PRs
 
 ## V4L2 control conventions

--- a/apply_patches.sh
+++ b/apply_patches.sh
@@ -176,4 +176,7 @@ if [[ "$ACTION" = "apply" ]]; then
     if [[ -d "${BUILD_SRCS}/hardware/nvidia/platform/t19x/galen/kernel-dts" ]]; then
         git -C "${BUILD_SRCS}/hardware/nvidia/platform/t19x/galen/kernel-dts" commit -m "RS patched" || true
     fi
+
+    "${PWD}/scripts/patch-state.sh" record "${PWD}" "${PWD}/${BUILD_SRCS}" \
+        "${JP_INPUT_VERSION}" "${JETPACK_VERSION}" "${KERNEL_DIR}" "${D4XX_SRC_DST}"
 fi

--- a/apply_patches_ext.sh
+++ b/apply_patches_ext.sh
@@ -70,3 +70,6 @@ elif [[ "$JETPACK_VERSION" == "5.x" ]]; then
     cp nvidia-oot/max96724.h "$TARGET/kernel/nvidia/include/media/"
     cp nvidia-oot/max96724.c "$TARGET/kernel/nvidia/drivers/media/i2c/"
 fi
+
+"${PWD}/scripts/patch-state.sh" record "${PWD}" "$(realpath "$TARGET")" \
+    "${JP_INPUT_VERSION}" "${JETPACK_VERSION}" "${KERNEL_DIR}" "${D4XX_SRC_DST}"

--- a/build_all.sh
+++ b/build_all.sh
@@ -38,6 +38,15 @@ if [[ -n "$2" ]]; then
     BUILD_SRCS=$(realpath $2)
 fi
 
+if version_lt "$JETPACK_VERSION" "6.0"; then
+    D4XX_SRC_DST=kernel/nvidia
+else
+    D4XX_SRC_DST=nvidia-oot
+fi
+
+"$DEVDIR/scripts/patch-state.sh" verify "$DEVDIR" "$BUILD_SRCS" \
+    "$JP_INPUT_VERSION" "$JETPACK_VERSION" "$KERNEL_DIR" "$D4XX_SRC_DST"
+
 if [[ $(uname -m) == aarch64 ]]; then
     echo
     echo Native build

--- a/scripts/patch-state.sh
+++ b/scripts/patch-state.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ACTION=${1:?record or verify is required}
+REPO_ROOT=${2:?repository root is required}
+BUILD_ROOT=${3:?generated source root is required}
+JP_INPUT_VERSION=${4:?JetPack version is required}
+JP_FAMILY=${5:?JetPack family is required}
+KERNEL_DIR=${6:?kernel source directory is required}
+DRIVER_SRC_DST=${7:?driver source directory is required}
+STATE_FILE="$BUILD_ROOT/.rs-patch-state"
+
+declare -a PATCH_MAP=()
+PATCH_MAP+=("$REPO_ROOT/$DRIVER_SRC_DST/$JP_INPUT_VERSION|$BUILD_ROOT/$DRIVER_SRC_DST")
+PATCH_MAP+=("$REPO_ROOT/$KERNEL_DIR/$JP_INPUT_VERSION|$BUILD_ROOT/$KERNEL_DIR")
+
+case "$JP_FAMILY" in
+	5.x)
+		PATCH_MAP+=("$REPO_ROOT/hardware/nvidia/platform/t19x/galen/kernel-dts/$JP_FAMILY|$BUILD_ROOT/hardware/nvidia/platform/t19x/galen/kernel-dts")
+		;;
+	6.x)
+		PATCH_MAP+=("$REPO_ROOT/hardware/nvidia/t23x/nv-public/$JP_FAMILY|$BUILD_ROOT/hardware/nvidia/t23x/nv-public")
+		;;
+esac
+
+hash_file()
+{
+	local root=$1
+	local file=$2
+
+	if [[ -f "$file" ]]; then
+		printf 'file=%s\n' "${file#$root/}"
+		sha256sum "$file" | awk '{print $1}'
+	else
+		printf 'missing=%s\n' "${file#$root/}"
+	fi
+}
+
+hash_patch_inputs()
+{
+	local mapping patch_dir patch file
+	local -a shared_inputs=(
+		"$REPO_ROOT/apply_patches.sh"
+		"$REPO_ROOT/apply_patches_ext.sh"
+		"$REPO_ROOT/build_all.sh"
+		"$REPO_ROOT/scripts/patch-state.sh"
+		"$REPO_ROOT/scripts/setup-common"
+		"$REPO_ROOT/kernel/realsense/d4xx.c"
+		"$REPO_ROOT/kernel/nvidia/max96712.h"
+		"$REPO_ROOT/nvidia-oot/max96712.h"
+		"$REPO_ROOT/nvidia-oot/max96717.c"
+		"$REPO_ROOT/nvidia-oot/max96717.h"
+		"$REPO_ROOT/nvidia-oot/max96724.c"
+		"$REPO_ROOT/nvidia-oot/max96724.h"
+	)
+
+	{
+		printf 'jp=%s\nfamily=%s\n' "$JP_INPUT_VERSION" "$JP_FAMILY"
+		for mapping in "${PATCH_MAP[@]}"; do
+			patch_dir=${mapping%%|*}
+			if [[ ! -d "$patch_dir" ]]; then
+				printf 'missing-patch-dir=%s\n' "${patch_dir#$REPO_ROOT/}"
+				continue
+			fi
+			while IFS= read -r patch; do
+				hash_file "$REPO_ROOT" "$patch"
+			done < <(find -L "$patch_dir" -maxdepth 1 -type f -name '*.patch' | sort)
+		done
+
+		if [[ -d "$REPO_ROOT/hardware/realsense" ]]; then
+			while IFS= read -r file; do
+				hash_file "$REPO_ROOT" "$file"
+			done < <(
+				find "$REPO_ROOT/hardware/realsense" -maxdepth 1 -type f \
+					\( -name '*.dts' -o -name '*.dtsi' -o -name '*.dtso' \) | sort
+			)
+		fi
+
+		for file in "${shared_inputs[@]}"; do
+			hash_file "$REPO_ROOT" "$file"
+		done
+	} | sha256sum | awk '{print $1}'
+}
+
+hash_generated_sources()
+{
+	local mapping patch_dir source_dir path file
+	local -a staged_sources=(
+		"$BUILD_ROOT/$DRIVER_SRC_DST/drivers/media/i2c/d4xx.c"
+		"$BUILD_ROOT/$DRIVER_SRC_DST/drivers/media/i2c/max96717.c"
+		"$BUILD_ROOT/$DRIVER_SRC_DST/drivers/media/i2c/max96724.c"
+		"$BUILD_ROOT/$DRIVER_SRC_DST/include/media/max96712.h"
+		"$BUILD_ROOT/$DRIVER_SRC_DST/include/media/max96717.h"
+		"$BUILD_ROOT/$DRIVER_SRC_DST/include/media/max96724.h"
+	)
+
+	{
+		for mapping in "${PATCH_MAP[@]}"; do
+			patch_dir=${mapping%%|*}
+			source_dir=${mapping#*|}
+			if [[ ! -d "$patch_dir" ]]; then
+				printf 'missing-patch-dir=%s\n' "${patch_dir#$REPO_ROOT/}"
+				continue
+			fi
+			while IFS= read -r path; do
+				[[ -n "$path" ]] && hash_file "$BUILD_ROOT" "$source_dir/$path"
+			done < <(
+				find -L "$patch_dir" -maxdepth 1 -type f -name '*.patch' -print0 |
+					sort -z |
+					xargs -0 -r sed -n 's|^+++ b/||p' |
+					grep -v '^/dev/null$' | sort -u
+			)
+		done
+
+		for file in "${staged_sources[@]}"; do
+			hash_file "$BUILD_ROOT" "$file"
+		done
+	} | sha256sum | awk '{print $1}'
+}
+
+read_state_value()
+{
+	local key=$1
+	awk -F= -v key="$key" '$1 == key { sub(/^[^=]*=/, ""); print; exit }' "$STATE_FILE"
+}
+
+current_commit=$(git -C "$REPO_ROOT" rev-parse HEAD)
+current_inputs_sha=$(hash_patch_inputs)
+current_generated_sha=$(hash_generated_sources)
+
+case "$ACTION" in
+	record)
+		tmp_state="$STATE_FILE.tmp.$$"
+		{
+			printf 'schema=1\n'
+			printf 'jp=%s\n' "$JP_INPUT_VERSION"
+			printf 'top_commit=%s\n' "$current_commit"
+			printf 'inputs_sha=%s\n' "$current_inputs_sha"
+			printf 'generated_sha=%s\n' "$current_generated_sha"
+		} > "$tmp_state"
+		mv "$tmp_state" "$STATE_FILE"
+		printf 'Recorded patch state: %s\n' "$STATE_FILE"
+		;;
+	verify)
+		if [[ ! -f "$STATE_FILE" ]]; then
+			printf 'ERROR: generated sources have no patch-state record: %s\n' "$STATE_FILE" >&2
+			printf 'Run: ./apply_patches.sh reset && ./apply_patches.sh\n' >&2
+			exit 1
+		fi
+		if [[ "$(read_state_value schema)" != "1" ||
+		      "$(read_state_value jp)" != "$JP_INPUT_VERSION" ||
+		      "$(read_state_value top_commit)" != "$current_commit" ||
+		      "$(read_state_value inputs_sha)" != "$current_inputs_sha" ||
+		      "$(read_state_value generated_sha)" != "$current_generated_sha" ]]; then
+			printf 'ERROR: generated sources do not match the current branch or patch inputs.\n' >&2
+			printf 'Run: ./apply_patches.sh reset && ./apply_patches.sh\n' >&2
+			exit 1
+		fi
+		printf 'Patch state verified for JetPack %s.\n' "$JP_INPUT_VERSION"
+		;;
+	*)
+		printf 'ERROR: unsupported patch-state action: %s\n' "$ACTION" >&2
+		exit 2
+		;;
+esac


### PR DESCRIPTION
## Summary

- Record the active JetPack patch, shared-input, and generated-source fingerprints after patch application.
- Verify the recorded state before `build_all.sh` starts compiling.
- Document the required reset/replay workflow and the role of `dev_gmsl_merge`.

## Why

`sources_<version>` is a mutable generated tree. A branch switch, PR checkout, rebase, or patch edit can leave that tree on an older patch set, while `build_all.sh --clean` only removes build artifacts. The build can then succeed against sources that do not represent the checked-out branch.

`dev_gmsl_merge` is a temporary GMSL integration baseline forked from `dev`. It allows independently reviewed GMSL changes to be stacked, exposes cross-PR conflicts early, and supports combined regression before promotion to `dev`; it does not replace `dev` as the default development branch.

## Behavior

- `apply_patches.sh` and `apply_patches_ext.sh` write `.rs-patch-state` after patch staging completes.
- `build_all.sh` rejects a missing or stale state before compilation.
- Recovery is explicit: `./apply_patches.sh reset && ./apply_patches.sh`.
- The check is format-independent and contains no NV12, calibration, media-bus, or CSI data-type assumptions.

## Scope

- Build orchestration and repository guidance only.
- No driver, DTS, patch-carrier, UAPI, ABI, or runtime behavior changes.

## Verification

- `bash -n` passed for all modified scripts.
- `git diff --check` passed.
- Record/unchanged-verify test passed.
- Patch-input mismatch and generated-source mismatch were both rejected with the reset/replay instruction.
- `shellcheck` is not installed in the local environment.