### PR TITLE
Host-POC_vc_mux: dev_gmsl: [D5x][GMSL] dual-RGB VC1 mux on Host side

### DIFF
--- a/hardware/realsense/tegra234-camera-d4xx-overlay-fg24-4ch-d5xx.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-fg24-4ch-d5xx.dts
@@ -94,6 +94,8 @@
 							vc-id = <1>;
 							port-index = <2>;
 							bus-width = <4>;
+							realsense,d5xx-vc-mux-source-id = <2>;
+							realsense,d5xx-vc-mux-owner-channel = <1>;
 							remote-endpoint = <&d5xx_csi_out1>;
 						};
 					};
@@ -133,6 +135,8 @@
 							vc-id = <1>;
 							port-index = <2>;
 							bus-width = <4>;
+							realsense,d5xx-vc-mux-source-id = <4>;
+							realsense,d5xx-vc-mux-owner-channel = <1>;
 							remote-endpoint = <&d5xx_csi_out4>;
 						};
 					};

--- a/hardware/realsense/tegra234-camera-d4xx-overlay-fg24-4ch-d5xx.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-fg24-4ch-d5xx.dts
@@ -67,7 +67,7 @@
 		target-path = "/";
 		__overlay__ {
 			tegra-capture-vi {
-				num-channels = <4>;
+				num-channels = <5>;
 				ports {
 					#address-cells = <1>;
 					#size-cells = <0>;
@@ -201,13 +201,22 @@
 							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/d5xx@1d";
 						};
 					};
+					cam_module4: module4 {
+						badge = "d5xx_rgb_right";
+						position = "centerright";
+						orientation = "1";
+						cam_module4_drivernode0: drivernode0 {
+							pcl_id = "v4l2_sensor";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/d5xx@1e";
+						};
+					};
 				};
 			};
 
 			bus@0 {
 				host1x@13e00000 {
 					nvcsi@15a00000 {
-						num-channels = <4>;
+						num-channels = <5>;
 						#address-cells = <1>;
 						#size-cells = <0>;
 

--- a/hardware/realsense/tegra234-camera-d4xx-overlay-fg24-4ch-d5xx.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-fg24-4ch-d5xx.dts
@@ -14,6 +14,7 @@
  *   VC1 = RGB    (YUY2, 1920x1080 @30fps)
  *   VC2 = IR     (Y8/Y8I/Y12I, 1280x720 @60fps)
  *   VC3 = IMU    (RAW8)
+ *   VC1 = RGB-left and RGB-right on D585 2C shared-VC builds
  *
  * GMSL link:
  *   GMSL2 Tunnel Mode, 6 Gbps
@@ -120,6 +121,19 @@
 							port-index = <2>;
 							bus-width = <4>;
 							remote-endpoint = <&d5xx_csi_out3>;
+						};
+					};
+
+					/* VC1: RGB-right on D585 2C shared-VC builds */
+					port@4 {
+						status = "okay";
+						reg = <4>;
+						d5xx_vi_in4: endpoint {
+							status = "okay";
+							vc-id = <1>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d5xx_csi_out4>;
 						};
 					};
 				};
@@ -308,6 +322,36 @@
 									d5xx_csi_out3: endpoint@7 {
 										status = "okay";
 										remote-endpoint = <&d5xx_vi_in3>;
+									};
+								};
+							};
+						};
+
+						/* NVCSI channel 4: RGB-right (shared VC1) */
+						channel@4 {
+							status = "okay";
+							reg = <4>;
+							ports {
+								status = "okay";
+								#address-cells = <1>;
+								#size-cells = <0>;
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d5xx_csi_in4: endpoint@8 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										vc-id = <1>;
+										remote-endpoint = <&d5xx_dualrgb_right_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d5xx_csi_out4: endpoint@9 {
+										status = "okay";
+										remote-endpoint = <&d5xx_vi_in4>;
 									};
 								};
 							};
@@ -535,6 +579,64 @@
 										port-index = <2>;
 										bus-width = <4>;
 										remote-endpoint = <&d5xx_csi_in1>;
+									};
+								};
+							};
+
+							mode0 {
+								pixel_t = "yuv_yuyv16";
+								num_lanes = "4";
+								csi_pixel_bit_depth = "16";
+								active_w = "1920";
+								active_h = "1080";
+								tegra_sinterface = "serial_c";
+								phy_mode = "DPHY";
+								discontinuous_clk = "no";
+								cil_settletime = "0";
+								deskew_initial_enable = "false";
+								deskew_periodic_enable = "false";
+								mclk_khz = "24000";
+								pix_clk_hz = "325000000";
+								serdes_pix_clk_hz = "375000000";
+								line_length = "1920";
+								embedded_metadata_height = "1";
+							};
+
+							gmsl-link {
+								src-csi-port = "a";
+								dst-csi-port = "a";
+								serdes-csi-link = "a";
+								csi-mode = "1x4";
+								st-vc = <1>;
+								vc-id = <1>;
+								num-lanes = <4>;
+							};
+						};
+
+						/* D585 2C RGB-right stream on shared VC1. */
+						d5xx_dualrgb_right: d5xx@1e {
+							status = "okay";
+							def-addr = <0x10>;
+							reg = <0x1e>;
+							override_reg = <0x1a>;
+							compatible = "realsense,d5xx";
+							use_sensor_mode_id = "true";
+							cam-type = "DUALRGB_RIGHT";
+							mipi-lane-rate-mbps = <1300>;
+							nvidia,gmsl-ser-device = <&ser_a>;
+							nvidia,gmsl-dser-device = <&dser>;
+
+							ports {
+								#address-cells = <1>;
+								#size-cells = <0>;
+
+								port@0 {
+									reg = <0>;
+									d5xx_dualrgb_right_out: endpoint {
+										vc-id = <1>;
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&d5xx_csi_in4>;
 									};
 								};
 							};

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -2146,25 +2146,38 @@ static int serdes_get_ser_pipe_id(struct ds5 *state, int dser_pipe_id,
 static int ds5_setup_pipeline(struct ds5 *state, u8 data_type1, u8 data_type2,
 			      int pipe_id, u32 vc_id, int ser_vc_id)
 {
-	int ret = 0;
+	int ret;
 	/* ser_pipe_id depends on both the serializer and the deserializer
 	 * (see serdes_get_ser_pipe_id()). */
 	int ser_pipe_id = serdes_get_ser_pipe_id(state, pipe_id, ser_vc_id);
 
-	ret |= state->dser_ops->bind_ser_to_dser_pipe(state->dser_dev, pipe_id, ser_pipe_id,
-				state->gmsl_link);
+	ret = state->dser_ops->bind_ser_to_dser_pipe(state->dser_dev, pipe_id,
+						     ser_pipe_id, state->gmsl_link);
+	if (ret)
+		goto warn;
+
 	dev_dbg(&state->client->dev,
 			"set ser pipe %d, dser pipe %d, data_type1: 0x%x, data_type2: 0x%x, link: %u, ser_vc_id: %u, vc_id: %u\n",
 			ser_pipe_id, pipe_id, data_type1, data_type2, state->gmsl_link,
 			ser_vc_id, vc_id);
-	ret |= state->ser_ops->set_pipe(state->ser_dev, ser_pipe_id,
+	ret = state->ser_ops->set_pipe(state->ser_dev, ser_pipe_id,
 				data_type1, data_type2, ser_vc_id);
-	ret |= state->dser_ops->set_pipe(state->dser_dev, pipe_id,
-				data_type1, data_type2, state->gmsl_link, ser_vc_id);
 	if (ret)
-		dev_warn(&state->client->dev,
-			 "failed to set pipe %d, data_type1: 0x%x, data_type2: 0x%x, vc_id: %u\n",
-			 pipe_id, data_type1, data_type2, vc_id);
+		goto warn;
+
+	ret = state->dser_ops->set_pipe(state->dser_dev, pipe_id,
+				data_type1, data_type2, state->gmsl_link, ser_vc_id);
+	if (!ret)
+		return 0;
+
+	/* Keep serializer shared-VC accounting transactional with setup. */
+	if (state->ser_ops->stream_stop)
+		state->ser_ops->stream_stop(state->ser_dev, ser_vc_id);
+
+warn:
+	dev_warn(&state->client->dev,
+		 "failed to set pipe %d, data_type1: 0x%x, data_type2: 0x%x, vc_id: %u (%d)\n",
+		 pipe_id, data_type1, data_type2, vc_id, ret);
 
 	return ret;
 }
@@ -6170,6 +6183,9 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 	bool ds5_config_done = !on; /* for stop, skip config */
 	bool reset_invalidated = false;
 	bool *streaming_flag = NULL;
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+	bool serdes_pipe_configured = false;
+#endif
 	int cur_ds5 = atomic_read(ds5_get_reset_gen(state));
 
 	/* Lazy invalidation after HW or deserializer reset.
@@ -6333,6 +6349,7 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 			}
 			ds5_config_done = true;
 #ifdef CONFIG_VIDEO_D4XX_SERDES
+			serdes_pipe_configured = true;
 			ds5_flush_idle_link(state);
 #endif
 		}
@@ -6415,6 +6432,9 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 			} else {
 				sensor->pipe_id = PIPE_NOT_CONFIGURED;
 			}
+			if (serdes_pipe_configured && state->ser_ops->stream_stop)
+				state->ser_ops->stream_stop(state->ser_dev,
+							    vc_id % DS5_MAX_STREAMS);
 		}
 #endif
 		mutex_lock(&state->ds5_dev->lock);

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -162,11 +162,13 @@ struct ser_interface {
 #define DS5_DEPTH_STREAM_STATUS		0x1004
 #define DS5_RGB_STREAM_STATUS		0x1008
 #define DS5_IMU_STREAM_STATUS		0x100C
+#define DS5_DUALRGB_RIGHT_STREAM_STATUS	0x1010
 #define DS5_IR_STREAM_STATUS		0x1014
 
 #define DS5_STREAM_DEPTH		0x0
 #define DS5_STREAM_RGB			0x1
 #define DS5_STREAM_IMU			0x2
+#define DS5_STREAM_DUALRGB_RIGHT	0x3
 #define DS5_STREAM_IR			0x4
 #define DS5_STREAM_STOP			0x100
 #define DS5_STREAM_START		0x200
@@ -188,6 +190,14 @@ struct ser_interface {
 #define DS5_RGB_FPS				0x402C
 #define DS5_RGB_CONTROL_STATUS 	0x402E
 #define DS5_RGB_OVERRIDE		0x403C
+
+#define DS5_DUALRGB_RIGHT_STREAM_DT	0x4060
+#define DS5_DUALRGB_RIGHT_STREAM_MD	0x4062
+#define DS5_DUALRGB_RIGHT_RES_WIDTH	0x4064
+#define DS5_DUALRGB_RIGHT_RES_HEIGHT	0x4068
+#define DS5_DUALRGB_RIGHT_FPS		0x406C
+#define DS5_DUALRGB_RIGHT_OVERRIDE	0x407C
+#define DS5_DUALRGB_RIGHT_CONTROL_STATUS	0x407E
 
 /* SerDes startup I2C readiness polling (defer probe if not responsive) */
 #define DS5_SERDES_STARTUP_TIMEOUT_MS 2000
@@ -263,6 +273,7 @@ struct ser_interface {
 #define DS5_DEPTH_CONFIG_STATUS		0x4800
 #define DS5_RGB_CONFIG_STATUS		0x4802
 #define DS5_IMU_CONFIG_STATUS		0x4804
+#define DS5_DUALRGB_RIGHT_CONFIG_STATUS	0x4806
 #define DS5_IR_CONFIG_STATUS		0x4808
 
 #define DS5_STATUS_STREAMING		0x1
@@ -692,6 +703,7 @@ struct ds5_dev {
 	bool depth_streaming;
 	bool ir_streaming;
 	bool rgb_streaming;
+	bool dualrgb_right_streaming;
 	bool imu_streaming;
 };
 
@@ -2240,6 +2252,14 @@ static int ds5_configure(struct ds5 *state)
 		fps_addr = DS5_DEPTH_FPS;
 		width_addr = DS5_DEPTH_RES_WIDTH;
 		height_addr = DS5_DEPTH_RES_HEIGHT;
+	} else if (state->is_dualrgb_right) {
+		sensor = &state->rgb.sensor;
+		dt_addr = DS5_DUALRGB_RIGHT_STREAM_DT;
+		md_addr = DS5_DUALRGB_RIGHT_STREAM_MD;
+		override_addr = DS5_DUALRGB_RIGHT_OVERRIDE;
+		fps_addr = DS5_DUALRGB_RIGHT_FPS;
+		width_addr = DS5_DUALRGB_RIGHT_RES_WIDTH;
+		height_addr = DS5_DUALRGB_RIGHT_RES_HEIGHT;
 	} else if (state->is_rgb) {
 		sensor = &state->rgb.sensor;
 		dt_addr = DS5_RGB_STREAM_DT;
@@ -2348,7 +2368,8 @@ static int ds5_configure(struct ds5 *state)
 				sensor->pipe_id, data_type1, data_type2, vc_id);
 	}
 #else /* Non-SERDES configuration */
-	vc_id = (state->is_depth) ? 0 : (state->is_rgb) ? 1 : (state->is_y8) ? 2 : 3;
+	vc_id = state->is_depth ? 0 : state->is_dualrgb_right ? 4 :
+		state->is_rgb ? 1 : state->is_y8 ? 2 : 3;
 	md_vc = vc_id;
 #endif
 
@@ -2776,6 +2797,7 @@ static bool d500_camera_is_idle_locked(struct ds5 *state)
 {
 	return !state->ds5_dev->depth_streaming &&
 	       !state->ds5_dev->rgb_streaming &&
+	       !state->ds5_dev->dualrgb_right_streaming &&
 	       !state->ds5_dev->ir_streaming &&
 	       !state->ds5_dev->imu_streaming;
 }
@@ -2976,6 +2998,7 @@ static void ds5_reset_streaming_flags(struct ds5_dev *ds5_dev)
 	ds5_dev->depth_streaming = false;
 	ds5_dev->ir_streaming = false;
 	ds5_dev->rgb_streaming = false;
+	ds5_dev->dualrgb_right_streaming = false;
 	ds5_dev->imu_streaming = false;
 	mutex_unlock(&ds5_dev->lock);
 }
@@ -3048,6 +3071,7 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	struct hwm_cmd reset_cmd;
 	bool depth_streaming;
 	bool rgb_streaming;
+	bool dualrgb_right_streaming;
 	bool ir_streaming;
 	bool imu_streaming;
 	u16 d585_product_id = READ_ONCE(state->ds5_dev->d585_product_id);
@@ -3092,6 +3116,7 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	mutex_lock(&state->ds5_dev->lock);
 	depth_streaming = state->ds5_dev->depth_streaming;
 	rgb_streaming = state->ds5_dev->rgb_streaming;
+	dualrgb_right_streaming = state->ds5_dev->dualrgb_right_streaming;
 	ir_streaming = state->ds5_dev->ir_streaming;
 	imu_streaming = state->ds5_dev->imu_streaming;
 	mutex_unlock(&state->ds5_dev->lock);
@@ -3100,6 +3125,9 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 		ds5_write(state, DS5_START_STOP_STREAM,	DS5_STREAM_STOP | DS5_STREAM_DEPTH);
 	if (rgb_streaming)
 		ds5_write(state, DS5_START_STOP_STREAM,	DS5_STREAM_STOP | DS5_STREAM_RGB);
+	if (dualrgb_right_streaming)
+		ds5_write(state, DS5_START_STOP_STREAM,
+			  DS5_STREAM_STOP | DS5_STREAM_DUALRGB_RIGHT);
 	if (ir_streaming)
 		ds5_write(state, DS5_START_STOP_STREAM,	DS5_STREAM_STOP | DS5_STREAM_IR);
 	if (imu_streaming)
@@ -6214,6 +6242,12 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		stream_id = DS5_STREAM_DEPTH;
 		vc_id = 0;
 		streaming_flag = &state->ds5_dev->depth_streaming;
+	} else if (state->is_dualrgb_right) {
+		config_status_base = DS5_DUALRGB_RIGHT_CONFIG_STATUS;
+		stream_status_base = DS5_DUALRGB_RIGHT_STREAM_STATUS;
+		stream_id = DS5_STREAM_DUALRGB_RIGHT;
+		vc_id = 4;
+		streaming_flag = &state->ds5_dev->dualrgb_right_streaming;
 	} else if (state->is_rgb) {
 		config_status_base = DS5_RGB_CONFIG_STATUS;
 		stream_status_base = DS5_RGB_STREAM_STATUS;
@@ -6320,10 +6354,11 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 	restore_val = sensor->streaming;
 	mutex_lock(&state->ds5_dev->lock);
 #ifdef CONFIG_VIDEO_D4XX_SERDES
-	/* Test before setting our own flag: all four down means the link is idle,
+	/* Test before setting our own flag: all logical streams down means the link is idle,
 	 * so the flush cannot truncate a sibling's in-flight frames. */
 	if (on && !(state->ds5_dev->depth_streaming ||
 		    state->ds5_dev->rgb_streaming ||
+		    state->ds5_dev->dualrgb_right_streaming ||
 		    state->ds5_dev->ir_streaming ||
 		    state->ds5_dev->imu_streaming))
 		state->ds5_dev->link_flush_pending = true;
@@ -7834,7 +7869,8 @@ static int ds5_probe(struct i2c_client *c
 		state->is_rgb = 1;
 		state->is_dualrgb_right = !strcmp(str, "DUALRGB_RIGHT");
 		state->control_base = DS5_RGB_CONTROL_BASE;
-		state->control_status_reg = DS5_RGB_CONTROL_STATUS;
+		state->control_status_reg = state->is_dualrgb_right ?
+			DS5_DUALRGB_RIGHT_CONTROL_STATUS : DS5_RGB_CONTROL_STATUS;
 	}
 	if (!ret && !strncmp(str, "IMU", strlen("IMU"))) {
 		state->is_imu = 1;

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -7823,7 +7823,8 @@ static int ds5_probe(struct i2c_client *c
 		state->control_base = DS5_DEPTH_CONTROL_BASE;
 		state->control_status_reg = DS5_DEPTH_CONTROL_STATUS;
 	}
-	if (!ret && !strncmp(str, "RGB", strlen("RGB"))) {
+	if (!ret && (!strncmp(str, "RGB", strlen("RGB")) ||
+		     !strcmp(str, "DUALRGB_RIGHT"))) {
 		state->is_rgb = 1;
 		state->control_base = DS5_RGB_CONTROL_BASE;
 		state->control_status_reg = DS5_RGB_CONTROL_STATUS;

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -614,6 +614,7 @@ struct ds5 {
 	struct regulator *vcc;
 	const struct ds5_variant *variant;
 	int is_depth, is_y8, is_rgb, is_imu;
+	bool is_dualrgb_right;
 	bool metadata_enabled;
 	int aggregated;
 	int reset_ref_ds5;
@@ -4743,6 +4744,10 @@ static int ds5_setup_and_link(struct ds5 *state)
 		}
 	}
 	if (NULL == state->ds5_dev) {
+		if (state->is_dualrgb_right) {
+			err = -EPROBE_DEFER;
+			goto out_unlock;
+		}
 	/* First stream instance for this camera, setup and link new DS5. */
 		for (i = 0; i < MAX_DS5_NUM; i++) {
 			bool free_slot;
@@ -7811,6 +7816,7 @@ static int ds5_probe(struct i2c_client *c
 	state->is_y8 = 0;
 	state->is_rgb = 0;
 	state->is_imu = 0;
+	state->is_dualrgb_right = false;
 #ifdef CONFIG_OF
 	ret = of_property_read_string(c->dev.of_node, "cam-type", &str);
 	if (!ret && !strncmp(str, "Depth", strlen("Depth"))) {
@@ -7826,6 +7832,7 @@ static int ds5_probe(struct i2c_client *c
 	if (!ret && (!strncmp(str, "RGB", strlen("RGB")) ||
 		     !strcmp(str, "DUALRGB_RIGHT"))) {
 		state->is_rgb = 1;
+		state->is_dualrgb_right = !strcmp(str, "DUALRGB_RIGHT");
 		state->control_base = DS5_RGB_CONTROL_BASE;
 		state->control_status_reg = DS5_RGB_CONTROL_STATUS;
 	}

--- a/nvidia-oot/6.2/0014-Pair-embedded-metadata-per-capture-descriptor.patch
+++ b/nvidia-oot/6.2/0014-Pair-embedded-metadata-per-capture-descriptor.patch
@@ -1,0 +1,197 @@
+From: RealSense <support@realsenseai.com>
+Date: Wed, 19 Aug 2026 11:20:00 +0800
+Subject: [PATCH] Pair embedded metadata per capture descriptor
+
+Allocate one page-aligned embedded-metadata DMA slot per VI capture
+descriptor.  Select the same slot at descriptor setup and buffer release so
+in-flight frames cannot overwrite each other's metadata.  Complete metadata
+with the pixel sequence and timestamp before releasing the pixel vb2 buffer.
+
+The change only adds capture_queue_depth * one-page coherent storage per
+metadata-enabled channel and does not copy pixel data.
+---
+ drivers/media/platform/tegra/camera/vi/channel.c  |  1 +
+ .../platform/tegra/camera/vi/vi5_fops.c           | 54 ++++++++++++++++++-----
+ include/media/mc_common.h                         |  1 +
+ 3 files changed, 46 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index ac5e0e9c..a270be19 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -2935,6 +2935,7 @@ int tegra_channel_cleanup_video_embedded(struct tegra_channel *chan)
+ 		dma_free_coherent(vi_unit_dev,
+ 				chan->emb_buf_size,
+ 				chan->emb_buf_addr, chan->emb_buf);
++		chan->emb_buf_stride = 0;
+ 		chan->emb_buf_size = 0;
+ 	}
+ 
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index c05f5f8f..c828daf1 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -16,6 +16,7 @@
+ #include <linux/fs.h>
+ #include <linux/kthread.h>
+ #include <linux/nvhost.h>
++#include <linux/overflow.h>
+ #include <linux/pm_runtime.h>
+ #include <linux/sched/task.h>
+ #include <linux/semaphore.h>
+@@ -437,12 +438,15 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	}
+ 
+ 	if (chan->embedded_data_height > 0) {
++		dma_addr_t emb_offset =
++			(dma_addr_t)descr_index * chan->emb_buf_stride;
++
+ 		desc->ch_cfg.embdata_enable = 1;
+ 		desc->ch_cfg.frame.embed_x = chan->embedded_data_width * BPP_MEM;
+ 		desc->ch_cfg.frame.embed_y = chan->embedded_data_height;
+ 
+ 		desc_memoryinfo->surface[VI_ATOMP_SURFACE_EMBEDDED].base_address
+-			= chan->emb_buf;
++			= chan->emb_buf + emb_offset;
+ 		desc_memoryinfo->surface[VI_ATOMP_SURFACE_EMBEDDED].size
+ 			= desc->ch_cfg.frame.embed_x * desc->ch_cfg.frame.embed_y;
+ 
+@@ -455,11 +459,15 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ }
+ 
+ static void vi5_release_metadata_buffer(struct tegra_channel *chan,
+-	struct vb2_v4l2_buffer *vbuf)
++	struct tegra_channel_buffer *buf)
+ {
+ 	struct vb2_buffer *evb = NULL;
+ 	struct vb2_v4l2_buffer *evbuf;
+-	void* frm_buffer;
++	struct vb2_v4l2_buffer *vbuf = &buf->buf;
++	void *frm_buffer;
++	void *metadata_addr;
++	unsigned int descr_index = buf->capture_descr_index[0];
++	unsigned int emb_offset;
+ 
+ 	spin_lock(&chan->embedded.spin_lock);
+ 	if (0 < chan->embedded.num_buffers) {
+@@ -476,10 +484,23 @@ static void vi5_release_metadata_buffer(struct tegra_channel *chan,
+ 		return;
+ 
+ 	frm_buffer = vb2_plane_vaddr(evb, 0);
+-	if (!frm_buffer)
++	if (!frm_buffer) {
++		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
+ 		return;
++	}
+ 
+-	memcpy(frm_buffer, chan->emb_buf_addr, D4XX_META_BUFSIZE);
++	if (!chan->emb_buf_stride ||
++		chan->emb_buf_size < D4XX_META_BUFSIZE ||
++		descr_index >= chan->capture_queue_depth ||
++		check_mul_overflow(descr_index, chan->emb_buf_stride,
++			&emb_offset) ||
++		emb_offset > chan->emb_buf_size - D4XX_META_BUFSIZE) {
++		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
++		return;
++	}
++
++	metadata_addr = (u8 *)chan->emb_buf_addr + emb_offset;
++	memcpy(frm_buffer, metadata_addr, D4XX_META_BUFSIZE);
+ 	evbuf = to_vb2_v4l2_buffer(evb);
+ 	evbuf->sequence = vbuf->sequence;
+ 	vb2_set_plane_payload(evb, 0, D4XX_META_PAYLOAD);
+@@ -496,10 +517,10 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+ 	vbuf->field = V4L2_FIELD_NONE;
+ 	vb2_set_plane_payload(&vbuf->vb2_buf, 0, chan->format.sizeimage);
+ 
+-	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);
+-
+ 	if (chan->embedded_data_height == 1 && buf->vb2_state == VB2_BUF_STATE_DONE)
+-		vi5_release_metadata_buffer(chan, vbuf);
++		vi5_release_metadata_buffer(chan, buf);
++
++	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);
+ }
+ 
+ static void vi5_capture_enqueue(struct tegra_channel *chan,
+@@ -921,6 +942,7 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 	struct device_node *node;
+ 	struct sensor_mode_properties *sensor_mode;
+ 	struct camera_common_data *s_data;
++	unsigned int emb_buf_stride = 0;
+ 	unsigned int emb_buf_size = 0;
+ 
+ 	/* Skip in bypass mode */
+@@ -944,6 +966,7 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 				if (s_data != NULL && node != NULL) {
+ 					int idx = s_data->mode_prop_idx;
+ 
++					emb_buf_stride = 0;
+ 					emb_buf_size = 0;
+ 					if (idx < s_data->sensor_props.\
+ 								num_modes) {
+@@ -958,15 +981,24 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 							sensor_mode->\
+ 							 image_properties.\
+ 						      embedded_metadata_height;
+-						/* rounding up to page size */
+-						emb_buf_size =
++						/* One DMA slot per capture descriptor. */
++						emb_buf_stride =
+ 							round_up(chan->\
+ 							embedded_data_width *
+ 								chan->\
+ 							embedded_data_height *
+ 							BPP_MEM, PAGE_SIZE);
++						if (!chan->capture_queue_depth ||
++							check_mul_overflow(emb_buf_stride,
++								chan->capture_queue_depth,
++								&emb_buf_size)) {
++							dev_err(&chan->video->dev,
++								"embedded buffer size overflow\n");
++							goto err_setup;
++						}
+ 					}
+ 				}
++				chan->emb_buf_stride = emb_buf_stride;
+ 				/* Allocate buffer for Embedded Data if need to*/
+ 				if (emb_buf_size > chan->emb_buf_size) {
+ 					struct device *vi_unit_dev;
+@@ -985,6 +1017,7 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 							chan->emb_buf_addr,
+ 							chan->emb_buf);
+ 						chan->emb_buf_size = 0;
++						chan->emb_buf_stride = 0;
+ 					}
+ 
+ 					chan->emb_buf_addr =
+@@ -998,6 +1031,7 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 						goto err_setup;
+ 					}
+ 					chan->emb_buf_size = emb_buf_size;
++					chan->emb_buf_stride = emb_buf_stride;
+ 				}
+ 			}
+ 			ret = tegra_channel_capture_setup(chan, vi_port);
+@@ -1087,6 +1121,7 @@ static int vi5_channel_stop_streaming(struct vb2_queue *vq)
+ 				dma_free_coherent(vi_unit_dev, chan->emb_buf_size,
+ 								chan->emb_buf_addr, chan->emb_buf);
+ 				chan->emb_buf_size = 0;
++				chan->emb_buf_stride = 0;
+ 			}
+ 
+ 			vi_channel_close_ex(chan->vi_channel_id[vi_port],
+diff --git a/include/media/mc_common.h b/include/media/mc_common.h
+index 9299917a..cea3ca26 100644
+--- a/include/media/mc_common.h
++++ b/include/media/mc_common.h
+@@ -295,6 +295,7 @@ struct tegra_channel {
+ 
+ 	dma_addr_t emb_buf;
+ 	void *emb_buf_addr;
++	unsigned int emb_buf_stride;
+ 	unsigned int emb_buf_size;
+ };
+ 
+-- 
+2.43.0

--- a/nvidia-oot/6.2/0015-D5xx-metadata-VC-mux-fanout.patch
+++ b/nvidia-oot/6.2/0015-D5xx-metadata-VC-mux-fanout.patch
@@ -509,7 +509,7 @@ index 02a1837f02b417eafabce82b1b158adc5414c171..a066e29282b460fecc15a54c4c96f102
  	memcpy(frm_buffer, metadata_addr, D4XX_META_BUFSIZE);
  	evbuf = to_vb2_v4l2_buffer(evb);
  	evbuf->sequence = vbuf->sequence;
-@@ -522,17 +546,266 @@ static void vi5_release_metadata_buffer(struct tegra_channel *chan,
+@@ -522,17 +546,275 @@ static void vi5_release_metadata_buffer(struct tegra_channel *chan,
  	vb2_buffer_done(evb, VB2_BUF_STATE_DONE);
  }
  
@@ -720,6 +720,15 @@ index 02a1837f02b417eafabce82b1b158adc5414c171..a066e29282b460fecc15a54c4c96f102
 +	secondary = chan->d5xx_vc_mux.secondary_chan;
 +	if (ret || (source_id != chan->d5xx_vc_mux.source_id &&
 +		    (!secondary || source_id != secondary->d5xx_vc_mux.source_id))) {
++		if (!chan->d5xx_vc_mux.invalid_metadata) {
++			u8 *metadata = vi5_metadata_addr(chan, buf);
++
++			if (metadata)
++				dev_info(chan->vi->dev,
++					 "D5xx VC mux first invalid metadata: ret=%d source=%u head=%*ph tail=%*ph\n",
++					 ret, source_id, 16, metadata, 32,
++					 metadata + D4XX_META_BUFSIZE - 32U);
++		}
 +		chan->d5xx_vc_mux.invalid_metadata++;
 +		buf->vb2_state = VB2_BUF_STATE_ERROR;
 +		goto release_owner;

--- a/nvidia-oot/6.2/0015-D5xx-metadata-VC-mux-fanout.patch
+++ b/nvidia-oot/6.2/0015-D5xx-metadata-VC-mux-fanout.patch
@@ -13,7 +13,7 @@ buffers when mux-specific start fails, preserving the videobuf2 contract.
 Signed-off-by: Shengyong Zhou <shengyong.zhou@realsenseai.com>
 
 diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
-index b5c9771c1df4d6a8dc6ad22b61bb31950f1bb254..9dd525f22f2ca6f4088bb97e5541af48fc60e020 100644
+index bd576606190a2ae9afb605ffb6eb3493ea1dd7f4..ce169f356c2fd44b2cb256dd1c08f28571f9c2cc 100644
 --- a/drivers/media/platform/tegra/camera/vi/channel.c
 +++ b/drivers/media/platform/tegra/camera/vi/channel.c
 @@ -10,6 +10,7 @@
@@ -32,7 +32,7 @@ index b5c9771c1df4d6a8dc6ad22b61bb31950f1bb254..9dd525f22f2ca6f4088bb97e5541af48
  
  #define TPG_CSI_GROUP_ID	10
  #define HDMI_IN_RATE 550000000
-@@ -1002,20 +1004,202 @@ int tegra_channel_set_power(struct tegra_channel *chan, bool on)
+@@ -1006,20 +1008,250 @@ int tegra_channel_set_power(struct tegra_channel *chan, bool on)
  }
  EXPORT_SYMBOL(tegra_channel_set_power);
  
@@ -114,6 +114,7 @@ index b5c9771c1df4d6a8dc6ad22b61bb31950f1bb254..9dd525f22f2ca6f4088bb97e5541af48
  	struct tegra_channel *chan = vb2_get_drv_priv(vq);
  	struct tegra_mc_vi *vi = chan->vi;
 +	bool dma_acquired = false;
++	bool standalone_start = false;
 +
 +	if (chan->d5xx_vc_mux.enabled && !chan->d5xx_vc_mux.owner) {
 +		struct tegra_channel *owner = chan->d5xx_vc_mux.owner_chan;
@@ -128,26 +129,43 @@ index b5c9771c1df4d6a8dc6ad22b61bb31950f1bb254..9dd525f22f2ca6f4088bb97e5541af48
 +			return d5xx_vc_mux_start_error(chan, -EPIPE);
 +		}
 +		chan->d5xx_vc_mux.stream_requested = true;
-+		/*
-+		 * The secondary source shares the owner's physical VC capture.
-+		 * Arm it when userspace starts this node, but do not tell the
-+		 * sensor to transmit until the owner VI is consuming that VC.
-+		 */
 +		if (!atomic_read(&owner->is_streaming)) {
-+			mutex_unlock(&owner->d5xx_vc_mux.copy_lock);
-+			return 0;
++			if (!owner->d5xx_vc_mux.stream_requested) {
++				mutex_unlock(&owner->d5xx_vc_mux.copy_lock);
++				usleep_range(2000, 3000);
++				mutex_lock(&owner->d5xx_vc_mux.copy_lock);
++			}
++			if (owner->d5xx_vc_mux.owner_stopping) {
++				chan->d5xx_vc_mux.stream_requested = false;
++				mutex_unlock(&owner->d5xx_vc_mux.copy_lock);
++				return d5xx_vc_mux_start_error(chan, -EPIPE);
++			}
++			/*
++			 * A single secondary node owns VI directly; a paired start
++			 * remains armed for the shared physical owner.
++			 */
++			if (!owner->d5xx_vc_mux.stream_requested) {
++				chan->d5xx_vc_mux.standalone = true;
++				standalone_start = true;
++				mutex_unlock(&owner->d5xx_vc_mux.copy_lock);
++			} else {
++				mutex_unlock(&owner->d5xx_vc_mux.copy_lock);
++				return 0;
++			}
 +		}
 +
-+		if (!d5xx_vc_mux_formats_match(owner, chan))
-+			ret = -EINVAL;
-+		else
-+			ret = d5xx_vc_mux_start_secondary_locked(owner);
-+		if (ret)
-+			chan->d5xx_vc_mux.stream_requested = false;
-+		mutex_unlock(&owner->d5xx_vc_mux.copy_lock);
-+		if (ret)
-+			return d5xx_vc_mux_start_error(chan, ret);
-+		return ret;
++		if (!standalone_start) {
++			if (!d5xx_vc_mux_formats_match(owner, chan))
++				ret = -EINVAL;
++			else
++				ret = d5xx_vc_mux_start_secondary_locked(owner);
++			if (ret)
++				chan->d5xx_vc_mux.stream_requested = false;
++			mutex_unlock(&owner->d5xx_vc_mux.copy_lock);
++			if (ret)
++				return d5xx_vc_mux_start_error(chan, ret);
++			return ret;
++		}
 +	}
 +
 +	if (chan->d5xx_vc_mux.owner) {
@@ -156,15 +174,24 @@ index b5c9771c1df4d6a8dc6ad22b61bb31950f1bb254..9dd525f22f2ca6f4088bb97e5541af48
 +		if (!chan->d5xx_vc_mux.secondary_chan)
 +			return d5xx_vc_mux_start_error(chan, -ENODEV);
 +		mutex_lock(&chan->d5xx_vc_mux.copy_lock);
++		if (chan->d5xx_vc_mux.secondary_chan->d5xx_vc_mux.standalone) {
++			mutex_unlock(&chan->d5xx_vc_mux.copy_lock);
++			return d5xx_vc_mux_start_error(chan, -EBUSY);
++		}
 +		chan->d5xx_vc_mux.owner_stopping = false;
++		chan->d5xx_vc_mux.stream_requested = true;
 +		mutex_unlock(&chan->d5xx_vc_mux.copy_lock);
 +
 +		dma_cap_zero(mask);
 +		dma_cap_set(DMA_MEMCPY, mask);
 +		chan->d5xx_vc_mux.dma_chan =
 +			dma_request_channel(mask, NULL, NULL);
-+		if (!chan->d5xx_vc_mux.dma_chan)
++		if (!chan->d5xx_vc_mux.dma_chan) {
++			mutex_lock(&chan->d5xx_vc_mux.copy_lock);
++			chan->d5xx_vc_mux.stream_requested = false;
++			mutex_unlock(&chan->d5xx_vc_mux.copy_lock);
 +			return d5xx_vc_mux_start_error(chan, -ENODEV);
++		}
 +		/*
 +		 * GPCDMA supports transfers up to 1 GiB.  Advertise that limit to
 +		 * the DMA API so the exported vb2 buffer is mapped as one IOVA
@@ -174,6 +201,9 @@ index b5c9771c1df4d6a8dc6ad22b61bb31950f1bb254..9dd525f22f2ca6f4088bb97e5541af48
 +			    chan->d5xx_vc_mux.dma_chan->device->dev, SZ_1G)) {
 +			dma_release_channel(chan->d5xx_vc_mux.dma_chan);
 +			chan->d5xx_vc_mux.dma_chan = NULL;
++			mutex_lock(&chan->d5xx_vc_mux.copy_lock);
++			chan->d5xx_vc_mux.stream_requested = false;
++			mutex_unlock(&chan->d5xx_vc_mux.copy_lock);
 +			return d5xx_vc_mux_start_error(chan, -ENODEV);
 +		}
 +
@@ -193,9 +223,18 @@ index b5c9771c1df4d6a8dc6ad22b61bb31950f1bb254..9dd525f22f2ca6f4088bb97e5541af48
  		ret = vi->fops->vi_power_on(chan);
 -		if (ret < 0)
 +		if (ret < 0) {
++			if (standalone_start) {
++				mutex_lock(&chan->d5xx_vc_mux.owner_chan->d5xx_vc_mux.copy_lock);
++				chan->d5xx_vc_mux.standalone = false;
++				chan->d5xx_vc_mux.stream_requested = false;
++				mutex_unlock(&chan->d5xx_vc_mux.owner_chan->d5xx_vc_mux.copy_lock);
++			}
 +			if (dma_acquired) {
 +				dma_release_channel(chan->d5xx_vc_mux.dma_chan);
 +				chan->d5xx_vc_mux.dma_chan = NULL;
++				mutex_lock(&chan->d5xx_vc_mux.copy_lock);
++				chan->d5xx_vc_mux.stream_requested = false;
++				mutex_unlock(&chan->d5xx_vc_mux.copy_lock);
 +				return d5xx_vc_mux_start_error(chan, ret);
 +			}
  			return ret;
@@ -203,9 +242,18 @@ index b5c9771c1df4d6a8dc6ad22b61bb31950f1bb254..9dd525f22f2ca6f4088bb97e5541af48
  
 -		return vi->fops->vi_start_streaming(vq, count);
 +		ret = vi->fops->vi_start_streaming(vq, count);
++		if (ret < 0 && standalone_start) {
++			mutex_lock(&chan->d5xx_vc_mux.owner_chan->d5xx_vc_mux.copy_lock);
++			chan->d5xx_vc_mux.standalone = false;
++			chan->d5xx_vc_mux.stream_requested = false;
++			mutex_unlock(&chan->d5xx_vc_mux.owner_chan->d5xx_vc_mux.copy_lock);
++		}
 +		if (ret < 0 && dma_acquired) {
 +			dma_release_channel(chan->d5xx_vc_mux.dma_chan);
 +			chan->d5xx_vc_mux.dma_chan = NULL;
++			mutex_lock(&chan->d5xx_vc_mux.copy_lock);
++			chan->d5xx_vc_mux.stream_requested = false;
++			mutex_unlock(&chan->d5xx_vc_mux.copy_lock);
 +		}
 +		if (!ret && chan->d5xx_vc_mux.owner) {
 +			struct tegra_channel *secondary =
@@ -237,11 +285,12 @@ index b5c9771c1df4d6a8dc6ad22b61bb31950f1bb254..9dd525f22f2ca6f4088bb97e5541af48
  	}
  	return 0;
  }
-@@ -1025,12 +1209,76 @@ static void tegra_channel_stop_streaming(struct vb2_queue *vq)
+@@ -1029,12 +1261,86 @@ static void tegra_channel_stop_streaming(struct vb2_queue *vq)
  	struct tegra_channel *chan = vb2_get_drv_priv(vq);
  	struct tegra_mc_vi *vi = chan->vi;
  
-+	if (chan->d5xx_vc_mux.enabled && !chan->d5xx_vc_mux.owner) {
++	if (chan->d5xx_vc_mux.enabled && !chan->d5xx_vc_mux.owner &&
++	    !chan->d5xx_vc_mux.standalone) {
 +		struct tegra_channel *owner = chan->d5xx_vc_mux.owner_chan;
 +
 +		if (owner)
@@ -256,6 +305,14 @@ index b5c9771c1df4d6a8dc6ad22b61bb31950f1bb254..9dd525f22f2ca6f4088bb97e5541af48
 +		if (owner)
 +			mutex_unlock(&owner->d5xx_vc_mux.copy_lock);
 +		return;
++	}
++	if (chan->d5xx_vc_mux.enabled && chan->d5xx_vc_mux.standalone) {
++		struct tegra_channel *owner = chan->d5xx_vc_mux.owner_chan;
++
++		mutex_lock(&owner->d5xx_vc_mux.copy_lock);
++		chan->d5xx_vc_mux.standalone = false;
++		chan->d5xx_vc_mux.stream_requested = false;
++		mutex_unlock(&owner->d5xx_vc_mux.copy_lock);
 +	}
 +
 +	if (chan->d5xx_vc_mux.owner) {
@@ -289,6 +346,7 @@ index b5c9771c1df4d6a8dc6ad22b61bb31950f1bb254..9dd525f22f2ca6f4088bb97e5541af48
 +	if (chan->d5xx_vc_mux.owner) {
 +		mutex_lock(&chan->d5xx_vc_mux.copy_lock);
 +		chan->d5xx_vc_mux.owner_stopping = false;
++		chan->d5xx_vc_mux.stream_requested = false;
 +		mutex_unlock(&chan->d5xx_vc_mux.copy_lock);
 +	}
 +
@@ -314,7 +372,7 @@ index b5c9771c1df4d6a8dc6ad22b61bb31950f1bb254..9dd525f22f2ca6f4088bb97e5541af48
  	/* Clean-up recorded videobuf2 queue initial timestamp */
  	queue_init_ts = 0;
  }
-@@ -2559,6 +2807,32 @@ int tegra_vi_get_port_info(struct tegra_channel *chan,
+@@ -2563,6 +2869,32 @@ int tegra_vi_get_port_info(struct tegra_channel *chan,
  				dev_err(chan->vi->dev, "num lanes error\n");
  			chan->numlanes = value;
  
@@ -347,7 +405,7 @@ index b5c9771c1df4d6a8dc6ad22b61bb31950f1bb254..9dd525f22f2ca6f4088bb97e5541af48
  			if (value > 12) {
  				dev_err(chan->vi->dev, "num lanes >12!\n");
  				return -EINVAL;
-@@ -3079,6 +3353,7 @@ int tegra_channel_init(struct tegra_channel *chan)
+@@ -3083,6 +3415,7 @@ int tegra_channel_init(struct tegra_channel *chan)
  	init_waitqueue_head(&chan->dequeue_wait);
  	spin_lock_init(&chan->dequeue_lock);
  	mutex_init(&chan->stop_kthread_lock);
@@ -355,7 +413,7 @@ index b5c9771c1df4d6a8dc6ad22b61bb31950f1bb254..9dd525f22f2ca6f4088bb97e5541af48
  	init_rwsem(&chan->reset_lock);
  	atomic_set(&chan->is_streaming, DISABLE);
  	spin_lock_init(&chan->capture_state_lock);
-@@ -3227,6 +3502,44 @@ int tegra_vi_channels_init(struct tegra_mc_vi *vi)
+@@ -3231,6 +3564,44 @@ int tegra_vi_channels_init(struct tegra_mc_vi *vi)
  		return ret;
  	}
  
@@ -401,7 +459,7 @@ index b5c9771c1df4d6a8dc6ad22b61bb31950f1bb254..9dd525f22f2ca6f4088bb97e5541af48
  }
  EXPORT_SYMBOL(tegra_vi_channels_init);
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-index 02a1837f02b417eafabce82b1b158adc5414c171..a066e29282b460fecc15a54c4c96f102b268fac5 100644
+index b078c6126f19e5ac590f5f0b7e4b4a28993988d3..b8fdd33e70e51ec2e93cf909cf1cfdeb1770132f 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 @@ -12,6 +12,9 @@
@@ -428,7 +486,7 @@ index 02a1837f02b417eafabce82b1b158adc5414c171..a066e29282b460fecc15a54c4c96f102
  
  static const struct vi_capture_setup default_setup = {
  	.channel_flags = 0
-@@ -472,27 +482,46 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -478,27 +488,46 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  		chan->capture_descr_sequence += 1;
  }
  
@@ -489,7 +547,7 @@ index 02a1837f02b417eafabce82b1b158adc5414c171..a066e29282b460fecc15a54c4c96f102
  
  	if (!evb)
  		return;
-@@ -503,17 +532,12 @@ static void vi5_release_metadata_buffer(struct tegra_channel *chan,
+@@ -509,17 +538,12 @@ static void vi5_release_metadata_buffer(struct tegra_channel *chan,
  		return;
  	}
  
@@ -509,7 +567,7 @@ index 02a1837f02b417eafabce82b1b158adc5414c171..a066e29282b460fecc15a54c4c96f102
  	memcpy(frm_buffer, metadata_addr, D4XX_META_BUFSIZE);
  	evbuf = to_vb2_v4l2_buffer(evb);
  	evbuf->sequence = vbuf->sequence;
-@@ -522,17 +546,275 @@ static void vi5_release_metadata_buffer(struct tegra_channel *chan,
+@@ -528,17 +552,275 @@ static void vi5_release_metadata_buffer(struct tegra_channel *chan,
  	vb2_buffer_done(evb, VB2_BUF_STATE_DONE);
  }
  
@@ -801,7 +859,7 @@ index 761a7cc4bdb9b5e23133443be9d634e4b48468fc..8ace6706707d8b36bab40fbe53f649a4
  
  #endif
 diff --git a/include/media/mc_common.h b/include/media/mc_common.h
-index cea3ca26bcab7e3f6113e82e16a94d84909cd66f..180ec74ee2a1aa7b7d5925ed9641e88b2806a623 100644
+index cea3ca26bcab7e3f6113e82e16a94d84909cd66f..b2a20ffd6c490a66c757f7da07065a726e8c4480 100644
 --- a/include/media/mc_common.h
 +++ b/include/media/mc_common.h
 @@ -35,6 +35,9 @@
@@ -828,7 +886,7 @@ index cea3ca26bcab7e3f6113e82e16a94d84909cd66f..180ec74ee2a1aa7b7d5925ed9641e88b
  #define to_tegra_channel_buffer(vb) \
  	container_of(vb, struct tegra_channel_buffer, buf)
  
-@@ -297,6 +307,27 @@ struct tegra_channel {
+@@ -297,6 +307,28 @@ struct tegra_channel {
  	void *emb_buf_addr;
  	unsigned int emb_buf_stride;
  	unsigned int emb_buf_size;
@@ -843,6 +901,7 @@ index cea3ca26bcab7e3f6113e82e16a94d84909cd66f..180ec74ee2a1aa7b7d5925ed9641e88b
 +		struct dma_chan *dma_chan;
 +		struct mutex copy_lock;
 +		bool stream_requested;
++		bool standalone;
 +		bool owner_stopping;
 +		struct d5xx_vc_mux_dma_map source_maps[VB2_MAX_FRAME];
 +		struct d5xx_vc_mux_dma_map secondary_maps[VB2_MAX_FRAME];

--- a/nvidia-oot/6.2/0015-D5xx-metadata-VC-mux-fanout.patch
+++ b/nvidia-oot/6.2/0015-D5xx-metadata-VC-mux-fanout.patch
@@ -1,0 +1,849 @@
+From: Shengyong Zhou <shengyong.zhou@realsenseai.com>
+Date: Sun, 23 Aug 2026 01:10:00 +0800
+Subject: [PATCH] D5xx metadata VC mux fanout
+
+Route a shared VC/DT capture by the frame-bound GMSL source identity.
+The physical owner queue remains zero-copy; the secondary normal V4L2 node
+receives one GPCDMA copy through DMA-BUF mappings without a CPU pixel copy.
+Arm a secondary source until the owner VI is active, and quiesce it before
+the physical owner stops so the shared HKR pipe cannot be left half-open.
+Allow either V4L2 node to stream on first. Return all driver-owned
+buffers when mux-specific start fails, preserving the videobuf2 contract.
+
+Signed-off-by: Shengyong Zhou <shengyong.zhou@realsenseai.com>
+
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index b5c9771c1df4d6a8dc6ad22b61bb31950f1bb254..9dd525f22f2ca6f4088bb97e5541af48fc60e020 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -10,6 +10,7 @@
+ #include <linux/bitmap.h>
+ #include <linux/clk.h>
+ #include <linux/delay.h>
++#include <linux/dmaengine.h>
+ #include <linux/nvhost.h>
+ #include <linux/lcm.h>
+ #include <linux/list.h>
+@@ -44,6 +45,7 @@
+ #include <uapi/linux/nvhost_nvcsi_ioctl.h>
+ #include "nvcsi/nvcsi.h"
+ #include "nvcsi/deskew.h"
++#include "vi5_fops.h"
+ 
+ #define TPG_CSI_GROUP_ID	10
+ #define HDMI_IN_RATE 550000000
+@@ -1002,20 +1004,202 @@ int tegra_channel_set_power(struct tegra_channel *chan, bool on)
+ }
+ EXPORT_SYMBOL(tegra_channel_set_power);
+ 
++/* owner->d5xx_vc_mux.copy_lock must be held by the caller. */
++static int d5xx_vc_mux_start_secondary_locked(struct tegra_channel *owner)
++{
++	struct tegra_channel *secondary = owner->d5xx_vc_mux.secondary_chan;
++	int ret;
++
++	if (!secondary)
++		return -ENODEV;
++	if (atomic_read(&secondary->is_streaming))
++		return 0;
++
++	ret = tegra_channel_set_power(secondary, true);
++	if (ret)
++		return ret;
++
++	tegra_camera_update_clknbw(secondary, true);
++	ret = v4l2_subdev_call(secondary->subdev_on_csi, video, s_stream, true);
++	if (ret == -ENOIOCTLCMD)
++		ret = 0;
++	if (ret) {
++		tegra_camera_update_clknbw(secondary, false);
++		tegra_channel_set_power(secondary, false);
++		return ret;
++	}
++
++	atomic_set(&secondary->is_streaming, ENABLE);
++	return 0;
++}
++
++static bool d5xx_vc_mux_formats_match(struct tegra_channel *owner,
++				       struct tegra_channel *secondary)
++{
++	return owner->format.width == secondary->format.width &&
++		owner->format.height == secondary->format.height &&
++		owner->format.pixelformat == secondary->format.pixelformat &&
++		owner->format.sizeimage == secondary->format.sizeimage;
++}
++
++/* Return every driver-owned buffer before a start_streaming() failure. */
++static int d5xx_vc_mux_start_error(struct tegra_channel *chan, int error)
++{
++	tegra_channel_queued_buf_done(chan, VB2_BUF_STATE_QUEUED, false);
++	return error;
++}
++
++/* owner->d5xx_vc_mux.copy_lock must be held by the caller. */
++static void d5xx_vc_mux_stop_secondary_locked(struct tegra_channel *owner,
++					       bool fail_queue)
++{
++	struct tegra_channel *secondary = owner->d5xx_vc_mux.secondary_chan;
++
++	if (!secondary)
++		return;
++
++	secondary->d5xx_vc_mux.stream_requested = false;
++	if (atomic_read(&secondary->is_streaming)) {
++		int ret = v4l2_subdev_call(secondary->subdev_on_csi, video,
++					   s_stream, false);
++
++		if (ret < 0 && ret != -ENOIOCTLCMD)
++			dev_err(owner->vi->dev,
++				"D5xx VC mux source stop failed: %d\n", ret);
++		tegra_camera_update_clknbw(secondary, false);
++		tegra_channel_set_power(secondary, false);
++		atomic_set(&secondary->is_streaming, DISABLE);
++	}
++
++	vi5_d5xx_vc_mux_dma_unmap(owner, true);
++	if (fail_queue)
++		vb2_queue_error(&secondary->queue);
++	tegra_channel_queued_buf_done(secondary, VB2_BUF_STATE_ERROR, false);
++}
++
+ static int tegra_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ {
+ 	struct tegra_channel *chan = vb2_get_drv_priv(vq);
+ 	struct tegra_mc_vi *vi = chan->vi;
++	bool dma_acquired = false;
++
++	if (chan->d5xx_vc_mux.enabled && !chan->d5xx_vc_mux.owner) {
++		struct tegra_channel *owner = chan->d5xx_vc_mux.owner_chan;
++		int ret;
++
++		if (!owner)
++			return d5xx_vc_mux_start_error(chan, -ENODEV);
++
++		mutex_lock(&owner->d5xx_vc_mux.copy_lock);
++		if (owner->d5xx_vc_mux.owner_stopping) {
++			mutex_unlock(&owner->d5xx_vc_mux.copy_lock);
++			return d5xx_vc_mux_start_error(chan, -EPIPE);
++		}
++		chan->d5xx_vc_mux.stream_requested = true;
++		/*
++		 * The secondary source shares the owner's physical VC capture.
++		 * Arm it when userspace starts this node, but do not tell the
++		 * sensor to transmit until the owner VI is consuming that VC.
++		 */
++		if (!atomic_read(&owner->is_streaming)) {
++			mutex_unlock(&owner->d5xx_vc_mux.copy_lock);
++			return 0;
++		}
++
++		if (!d5xx_vc_mux_formats_match(owner, chan))
++			ret = -EINVAL;
++		else
++			ret = d5xx_vc_mux_start_secondary_locked(owner);
++		if (ret)
++			chan->d5xx_vc_mux.stream_requested = false;
++		mutex_unlock(&owner->d5xx_vc_mux.copy_lock);
++		if (ret)
++			return d5xx_vc_mux_start_error(chan, ret);
++		return ret;
++	}
++
++	if (chan->d5xx_vc_mux.owner) {
++		dma_cap_mask_t mask;
++
++		if (!chan->d5xx_vc_mux.secondary_chan)
++			return d5xx_vc_mux_start_error(chan, -ENODEV);
++		mutex_lock(&chan->d5xx_vc_mux.copy_lock);
++		chan->d5xx_vc_mux.owner_stopping = false;
++		mutex_unlock(&chan->d5xx_vc_mux.copy_lock);
++
++		dma_cap_zero(mask);
++		dma_cap_set(DMA_MEMCPY, mask);
++		chan->d5xx_vc_mux.dma_chan =
++			dma_request_channel(mask, NULL, NULL);
++		if (!chan->d5xx_vc_mux.dma_chan)
++			return d5xx_vc_mux_start_error(chan, -ENODEV);
++		/*
++		 * GPCDMA supports transfers up to 1 GiB.  Advertise that limit to
++		 * the DMA API so the exported vb2 buffer is mapped as one IOVA
++		 * segment instead of the default 64 KiB segments.
++		 */
++		if (dma_set_max_seg_size(
++			    chan->d5xx_vc_mux.dma_chan->device->dev, SZ_1G)) {
++			dma_release_channel(chan->d5xx_vc_mux.dma_chan);
++			chan->d5xx_vc_mux.dma_chan = NULL;
++			return d5xx_vc_mux_start_error(chan, -ENODEV);
++		}
++
++		chan->d5xx_vc_mux.owner_frames = 0;
++		chan->d5xx_vc_mux.secondary_frames = 0;
++		chan->d5xx_vc_mux.dropped_frames = 0;
++		chan->d5xx_vc_mux.invalid_metadata = 0;
++		chan->d5xx_vc_mux.dma_errors = 0;
++		chan->d5xx_vc_mux.dma_last_error = 0;
++		dma_acquired = true;
++	}
+ 
+ 	if (vi->fops) {
+ 		int ret = 0;
+ 
+ 		/* power on hw at the start of streaming */
+ 		ret = vi->fops->vi_power_on(chan);
+-		if (ret < 0)
++		if (ret < 0) {
++			if (dma_acquired) {
++				dma_release_channel(chan->d5xx_vc_mux.dma_chan);
++				chan->d5xx_vc_mux.dma_chan = NULL;
++				return d5xx_vc_mux_start_error(chan, ret);
++			}
+ 			return ret;
++		}
+ 
+-		return vi->fops->vi_start_streaming(vq, count);
++		ret = vi->fops->vi_start_streaming(vq, count);
++		if (ret < 0 && dma_acquired) {
++			dma_release_channel(chan->d5xx_vc_mux.dma_chan);
++			chan->d5xx_vc_mux.dma_chan = NULL;
++		}
++		if (!ret && chan->d5xx_vc_mux.owner) {
++			struct tegra_channel *secondary =
++				chan->d5xx_vc_mux.secondary_chan;
++
++			mutex_lock(&chan->d5xx_vc_mux.copy_lock);
++			if (secondary->d5xx_vc_mux.stream_requested &&
++			    !atomic_read(&secondary->is_streaming)) {
++				if (!d5xx_vc_mux_formats_match(chan, secondary))
++					ret = -EINVAL;
++				else
++					ret = d5xx_vc_mux_start_secondary_locked(chan);
++				if (ret) {
++					secondary->d5xx_vc_mux.stream_requested =
++						false;
++					vb2_queue_error(&secondary->queue);
++					tegra_channel_queued_buf_done(secondary,
++						VB2_BUF_STATE_ERROR, false);
++					dev_err(chan->vi->dev,
++						"D5xx VC mux source start failed: %d\n",
++						ret);
++					/* Keep the already-running owner usable. */
++					ret = 0;
++				}
++			}
++			mutex_unlock(&chan->d5xx_vc_mux.copy_lock);
++		}
++		return ret;
+ 	}
+ 	return 0;
+ }
+@@ -1025,12 +1209,76 @@ static void tegra_channel_stop_streaming(struct vb2_queue *vq)
+ 	struct tegra_channel *chan = vb2_get_drv_priv(vq);
+ 	struct tegra_mc_vi *vi = chan->vi;
+ 
++	if (chan->d5xx_vc_mux.enabled && !chan->d5xx_vc_mux.owner) {
++		struct tegra_channel *owner = chan->d5xx_vc_mux.owner_chan;
++
++		if (owner)
++			mutex_lock(&owner->d5xx_vc_mux.copy_lock);
++		if (owner)
++			d5xx_vc_mux_stop_secondary_locked(owner, false);
++		else {
++			chan->d5xx_vc_mux.stream_requested = false;
++			tegra_channel_queued_buf_done(chan, VB2_BUF_STATE_ERROR,
++						       false);
++		}
++		if (owner)
++			mutex_unlock(&owner->d5xx_vc_mux.copy_lock);
++		return;
++	}
++
++	if (chan->d5xx_vc_mux.owner) {
++		struct tegra_channel *secondary =
++			chan->d5xx_vc_mux.secondary_chan;
++		bool secondary_active = false;
++
++		mutex_lock(&chan->d5xx_vc_mux.copy_lock);
++		chan->d5xx_vc_mux.owner_stopping = true;
++		if (secondary) {
++			secondary_active =
++				secondary->d5xx_vc_mux.stream_requested ||
++				atomic_read(&secondary->is_streaming);
++			/*
++			 * The owner supplies the physical VI capture.  If it closes,
++			 * fail the dependent queue so userspace can STREAMOFF it and
++			 * restart the pair from a clean shared-pipe state.
++			 */
++			if (secondary_active)
++				d5xx_vc_mux_stop_secondary_locked(chan, true);
++		}
++		mutex_unlock(&chan->d5xx_vc_mux.copy_lock);
++	}
++
+ 	if (vi->fops) {
+ 		vi->fops->vi_stop_streaming(vq);
+ 		atomic_set(&chan->is_streaming, DISABLE);
+ 		vi->fops->vi_power_off(chan);
+ 	}
+ 
++	if (chan->d5xx_vc_mux.owner) {
++		mutex_lock(&chan->d5xx_vc_mux.copy_lock);
++		chan->d5xx_vc_mux.owner_stopping = false;
++		mutex_unlock(&chan->d5xx_vc_mux.copy_lock);
++	}
++
++	if (chan->d5xx_vc_mux.owner && chan->d5xx_vc_mux.dma_chan) {
++		mutex_lock(&chan->d5xx_vc_mux.copy_lock);
++		vi5_d5xx_vc_mux_dma_unmap(chan, false);
++		vi5_d5xx_vc_mux_dma_unmap(chan, true);
++		dev_info(chan->vi->dev,
++			 "D5xx VC mux: source %u=%llu source %u=%llu dropped=%llu invalid=%llu dma_errors=%llu last_dma_error=%d\n",
++			 chan->d5xx_vc_mux.source_id,
++			 (unsigned long long)chan->d5xx_vc_mux.owner_frames,
++			 chan->d5xx_vc_mux.secondary_chan->d5xx_vc_mux.source_id,
++			 (unsigned long long)chan->d5xx_vc_mux.secondary_frames,
++			 (unsigned long long)chan->d5xx_vc_mux.dropped_frames,
++			 (unsigned long long)chan->d5xx_vc_mux.invalid_metadata,
++			 (unsigned long long)chan->d5xx_vc_mux.dma_errors,
++			 chan->d5xx_vc_mux.dma_last_error);
++		dma_release_channel(chan->d5xx_vc_mux.dma_chan);
++		chan->d5xx_vc_mux.dma_chan = NULL;
++		mutex_unlock(&chan->d5xx_vc_mux.copy_lock);
++	}
++
+ 	/* Clean-up recorded videobuf2 queue initial timestamp */
+ 	queue_init_ts = 0;
+ }
+@@ -2559,6 +2807,32 @@ int tegra_vi_get_port_info(struct tegra_channel *chan,
+ 				dev_err(chan->vi->dev, "num lanes error\n");
+ 			chan->numlanes = value;
+ 
++			{
++				int mux_ret;
++				u32 source_id;
++				u32 owner_channel_id;
++
++				mux_ret = of_property_read_u32(
++					ep, "realsense,d5xx-vc-mux-source-id",
++					&source_id);
++				if (!mux_ret && (source_id > U8_MAX ||
++						 of_property_read_u32(ep,
++						 "realsense,d5xx-vc-mux-owner-channel",
++						 &owner_channel_id))) {
++					dev_err(chan->vi->dev,
++						"invalid D5xx VC mux endpoint\n");
++					return -EINVAL;
++				}
++				if (!mux_ret) {
++					chan->d5xx_vc_mux.enabled = true;
++					chan->d5xx_vc_mux.source_id = source_id;
++					chan->d5xx_vc_mux.owner_channel_id =
++						owner_channel_id;
++					chan->d5xx_vc_mux.owner =
++						index == owner_channel_id;
++				}
++			}
++
+ 			if (value > 12) {
+ 				dev_err(chan->vi->dev, "num lanes >12!\n");
+ 				return -EINVAL;
+@@ -3079,6 +3353,7 @@ int tegra_channel_init(struct tegra_channel *chan)
+ 	init_waitqueue_head(&chan->dequeue_wait);
+ 	spin_lock_init(&chan->dequeue_lock);
+ 	mutex_init(&chan->stop_kthread_lock);
++	mutex_init(&chan->d5xx_vc_mux.copy_lock);
+ 	init_rwsem(&chan->reset_lock);
+ 	atomic_set(&chan->is_streaming, DISABLE);
+ 	spin_lock_init(&chan->capture_state_lock);
+@@ -3227,6 +3502,44 @@ int tegra_vi_channels_init(struct tegra_mc_vi *vi)
+ 		return ret;
+ 	}
+ 
++	list_for_each_entry(it, &vi->vi_chans, list) {
++		struct tegra_channel *owner = NULL;
++		struct tegra_channel *candidate;
++
++		if (!it->d5xx_vc_mux.enabled)
++			continue;
++
++		list_for_each_entry(candidate, &vi->vi_chans, list) {
++			if (candidate->id == it->d5xx_vc_mux.owner_channel_id) {
++				owner = candidate;
++				break;
++			}
++		}
++
++		if (!owner || !owner->d5xx_vc_mux.enabled ||
++		    !owner->d5xx_vc_mux.owner ||
++		    owner->port[0] != it->port[0] ||
++		    owner->virtual_channel != it->virtual_channel) {
++			dev_err(vi->dev, "invalid D5xx VC mux topology on channel %u\n",
++				it->id);
++			return -EINVAL;
++		}
++
++		it->d5xx_vc_mux.owner_chan = owner;
++		if (it == owner)
++			continue;
++		if (owner->d5xx_vc_mux.secondary_chan ||
++		    owner->d5xx_vc_mux.source_id == it->d5xx_vc_mux.source_id) {
++			dev_err(vi->dev, "ambiguous D5xx VC mux topology\n");
++			return -EINVAL;
++		}
++		owner->d5xx_vc_mux.secondary_chan = it;
++		dev_info(vi->dev,
++			 "D5xx VC mux topology: owner channel %u source %u, secondary channel %u source %u\n",
++			 owner->id, owner->d5xx_vc_mux.source_id,
++			 it->id, it->d5xx_vc_mux.source_id);
++	}
++
+ 	return 0;
+ }
+ EXPORT_SYMBOL(tegra_vi_channels_init);
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index 02a1837f02b417eafabce82b1b158adc5414c171..a066e29282b460fecc15a54c4c96f102b268fac5 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -12,6 +12,9 @@
+  */
+ 
+ #include <linux/errno.h>
++#include <linux/completion.h>
++#include <linux/dma-mapping.h>
++#include <linux/dmaengine.h>
+ #include <linux/freezer.h>
+ #include <linux/fs.h>
+ #include <linux/kthread.h>
+@@ -42,6 +45,13 @@
+ #define VI_CHAN_PATH_MAX 40
+ 
+ #define CAPTURE_TIMEOUT_MS	2500
++#define D5XX_GMSL_META_ID	0x80000022U
++#define D5XX_GMSL_META_SIZE	11U
++#define D5XX_GMSL_META_OFFSET	(D4XX_META_BUFSIZE - D5XX_GMSL_META_SIZE)
++#define D5XX_GMSL_META_VERSION_OFFSET	(D5XX_GMSL_META_OFFSET + 8U)
++#define D5XX_GMSL_META_FLAGS_OFFSET	(D5XX_GMSL_META_OFFSET + 9U)
++#define D5XX_GMSL_META_SOURCE_OFFSET	(D5XX_GMSL_META_OFFSET + 10U)
++#define D5XX_VC_MUX_DMA_TIMEOUT_MS	100U
+ 
+ static const struct vi_capture_setup default_setup = {
+ 	.channel_flags = 0
+@@ -472,27 +482,46 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 		chan->capture_descr_sequence += 1;
+ }
+ 
+-static void vi5_release_metadata_buffer(struct tegra_channel *chan,
+-	struct tegra_channel_buffer *buf)
++static void *vi5_metadata_addr(struct tegra_channel *chan,
++			       struct tegra_channel_buffer *buf)
++{
++	unsigned int descr_index = buf->capture_descr_index[0];
++	unsigned int emb_offset;
++
++	if (!chan->emb_buf_stride ||
++	    chan->emb_buf_size < D4XX_META_BUFSIZE ||
++	    descr_index >= chan->capture_queue_depth ||
++	    check_mul_overflow(descr_index, chan->emb_buf_stride,
++			       &emb_offset) ||
++	    emb_offset > chan->emb_buf_size - D4XX_META_BUFSIZE)
++		return NULL;
++
++	return (u8 *)chan->emb_buf_addr + emb_offset;
++}
++
++static void vi5_release_metadata_buffer(struct tegra_channel *capture_chan,
++					struct tegra_channel *output_chan,
++					struct tegra_channel_buffer *buf,
++					struct vb2_v4l2_buffer *vbuf)
+ {
+ 	struct vb2_buffer *evb = NULL;
+ 	struct vb2_v4l2_buffer *evbuf;
+-	struct vb2_v4l2_buffer *vbuf = &buf->buf;
+ 	void *frm_buffer;
+ 	void *metadata_addr;
+-	unsigned int descr_index = buf->capture_descr_index[0];
+-	unsigned int emb_offset;
+ 
+-	spin_lock(&chan->embedded.spin_lock);
+-	if (0 < chan->embedded.num_buffers) {
+-		evb = chan->embedded.buffers[chan->embedded.tail];
+-		chan->embedded.buffers[chan->embedded.tail] = NULL;
+-		chan->embedded.tail++;
+-		if (chan->embedded.tail > 15)
+-			chan->embedded.tail = chan->embedded.tail - 16;
+-		chan->embedded.num_buffers--;
++	if (!output_chan->embedded.video)
++		return;
++
++	spin_lock(&output_chan->embedded.spin_lock);
++	if (output_chan->embedded.num_buffers > 0) {
++		evb = output_chan->embedded.buffers[output_chan->embedded.tail];
++		output_chan->embedded.buffers[output_chan->embedded.tail] = NULL;
++		output_chan->embedded.tail++;
++		if (output_chan->embedded.tail > 15)
++			output_chan->embedded.tail = output_chan->embedded.tail - 16;
++		output_chan->embedded.num_buffers--;
+ 	}
+-	spin_unlock(&chan->embedded.spin_lock);
++	spin_unlock(&output_chan->embedded.spin_lock);
+ 
+ 	if (!evb)
+ 		return;
+@@ -503,17 +532,12 @@ static void vi5_release_metadata_buffer(struct tegra_channel *chan,
+ 		return;
+ 	}
+ 
+-	if (!chan->emb_buf_stride ||
+-		chan->emb_buf_size < D4XX_META_BUFSIZE ||
+-		descr_index >= chan->capture_queue_depth ||
+-		check_mul_overflow(descr_index, chan->emb_buf_stride,
+-			&emb_offset) ||
+-		emb_offset > chan->emb_buf_size - D4XX_META_BUFSIZE) {
++	metadata_addr = vi5_metadata_addr(capture_chan, buf);
++	if (!metadata_addr) {
+ 		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
+ 		return;
+ 	}
+ 
+-	metadata_addr = (u8 *)chan->emb_buf_addr + emb_offset;
+ 	memcpy(frm_buffer, metadata_addr, D4XX_META_BUFSIZE);
+ 	evbuf = to_vb2_v4l2_buffer(evb);
+ 	evbuf->sequence = vbuf->sequence;
+@@ -522,17 +546,266 @@ static void vi5_release_metadata_buffer(struct tegra_channel *chan,
+ 	vb2_buffer_done(evb, VB2_BUF_STATE_DONE);
+ }
+ 
++static int d5xx_vc_mux_source_id(struct tegra_channel *chan,
++				 struct tegra_channel_buffer *buf, u8 *source_id)
++{
++	u8 *metadata = vi5_metadata_addr(chan, buf);
++	__le32 id;
++	__le32 size;
++
++	if (!metadata)
++		return -EINVAL;
++
++	memcpy(&id, metadata + D5XX_GMSL_META_OFFSET, sizeof(id));
++	memcpy(&size, metadata + D5XX_GMSL_META_OFFSET + sizeof(id),
++	       sizeof(size));
++	if (le32_to_cpu(id) != D5XX_GMSL_META_ID ||
++	    le32_to_cpu(size) != D5XX_GMSL_META_SIZE ||
++	    metadata[D5XX_GMSL_META_VERSION_OFFSET] != 1U ||
++	    !(metadata[D5XX_GMSL_META_FLAGS_OFFSET] & BIT(0)))
++		return -EINVAL;
++
++	*source_id = metadata[D5XX_GMSL_META_SOURCE_OFFSET];
++	return 0;
++}
++
++static struct tegra_channel_buffer *
++d5xx_vc_mux_dequeue_target(struct tegra_channel *chan)
++{
++	struct tegra_channel_buffer *buf = NULL;
++
++	spin_lock(&chan->start_lock);
++	if (!list_empty(&chan->capture)) {
++		buf = list_first_entry(&chan->capture,
++				       struct tegra_channel_buffer, queue);
++		list_del_init(&buf->queue);
++	}
++	spin_unlock(&chan->start_lock);
++	return buf;
++}
++
++static void d5xx_vc_mux_dma_complete(void *arg)
++{
++	complete(arg);
++}
++
++static void d5xx_vc_mux_dma_unmap_one(struct d5xx_vc_mux_dma_map *map)
++{
++	if (!map->dbuf)
++		return;
++
++	if (map->sgt)
++		dma_buf_unmap_attachment(map->attach, map->sgt, map->dir);
++	if (map->attach)
++		dma_buf_detach(map->dbuf, map->attach);
++	dma_buf_put(map->dbuf);
++	memset(map, 0, sizeof(*map));
++}
++
++void vi5_d5xx_vc_mux_dma_unmap(struct tegra_channel *owner, bool secondary)
++{
++	struct d5xx_vc_mux_dma_map *maps = secondary ?
++		owner->d5xx_vc_mux.secondary_maps :
++		owner->d5xx_vc_mux.source_maps;
++	unsigned int i;
++
++	for (i = 0; i < VB2_MAX_FRAME; i++)
++		d5xx_vc_mux_dma_unmap_one(&maps[i]);
++}
++
++static int d5xx_vc_mux_dma_map(struct tegra_channel *owner,
++			       struct vb2_buffer *vb,
++			       struct d5xx_vc_mux_dma_map *map,
++			       enum dma_data_direction dir)
++{
++	struct dma_buf *dbuf;
++
++	if (map->dbuf)
++		return 0;
++
++	if (vb->planes[0].dbuf) {
++		dbuf = vb->planes[0].dbuf;
++		get_dma_buf(dbuf);
++	} else {
++		const struct vb2_mem_ops *mem_ops = vb->vb2_queue->mem_ops;
++
++		if (!mem_ops || !mem_ops->get_dmabuf)
++			return -EOPNOTSUPP;
++		dbuf = mem_ops->get_dmabuf(vb, vb->planes[0].mem_priv, O_RDWR);
++		if (IS_ERR_OR_NULL(dbuf))
++			return -EIO;
++	}
++
++	map->attach = dma_buf_attach(dbuf, owner->d5xx_vc_mux.dma_chan->device->dev);
++	if (IS_ERR(map->attach)) {
++		int ret = PTR_ERR(map->attach);
++
++		map->attach = NULL;
++		dma_buf_put(dbuf);
++		return ret;
++	}
++
++	map->sgt = dma_buf_map_attachment(map->attach, dir);
++	if (IS_ERR(map->sgt)) {
++		int ret = PTR_ERR(map->sgt);
++
++		map->sgt = NULL;
++		dma_buf_detach(dbuf, map->attach);
++		map->attach = NULL;
++		dma_buf_put(dbuf);
++		return ret;
++	}
++
++	map->dbuf = dbuf;
++	map->dir = dir;
++	return 0;
++}
++
++static int d5xx_vc_mux_dma_copy(struct tegra_channel *owner,
++				 struct tegra_channel_buffer *src,
++				 struct tegra_channel_buffer *dst)
++{
++	struct dma_chan *chan = owner->d5xx_vc_mux.dma_chan;
++	struct d5xx_vc_mux_dma_map *src_map;
++	struct d5xx_vc_mux_dma_map *dst_map;
++	struct dma_async_tx_descriptor *tx;
++	DECLARE_COMPLETION_ONSTACK(done);
++	dma_cookie_t cookie;
++	size_t len = owner->format.sizeimage;
++	int ret;
++
++	if (!chan || src->buf.vb2_buf.index >= VB2_MAX_FRAME ||
++	    dst->buf.vb2_buf.index >= VB2_MAX_FRAME ||
++	    vb2_plane_size(&src->buf.vb2_buf, 0) < len ||
++	    vb2_plane_size(&dst->buf.vb2_buf, 0) < len)
++		return -ENODEV;
++
++	src_map = &owner->d5xx_vc_mux.source_maps[src->buf.vb2_buf.index];
++	dst_map = &owner->d5xx_vc_mux.secondary_maps[dst->buf.vb2_buf.index];
++	ret = d5xx_vc_mux_dma_map(owner, &src->buf.vb2_buf, src_map,
++				  DMA_TO_DEVICE);
++	if (ret)
++		return ret;
++	ret = d5xx_vc_mux_dma_map(owner, &dst->buf.vb2_buf, dst_map,
++				  DMA_FROM_DEVICE);
++	if (ret)
++		return ret;
++
++	dma_sync_sgtable_for_device(chan->device->dev, src_map->sgt,
++				    DMA_TO_DEVICE);
++	dma_sync_sgtable_for_device(chan->device->dev, dst_map->sgt,
++				    DMA_FROM_DEVICE);
++
++	if (src_map->sgt->nents != 1 || dst_map->sgt->nents != 1 ||
++	    sg_dma_len(src_map->sgt->sgl) < len ||
++	    sg_dma_len(dst_map->sgt->sgl) < len)
++		return -E2BIG;
++
++	tx = dmaengine_prep_dma_memcpy(chan,
++				       sg_dma_address(dst_map->sgt->sgl),
++				       sg_dma_address(src_map->sgt->sgl), len,
++				       DMA_CTRL_ACK | DMA_PREP_INTERRUPT);
++	if (!tx)
++		return -EIO;
++	tx->callback = d5xx_vc_mux_dma_complete;
++	tx->callback_param = &done;
++	cookie = dmaengine_submit(tx);
++	ret = dma_submit_error(cookie);
++	if (ret)
++		return ret;
++
++	dma_async_issue_pending(chan);
++	if (!wait_for_completion_timeout(&done,
++					 msecs_to_jiffies(D5XX_VC_MUX_DMA_TIMEOUT_MS))) {
++		dmaengine_terminate_sync(chan);
++		return -ETIMEDOUT;
++	}
++
++	dma_sync_sgtable_for_cpu(chan->device->dev, dst_map->sgt,
++				 DMA_FROM_DEVICE);
++	return 0;
++}
++
++static void d5xx_vc_mux_recycle_owner(struct tegra_channel *chan,
++				      struct tegra_channel_buffer *buf)
++{
++	buf->vb2_state = VB2_BUF_STATE_QUEUED;
++	spin_lock(&chan->start_lock);
++	list_add_tail(&buf->queue, &chan->capture);
++	spin_unlock(&chan->start_lock);
++	wake_up_interruptible(&chan->start_wait);
++}
++
+ static void vi5_release_buffer(struct tegra_channel *chan,
+ 	struct tegra_channel_buffer *buf)
+ {
+ 	struct vb2_v4l2_buffer *vbuf = &buf->buf;
++	struct tegra_channel *secondary;
++	struct tegra_channel_buffer *target;
++	u8 source_id;
++	int ret;
++
++	if (!chan->d5xx_vc_mux.owner ||
++	    buf->vb2_state != VB2_BUF_STATE_DONE)
++		goto release_owner;
++
++	ret = d5xx_vc_mux_source_id(chan, buf, &source_id);
++	secondary = chan->d5xx_vc_mux.secondary_chan;
++	if (ret || (source_id != chan->d5xx_vc_mux.source_id &&
++		    (!secondary || source_id != secondary->d5xx_vc_mux.source_id))) {
++		chan->d5xx_vc_mux.invalid_metadata++;
++		buf->vb2_state = VB2_BUF_STATE_ERROR;
++		goto release_owner;
++	}
++
++	if (source_id == chan->d5xx_vc_mux.source_id) {
++		chan->d5xx_vc_mux.owner_frames++;
++		goto release_owner;
++	}
++
++	mutex_lock(&chan->d5xx_vc_mux.copy_lock);
++	if (!atomic_read(&secondary->is_streaming)) {
++		chan->d5xx_vc_mux.dropped_frames++;
++		goto recycle_owner;
++	}
++
++	target = d5xx_vc_mux_dequeue_target(secondary);
++	if (!target) {
++		chan->d5xx_vc_mux.dropped_frames++;
++		goto recycle_owner;
++	}
++
++	ret = d5xx_vc_mux_dma_copy(chan, buf, target);
++	if (ret) {
++		chan->d5xx_vc_mux.dma_errors++;
++		chan->d5xx_vc_mux.dma_last_error = ret;
++		vb2_buffer_done(&target->buf.vb2_buf, VB2_BUF_STATE_ERROR);
++		goto recycle_owner;
++	}
++
++	target->buf.sequence = secondary->sequence++;
++	target->buf.field = V4L2_FIELD_NONE;
++	target->buf.vb2_buf.timestamp = vbuf->vb2_buf.timestamp;
++	vb2_set_plane_payload(&target->buf.vb2_buf, 0,
++			      secondary->format.sizeimage);
++	if (chan->embedded_data_height == 1)
++		vi5_release_metadata_buffer(chan, secondary, buf, &target->buf);
++	vb2_buffer_done(&target->buf.vb2_buf, VB2_BUF_STATE_DONE);
++	chan->d5xx_vc_mux.secondary_frames++;
++
++recycle_owner:
++	mutex_unlock(&chan->d5xx_vc_mux.copy_lock);
++	d5xx_vc_mux_recycle_owner(chan, buf);
++	return;
++
++release_owner:
+ 
+ 	vbuf->sequence = chan->sequence++;
+ 	vbuf->field = V4L2_FIELD_NONE;
+ 	vb2_set_plane_payload(&vbuf->vb2_buf, 0, chan->format.sizeimage);
+ 
+ 	if (chan->embedded_data_height == 1 && buf->vb2_state == VB2_BUF_STATE_DONE)
+-		vi5_release_metadata_buffer(chan, buf);
++		vi5_release_metadata_buffer(chan, chan, buf, vbuf);
+ 
+ 	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);
+ }
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.h b/drivers/media/platform/tegra/camera/vi/vi5_fops.h
+index 761a7cc4bdb9b5e23133443be9d634e4b48468fc..8ace6706707d8b36bab40fbe53f649a4dc38bc99 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.h
+@@ -8,6 +8,9 @@
+ #ifndef __T186_VI5_H__
+ #define __T186_VI5_H__
+ 
++struct tegra_channel;
++
+ extern struct tegra_vi_fops vi5_fops;
++void vi5_d5xx_vc_mux_dma_unmap(struct tegra_channel *owner, bool secondary);
+ 
+ #endif
+diff --git a/include/media/mc_common.h b/include/media/mc_common.h
+index cea3ca26bcab7e3f6113e82e16a94d84909cd66f..180ec74ee2a1aa7b7d5925ed9641e88b2806a623 100644
+--- a/include/media/mc_common.h
++++ b/include/media/mc_common.h
+@@ -35,6 +35,9 @@
+ #include <media/tegra_camera_core.h>
+ #include <media/csi.h>
+ #include <linux/workqueue.h>
++#include <linux/dma-buf.h>
++#include <linux/dma-direction.h>
++#include <linux/scatterlist.h>
+ #include <linux/semaphore.h>
+ #include <linux/rwsem.h>
+ #include <linux/version.h>
+@@ -94,6 +97,13 @@ struct tegra_channel_buffer {
+ 	int state;
+ };
+ 
++struct d5xx_vc_mux_dma_map {
++	struct dma_buf *dbuf;
++	struct dma_buf_attachment *attach;
++	struct sg_table *sgt;
++	enum dma_data_direction dir;
++};
++
+ #define to_tegra_channel_buffer(vb) \
+ 	container_of(vb, struct tegra_channel_buffer, buf)
+ 
+@@ -297,6 +307,27 @@ struct tegra_channel {
+ 	void *emb_buf_addr;
+ 	unsigned int emb_buf_stride;
+ 	unsigned int emb_buf_size;
++
++	struct {
++		bool enabled;
++		bool owner;
++		u8 source_id;
++		u32 owner_channel_id;
++		struct tegra_channel *owner_chan;
++		struct tegra_channel *secondary_chan;
++		struct dma_chan *dma_chan;
++		struct mutex copy_lock;
++		bool stream_requested;
++		bool owner_stopping;
++		struct d5xx_vc_mux_dma_map source_maps[VB2_MAX_FRAME];
++		struct d5xx_vc_mux_dma_map secondary_maps[VB2_MAX_FRAME];
++		u64 owner_frames;
++		u64 secondary_frames;
++		u64 dropped_frames;
++		u64 invalid_metadata;
++		u64 dma_errors;
++		int dma_last_error;
++	} d5xx_vc_mux;
+ };
+ 
+ #define to_tegra_channel(vdev) \

--- a/nvidia-oot/max96717.c
+++ b/nvidia-oot/max96717.c
@@ -78,8 +78,8 @@ struct max96717 {
 	struct max96717_client_ctx g_client;
 	struct mutex lock;
 	bool pixel_mode;
-	/* bit[ser_vc_id] set while that pipe is streaming (set in set_pipe,
-	 * cleared in stream_stop). When it drops to 0 the MIPI RX is re-armed. */
+	/* Multiple logical streams may share one tunnel VC. */
+	u8 active_vc_refcount[MAX96717_MAX_VC];
 	u16 active_vc_mask;
 };
 
@@ -399,6 +399,8 @@ int max96717_init_settings(struct device *dev)
 	 * ensures a deserializer/link reset can't strand a stale bit and
 	 * permanently suppress the last-stream MIPI RX re-arm. */
 	priv->active_vc_mask = 0;
+	memset(priv->active_vc_refcount, 0,
+	       sizeof(priv->active_vc_refcount));
 
 	err |= max96717_set_registers(dev, gpio_release,
 				     ARRAY_SIZE(gpio_release));
@@ -435,8 +437,14 @@ int max96717_set_pipe(struct device *dev, int pipe_id,
 		return -EINVAL;
 
 	mutex_lock(&priv->lock);
-
+	if (priv->active_vc_refcount[vc_id] == U8_MAX) {
+		err = -EOVERFLOW;
+		goto unlock;
+	}
+	priv->active_vc_refcount[vc_id]++;
 	priv->active_vc_mask |= (u16)BIT(vc_id);
+
+unlock:
 	mutex_unlock(&priv->lock);
 
 	return err;
@@ -452,7 +460,14 @@ int max96717_stream_stop(struct device *dev, u32 vc_id)
 		return -EINVAL;
 
 	mutex_lock(&priv->lock);
-	priv->active_vc_mask &= (u16)~BIT(vc_id);
+	if (!priv->active_vc_refcount[vc_id]) {
+		dev_warn(dev, "%s: VC%u is not active\n", __func__, vc_id);
+		err = -EINVAL;
+		goto unlock;
+	}
+	priv->active_vc_refcount[vc_id]--;
+	if (!priv->active_vc_refcount[vc_id])
+		priv->active_vc_mask &= (u16)~BIT(vc_id);
 
 	if (priv->pixel_mode && priv->active_vc_mask == 0) {
 		/*
@@ -464,6 +479,8 @@ int max96717_stream_stop(struct device *dev, u32 vc_id)
 		dev_dbg(dev, "%s: last stream stopped, MIPI RX re-armed (err %d)\n",
 			__func__, err);
 	}
+
+unlock:
 	mutex_unlock(&priv->lock);
 
 	return err;

--- a/nvidia-oot/max96724.c
+++ b/nvidia-oot/max96724.c
@@ -1009,7 +1009,6 @@ EXPORT_SYMBOL(max96724_sdev_unregister);
 
 int max96724_get_available_pipe_id(struct device *dev, int vc_id)
 {
-	int i;
 	int pipe_id = -ENOMEM;
 	struct max96724 *priv = dev_get_drvdata(dev);
 
@@ -1017,12 +1016,15 @@ int max96724_get_available_pipe_id(struct device *dev, int vc_id)
 		return -EINVAL;
 
 	mutex_lock(&priv->lock);
-	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
-		if (i == vc_id && !priv->pipe[i].st_count) {
-			priv->pipe[i].st_count++;
-			pipe_id = i;
-			break;
-		}
+	/*
+	 * Tunnel-mode MAX96724 keeps one deserializer pipe per output VC.
+	 * Multiple logical HKR sources may intentionally share that VC and are
+	 * separated later by metadata source-id fan-out in VI. Treat the pipe as
+	 * a refcounted VC resource instead of an exclusive stream resource.
+	 */
+	if (priv->pipe[vc_id].st_count != U32_MAX) {
+		priv->pipe[vc_id].st_count++;
+		pipe_id = vc_id;
 	}
 	mutex_unlock(&priv->lock);
 
@@ -1039,8 +1041,14 @@ int max96724_release_pipe(struct device *dev, int pipe_id)
 		return -EINVAL;
 
 	mutex_lock(&priv->lock);
-	priv->pipe[pipe_id].st_count = 0;
-	priv->retriggered_pipe_mask &= ~BIT(pipe_id);
+	if (priv->pipe[pipe_id].st_count)
+		priv->pipe[pipe_id].st_count--;
+	else
+		dev_warn(dev, "%s: pipe %d is not active\n", __func__,
+			 pipe_id);
+
+	if (!priv->pipe[pipe_id].st_count)
+		priv->retriggered_pipe_mask &= ~BIT(pipe_id);
 	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
 		if (priv->pipe[i].st_count)
 			break;


### PR DESCRIPTION
## Summary

Host-side proof of concept for D585 Dual-RGB when Left MC2 and Right MC4 arrive on the same CSI VC1 with their native DT1E unchanged. Two normal V4L2 video nodes and two metadata sidecars remain visible to userspace; applications do not need to understand the VC mux.

## Implementation

- Configure MC2 and MC4 endpoints as a shared-VC topology through device-tree source IDs.
- Keep MC2 as the zero-copy physical VI owner.
- Route each completed frame by the frame-bound GMSL source ID in embedded metadata.
- Deliver MC4 frames to the second standard V4L2 node with one GPCDMA DMA-BUF copy and no CPU full-frame copy.
- Fan out the paired metadata buffer to the matching metadata node.
- Support either video node starting first, independent secondary stop while the owner remains active, format validation, and complete VB2 buffer return on every mux-specific start failure.
- Emit stream-off counters for both sources, dropped/invalid metadata, and DMA errors.

## Validation

- JetPack 6.2.2 full build passed; the deployed Image, DTBO, and tegra-camera module match the local build.
- D585 was verified in 2C Dual-RGB mode with the shared-VC HKR image.
- Secondary-first 1280x960 YUYV at 30 FPS passed: secondary completed 120 frames, then stopped while owner continued to 240 frames; invalid metadata and DMA errors stayed zero.
- The former secondary-first format-mismatch panic path passed: secondary returned EIO cleanly, owner completed 120 frames, and no VB2 warning or panic occurred. A following same-format dual run passed without reboot.
- Existing v4l2_preview.py passed with two RGB video nodes and two metadata nodes:
  - capture-only: RGB 129/129 good, Right 122/122 good, metadata valid with no stream mismatch;
  - YUYV decode: RGB 92/92 good, Right 91/91 good, both application streams PASS.
- HKR stream-off statistics showed independent HIF MIPI stream 0 and stream 1 req/done completion.

## Known POC scope and remaining work

- This patch implements one owner plus one secondary. Generalizing the topology to the product limit of up to four MC sources sharing one VC remains separate work.
- 1600x1300 at 25 FPS is not claimed for the real MC2/MC4 Dual-RGB case: the current HKR image reports an MC2 static graph configuration failure before Host capture can be evaluated.
- On the current Jetson image, generic enumeration creates color-0 for MC4 and color-1 for MC2. Both nodes work, but stable left/right alias semantics still need to be defined; validation used explicit video and metadata node paths.
- GR0P enumeration produces an existing V4L2 Unknown pixelformat warning and is unrelated to this mux path.

## D5x PR set

HKR runtime must be built with the generic `BUILD_HIF_MIPI_MC2VC_MUX=ON` route policy. The option currently selects D585 MC2/MC4 -> VC1 but is not limited to Dual-RGB, VC1, or exactly two MCs.

Depends-On: https://github.com/RealSenseAI-Internal/soc-rs-hkr-apps/pull/297
Depends-On: https://github.com/RealSenseAI-Internal/soc-rs-hkr-test/pull/376
Depends-On: https://github.com/RealSenseAI-Internal/soc-rs-hkr-trunk/pull/135
Depends-On: https://github.com/RealSenseAI-Internal/soc-rs-soc-device-mgr/pull/475
Depends-On: https://github.com/RealSenseAI-Internal/soc-rs-soc-io-drivers/pull/556
