### PR TITLE
Recover D585 prototype after hardware reset

### DIFF
--- a/kernel/nvidia/5.0.2/0017-Adding-max96712-support-for-D4xx.patch
+++ b/kernel/nvidia/5.0.2/0017-Adding-max96712-support-for-D4xx.patch
@@ -7,8 +7,8 @@ Add MAX96712 deserializer driver support for D4XX cameras.
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- drivers/media/i2c/max96712.c | 1170 +++++++++++++++++++++++++++++++++-
- 1 file changed, 1167 insertions(+), 3 deletions(-)
+ drivers/media/i2c/max96712.c | 1222 +++++++++++++++++++++++++++++++++-
+ 1 file changed, 1219 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/media/i2c/max96712.c b/drivers/media/i2c/max96712.c
 index 8081385..b7dcc99 100644
@@ -479,7 +479,7 @@ index 8081385..b7dcc99 100644
  		i2c_unregister_device(client);
  		client = NULL;
  	}
-@@ -252,13 +635,793 @@ max96712_remove(struct i2c_client *client)
+@@ -252,13 +635,845 @@ max96712_remove(struct i2c_client *client)
  	return 0;
  }
  
@@ -711,10 +711,14 @@ index 8081385..b7dcc99 100644
 +}
 +EXPORT_SYMBOL(max96712_get_ser_pipe_id);
 +
-+static void max96712_reset_oneshot_link_mask(struct max96712 *priv, uint8_t link_mask)
++static int max96712_reset_oneshot_link_mask(struct max96712 *priv, uint8_t link_mask)
 +{
-+	max96712_write_reg(priv, MAX96712_CTRL1_ADDR, link_mask);
++	int err = max96712_write_reg(priv, MAX96712_CTRL1_ADDR, link_mask);
++
++	if (err)
++		return err;
 +	msleep(100);
++	return 0;
 +}
 +
 +void max96712_reset_oneshot(struct device *dev)
@@ -1177,6 +1181,54 @@ index 8081385..b7dcc99 100644
 +}
 +EXPORT_SYMBOL(max96712_setup_link);
 +
++int max96712_recover_link(struct device *dev, struct device *ser_dev, u32 link_id)
++{
++	struct max96712 *priv = dev_get_drvdata(dev);
++	struct i2c_client *ser_client = to_i2c_client(ser_dev);
++	u8 target_addr;
++	int restore_err;
++	int err;
++
++	target_addr = ser_client->addr;
++	if (link_id >= MAX96712_MAX_LINKS ||
++	    !(priv->link_mask & BIT(link_id)))
++		return -EINVAL;
++
++	mutex_lock(&priv->lock);
++
++	/* Isolate the requested link so a serializer at the default address
++	 * cannot collide with a serializer on another camera module.
++	 */
++	err = max96712_write_reg(priv, MAX96712_REG6_ADDR,
++				   0xF0 | BIT(link_id));
++	if (!err) {
++		msleep(20);
++		err = max96712_reset_oneshot_link_mask(priv, BIT(link_id));
++	}
++
++	if (!err)
++		err = max96712_wait_for_link_lock_mask(dev, BIT(link_id));
++
++	/* A prototype serializer restarts at the default address. Once the
++	 * deserializer reports link lock, restore the assigned non-zero alias.
++	 */
++	if (!err && target_addr != MAX9295_DEFAULT_ADDR) {
++		err = max96712_write_slave_reg(priv, MAX9295_DEFAULT_ADDR, 0,
++					       target_addr << 1);
++		if (!err)
++			msleep(20);
++	}
++
++	restore_err = max96712_write_reg(priv, MAX96712_REG6_ADDR,
++					     0xF0 | priv->link_mask);
++	if (!err)
++		err = restore_err;
++
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96712_recover_link);
++
 +int max96712_setup_control(struct device *dev, struct device *s_dev)
 +{
 +	struct max96712 *priv = dev_get_drvdata(dev);
@@ -1274,7 +1326,7 @@ index 8081385..b7dcc99 100644
  	{ },
  };
  
-@@ -268,6 +1431,7 @@ static struct i2c_driver max96712_i2c_driver = {
+@@ -268,6 +1483,7 @@ static struct i2c_driver max96712_i2c_driver = {
  	.driver = {
  		.name = "max96712",
  		.owner = THIS_MODULE,
@@ -1284,4 +1336,3 @@ index 8081385..b7dcc99 100644
  	.remove = max96712_remove,
 -- 
 2.43.0
-

--- a/kernel/nvidia/5.1.2/0007-Adding-max96712-support-for-D4xx.patch
+++ b/kernel/nvidia/5.1.2/0007-Adding-max96712-support-for-D4xx.patch
@@ -7,8 +7,8 @@ Add MAX96712 deserializer driver support for D4XX cameras.
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- drivers/media/i2c/max96712.c | 1215 ++++++++++++++++++++++++++++++++--
- 1 file changed, 1175 insertions(+), 40 deletions(-)
+ drivers/media/i2c/max96712.c | 1267 ++++++++++++++++++++++++++++++++--
+ 1 file changed, 1227 insertions(+), 40 deletions(-)
 
 diff --git a/drivers/media/i2c/max96712.c b/drivers/media/i2c/max96712.c
 index 329a10d..c8bde22 100644
@@ -562,7 +562,7 @@ index 329a10d..c8bde22 100644
  		i2c_unregister_device(client);
  		client = NULL;
  	}
-@@ -285,13 +639,793 @@ max96712_remove(struct i2c_client *client)
+@@ -285,13 +639,845 @@ max96712_remove(struct i2c_client *client)
  	return 0;
  }
  
@@ -794,10 +794,14 @@ index 329a10d..c8bde22 100644
 +}
 +EXPORT_SYMBOL(max96712_get_ser_pipe_id);
 +
-+static void max96712_reset_oneshot_link_mask(struct max96712 *priv, uint8_t link_mask)
++static int max96712_reset_oneshot_link_mask(struct max96712 *priv, uint8_t link_mask)
 +{
-+	max96712_write_reg(priv, MAX96712_CTRL1_ADDR, link_mask);
++	int err = max96712_write_reg(priv, MAX96712_CTRL1_ADDR, link_mask);
++
++	if (err)
++		return err;
 +	msleep(100);
++	return 0;
 +}
 +
 +void max96712_reset_oneshot(struct device *dev)
@@ -1260,6 +1264,54 @@ index 329a10d..c8bde22 100644
 +}
 +EXPORT_SYMBOL(max96712_setup_link);
 +
++int max96712_recover_link(struct device *dev, struct device *ser_dev, u32 link_id)
++{
++	struct max96712 *priv = dev_get_drvdata(dev);
++	struct i2c_client *ser_client = to_i2c_client(ser_dev);
++	u8 target_addr;
++	int restore_err;
++	int err;
++
++	target_addr = ser_client->addr;
++	if (link_id >= MAX96712_MAX_LINKS ||
++	    !(priv->link_mask & BIT(link_id)))
++		return -EINVAL;
++
++	mutex_lock(&priv->lock);
++
++	/* Isolate the requested link so a serializer at the default address
++	 * cannot collide with a serializer on another camera module.
++	 */
++	err = max96712_write_reg(priv, MAX96712_REG6_ADDR,
++				   0xF0 | BIT(link_id));
++	if (!err) {
++		msleep(20);
++		err = max96712_reset_oneshot_link_mask(priv, BIT(link_id));
++	}
++
++	if (!err)
++		err = max96712_wait_for_link_lock_mask(dev, BIT(link_id));
++
++	/* A prototype serializer restarts at the default address. Once the
++	 * deserializer reports link lock, restore the assigned non-zero alias.
++	 */
++	if (!err && target_addr != MAX9295_DEFAULT_ADDR) {
++		err = max96712_write_slave_reg(priv, MAX9295_DEFAULT_ADDR, 0,
++					       target_addr << 1);
++		if (!err)
++			msleep(20);
++	}
++
++	restore_err = max96712_write_reg(priv, MAX96712_REG6_ADDR,
++					     0xF0 | priv->link_mask);
++	if (!err)
++		err = restore_err;
++
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96712_recover_link);
++
 +int max96712_setup_control(struct device *dev, struct device *s_dev)
 +{
 +	struct max96712 *priv = dev_get_drvdata(dev);
@@ -1357,7 +1409,7 @@ index 329a10d..c8bde22 100644
  	{ },
  };
  
-@@ -301,6 +1435,7 @@ static struct i2c_driver max96712_i2c_driver = {
+@@ -301,6 +1487,7 @@ static struct i2c_driver max96712_i2c_driver = {
  	.driver = {
  		.name = "max96712",
  		.owner = THIS_MODULE,
@@ -1367,4 +1419,3 @@ index 329a10d..c8bde22 100644
  	.remove = max96712_remove,
 -- 
 2.43.0
-

--- a/kernel/nvidia/max96712.h
+++ b/kernel/nvidia/max96712.h
@@ -71,6 +71,7 @@ void max96712_reset_oneshot(struct device *dev);
  * called per-link from d4xx's ds5_hw_reset_with_recovery(). */
 void max96712_reset_oneshot_link(struct device *dev, u32 link);
 int max96712_setup_link(struct device *dev, struct device *s_dev);
+int max96712_recover_link(struct device *dev, struct device *ser_dev, u32 link);
 int max96712_setup_control(struct device *dev, struct device *s_dev);
 int max96712_reset_control(struct device *dev, struct device *s_dev);
 int max96712_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx);

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -72,6 +72,7 @@ struct dser_interface {
 	int (*setup_link)(struct device *dev, struct device *s_dev);
 	int (*setup_control)(struct device *dev, struct device *s_dev);
 	int (*reset_control)(struct device *dev, struct device *s_dev);
+	int (*recover_link)(struct device *dev, struct device *ser_dev, u32 link);
 	int (*setup_fsync)(struct device *dev, u32 fps);
 	int (*disable_fsync)(struct device *dev);
 	
@@ -148,6 +149,9 @@ struct ser_interface {
 /* GVD response payload size per product line */
 #define DS5_GVD_LEN_D4XX		276
 #define DS5_GVD_LEN_D5XX		606
+#define D585_GVD_PID_OFFSET		18
+#define D585_2C_PROTO_PID		0x0C07
+#define D585_3C_PROTO_PID		0x0C08
 
 #define DS5_MIPI_LANE_NUMS		0x0400
 #define DS5_MIPI_LANE_DATARATE		0x0402
@@ -659,6 +663,7 @@ struct ds5_dev {
 	* read still returns 0.
 	*/
 	u16 cached_device_type;
+	u16 d585_product_id;
 
 	/* Timestamp (jiffies) of last completed HW reset.
 	* Used to enforce DS5_HW_RESET_COOLDOWN_MS between consecutive resets
@@ -756,6 +761,7 @@ static const struct dser_interface max96712_interface = {
 	.setup_link = max96712_setup_link,
 	.setup_control = max96712_setup_control,
 	.reset_control = max96712_reset_control,
+	.recover_link = max96712_recover_link,
 	.sdev_register = max96712_sdev_register,
 	.sdev_unregister = max96712_sdev_unregister,
 	.power_on = max96712_power_on,
@@ -774,6 +780,7 @@ static const struct dser_interface max96724_interface = {
 	.setup_link = max96724_setup_link,
 	.setup_control = max96724_setup_control,
 	.reset_control = max96724_reset_control,
+	.recover_link = max96724_recover_link,
 	.setup_fsync = max96724_setup_fsync,
 	.disable_fsync = max96724_disable_fsync,
 	.sdev_register = max96724_sdev_register,
@@ -855,6 +862,8 @@ static inline bool ds5_is_d58x(struct ds5 *state)
 		READ_ONCE(state->ds5_dev->cached_device_type) ==
 			DS5_DEVICE_TYPE_D58X;
 }
+
+static int ds5_hw_init(struct i2c_client *c, struct ds5 *state);
 
 static inline u16 ds5_rgb_ctrl_offset(struct ds5 *state, u16 d4xx_offset,
 				      u16 d58x_offset)
@@ -3027,6 +3036,9 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	bool rgb_streaming;
 	bool ir_streaming;
 	bool imu_streaming;
+	u16 d585_product_id = READ_ONCE(state->ds5_dev->d585_product_id);
+	bool d585_proto_reset = d585_product_id == D585_2C_PROTO_PID ||
+				 d585_product_id == D585_3C_PROTO_PID;
 	unsigned long ds5_last_reset_jiffies = READ_ONCE(state->ds5_dev->last_reset_jiffies);
 	unsigned long ts, timeout;
 
@@ -3095,7 +3107,9 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	 *    has long finished its init (matching v1.0.1.33 behavior).
 	 */
 	atomic_inc(ds5_get_reset_gen(state));
-	WRITE_ONCE(state->ds5_dev->cached_device_type, DS5_DEVICE_TYPE_UNKNOWN);
+	if (!d585_proto_reset)
+		WRITE_ONCE(state->ds5_dev->cached_device_type,
+			   DS5_DEVICE_TYPE_UNKNOWN);
 	ds5_reset_streaming_flags(state->ds5_dev);
 
 	/* 3. Scratch one control-status register before reset.
@@ -3128,6 +3142,33 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	/* 5. Delay to allow reset to complete */
 	ts = jiffies;
 	msleep(DS5_HW_RESET_INITIAL_DELAY_MS);
+
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+	if (d585_proto_reset) {
+		struct ds5 *primary = state->ds5_dev->ds5_primary;
+
+		if (!primary || !primary->dser_ops->recover_link)
+			return -ENODEV;
+
+		mutex_lock(&serdes_lock__);
+		ret = primary->ser_ops->reset_control(primary->ser_dev);
+		if (!ret)
+			ret = primary->dser_ops->recover_link(primary->dser_dev,
+						      primary->ser_dev,
+						      primary->gmsl_link);
+		if (!ret)
+			ret = primary->ser_ops->setup_control(primary->ser_dev);
+		if (!ret)
+			ret = primary->ser_ops->init_settings(primary->ser_dev);
+		mutex_unlock(&serdes_lock__);
+		if (ret) {
+			dev_err(&state->client->dev,
+				"%s(): D585 prototype SerDes recovery failed (%d)\n",
+				__func__, ret);
+			return ret;
+		}
+	}
+#endif
 
 	/* 6. Poll for control-status defaults to confirm reset completion. */
 	for (retry = 0, timeout = ts + msecs_to_jiffies(DS5_HW_RESET_TIMEOUT_MS);
@@ -3200,6 +3241,13 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 		dev_err(&state->client->dev,
 			"%s(): Failed to read firmware build: %d\n", __func__, ret);
 		return ret;
+	}
+
+	/* HKR reboot drops its MIPI TX runtime configuration. */
+	if (d585_proto_reset) {
+		ret = ds5_hw_init(state->client, state);
+		if (ret)
+			return ret;
 	}
 
 	dev_info(&state->client->dev,
@@ -3581,6 +3629,16 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 		if (ctrl->p_new.p_u8) {
 			u16 size = 0;
 			struct hwm_cmd *cmd = (struct hwm_cmd *)ctrl->p_new.p_u8;
+
+			u16 pid = READ_ONCE(state->ds5_dev->d585_product_id);
+
+			if (cmd->opcode == 0x20 &&
+			    (pid == D585_2C_PROTO_PID ||
+			     pid == D585_3C_PROTO_PID)) {
+				ret = ds5_hw_reset_with_recovery(state);
+				break;
+			}
+
 			size = *((u8 *)ctrl->p_new.p_u8 + 1) << 8;
 			size |= *((u8 *)ctrl->p_new.p_u8 + 0);
 			ret = ds5_hwmc_send(state, size + 4, cmd);
@@ -4577,6 +4635,7 @@ static void ds5_init_ds5_dev(struct ds5 *state, struct ds5_dev *ds5_dev)
 	ds5_dev->ds5_primary = state;
 	ds5_dev->serdes_setup_complete = false;
 	ds5_dev->cached_device_type = DS5_DEVICE_TYPE_UNKNOWN;
+	ds5_dev->d585_product_id = 0;
 	ds5_dev->configured_device_mode = D500_DEVICE_MODE_3C;
 	ds5_dev->active_device_mode = D500_DEVICE_MODE_3C;
 	ds5_dev->device_mode_valid = false;
@@ -7815,6 +7874,28 @@ static int ds5_probe(struct i2c_client *c
 			"%s(): device type is not valid: %d (last val 0x%x)\n",
 			__func__, ret, rec_state);
 		goto e_chardev;
+	}
+
+	if (rec_state == DS5_DEVICE_TYPE_D58X &&
+	    !READ_ONCE(state->ds5_dev->d585_product_id)) {
+		unsigned char *gvd_data = kzalloc(DS5_GVD_LEN_D5XX, GFP_KERNEL);
+
+		if (gvd_data) {
+			ret = ds5_gvd(state, gvd_data, DS5_GVD_LEN_D5XX);
+			if (ret) {
+				dev_warn(&c->dev,
+					 "%s(): cannot cache D585 PID from GVD (%d)\n",
+					 __func__, ret);
+			} else {
+				u16 pid = gvd_data[D585_GVD_PID_OFFSET] |
+					  (gvd_data[D585_GVD_PID_OFFSET + 1] << 8);
+
+				WRITE_ONCE(state->ds5_dev->d585_product_id, pid);
+				dev_info(&c->dev, "%s(): D585 PID 0x%04x\n",
+					 __func__, pid);
+			}
+			kfree(gvd_data);
+		}
 	}
 
 	ds5_read_with_check(state, DS5_FW_VERSION, &state->fw_version);

--- a/nvidia-oot/6.0/0003-Adding-max96712-support-for-D4xx.patch
+++ b/nvidia-oot/6.0/0003-Adding-max96712-support-for-D4xx.patch
@@ -7,8 +7,8 @@ Add MAX96712 deserializer driver support for D4XX/D5XX cameras.
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- drivers/media/i2c/max96712.c | 1199 +++++++++++++++++++++++++++++++++-
- 1 file changed, 1164 insertions(+), 35 deletions(-)
+ drivers/media/i2c/max96712.c | 1251 +++++++++++++++++++++++++++++++++-
+ 1 file changed, 1216 insertions(+), 35 deletions(-)
 
 diff --git a/drivers/media/i2c/max96712.c b/drivers/media/i2c/max96712.c
 index 8e237ee..c1e57e2 100644
@@ -535,7 +535,7 @@ index 8e237ee..c1e57e2 100644
  		i2c_unregister_device(client);
  		client = NULL;
  	}
-@@ -284,13 +631,794 @@ static void max96712_remove(struct i2c_client *client)
+@@ -284,13 +631,846 @@ static void max96712_remove(struct i2c_client *client)
  #endif
  }
  
@@ -760,10 +760,14 @@ index 8e237ee..c1e57e2 100644
 +}
 +EXPORT_SYMBOL(max96712_release_pipe);
 +
-+static void max96712_reset_oneshot_link_mask(struct max96712 *priv, uint8_t link_mask)
++static int max96712_reset_oneshot_link_mask(struct max96712 *priv, uint8_t link_mask)
 +{
-+	max96712_write_reg(priv, MAX96712_CTRL1_ADDR, link_mask);
++	int err = max96712_write_reg(priv, MAX96712_CTRL1_ADDR, link_mask);
++
++	if (err)
++		return err;
 +	msleep(100);
++	return 0;
 +}
 +
 +void max96712_reset_oneshot(struct device *dev)
@@ -1227,6 +1231,54 @@ index 8e237ee..c1e57e2 100644
 +}
 +EXPORT_SYMBOL(max96712_setup_link);
 +
++int max96712_recover_link(struct device *dev, struct device *ser_dev, u32 link_id)
++{
++	struct max96712 *priv = dev_get_drvdata(dev);
++	struct i2c_client *ser_client = to_i2c_client(ser_dev);
++	u8 target_addr;
++	int restore_err;
++	int err;
++
++	target_addr = ser_client->addr;
++	if (link_id >= MAX96712_MAX_LINKS ||
++	    !(priv->link_mask & BIT(link_id)))
++		return -EINVAL;
++
++	mutex_lock(&priv->lock);
++
++	/* Isolate the requested link so a serializer at the default address
++	 * cannot collide with a serializer on another camera module.
++	 */
++	err = max96712_write_reg(priv, MAX96712_REG6_ADDR,
++				   0xF0 | BIT(link_id));
++	if (!err) {
++		msleep(20);
++		err = max96712_reset_oneshot_link_mask(priv, BIT(link_id));
++	}
++
++	if (!err)
++		err = max96712_wait_for_link_lock_mask(dev, BIT(link_id));
++
++	/* A prototype serializer restarts at the default address. Once the
++	 * deserializer reports link lock, restore the assigned non-zero alias.
++	 */
++	if (!err && target_addr != MAX9295_DEFAULT_ADDR) {
++		err = max96712_write_slave_reg(priv, MAX9295_DEFAULT_ADDR, 0,
++					       target_addr << 1);
++		if (!err)
++			msleep(20);
++	}
++
++	restore_err = max96712_write_reg(priv, MAX96712_REG6_ADDR,
++					     0xF0 | priv->link_mask);
++	if (!err)
++		err = restore_err;
++
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96712_recover_link);
++
 +int max96712_setup_control(struct device *dev, struct device *s_dev)
 +{
 +	struct max96712 *priv = dev_get_drvdata(dev);
@@ -1331,7 +1383,7 @@ index 8e237ee..c1e57e2 100644
  	{ },
  };
  
-@@ -300,6 +1428,7 @@ static struct i2c_driver max96712_i2c_driver = {
+@@ -300,6 +1480,7 @@ static struct i2c_driver max96712_i2c_driver = {
  	.driver = {
  		.name = "max96712",
  		.owner = THIS_MODULE,
@@ -1341,4 +1393,3 @@ index 8e237ee..c1e57e2 100644
  	.remove = max96712_remove,
 -- 
 2.43.0
-

--- a/nvidia-oot/max96712.h
+++ b/nvidia-oot/max96712.h
@@ -58,6 +58,7 @@ void max96712_reset_oneshot(struct device *dev);
  * called per-link from d4xx's ds5_hw_reset_with_recovery(). */
 void max96712_reset_oneshot_link(struct device *dev, u32 link);
 int max96712_setup_link(struct device *dev, struct device *s_dev);
+int max96712_recover_link(struct device *dev, struct device *ser_dev, u32 link);
 int max96712_setup_control(struct device *dev, struct device *s_dev);
 int max96712_reset_control(struct device *dev, struct device *s_dev);
 int max96712_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx);

--- a/nvidia-oot/max96724.c
+++ b/nvidia-oot/max96724.c
@@ -699,6 +699,63 @@ static int max96724_assign_serializer_addresses(struct device *dev)
 	return err;
 }
 
+int max96724_recover_link(struct device *dev, struct device *ser_dev, u32 link)
+{
+	struct i2c_client *ser_client;
+	struct max96724 *priv;
+	unsigned int reg_val = 0;
+	u16 dev_reg = MAX96717_DEV_ADDR;
+	u8 target_addr;
+	int restore_err;
+	int err;
+
+	if (!dev || !ser_dev)
+		return -EINVAL;
+
+	priv = dev_get_drvdata(dev);
+	if (!priv)
+		return -ENODEV;
+	ser_client = to_i2c_client(ser_dev);
+
+	target_addr = ser_client->addr;
+	if (link >= MAX96724_MAX_LINKS || !(priv->link_mask & BIT(link)))
+		return -EINVAL;
+
+	mutex_lock(&priv->lock);
+
+	/*
+	 * Select only the reset camera's link while its serializer is back at
+	 * the default address, then retrain that link without resetting the
+	 * shared deserializer. Other enabled links are briefly gated and restored
+	 * before this function returns.
+	 */
+	err = max96724_enable_links(dev, BIT(link), true);
+	if (!err)
+		err = max96724_wait_link_lock(dev, link);
+	if (!err) {
+		err = max96724_read_slave_reg(priv, target_addr, dev_reg, &reg_val);
+		if (err || reg_val != target_addr << 1) {
+			err = max96724_write_slave_reg(priv, MAX96717_DEFAULT_ADDR,
+						       dev_reg,
+						       target_addr << 1);
+			if (!err) {
+				msleep(20);
+				err = max96724_read_slave_reg(priv, target_addr, dev_reg, &reg_val);
+				if (!err && reg_val != target_addr << 1)
+					err = -ENODEV;
+			}
+		}
+	}
+
+	restore_err = max96724_enable_links(dev, priv->link_mask, false);
+	if (!err)
+		err = restore_err;
+
+	mutex_unlock(&priv->lock);
+	return err;
+}
+EXPORT_SYMBOL(max96724_recover_link);
+
 int max96724_setup_link(struct device *dev, struct device *s_dev)
 {
 	struct max96724 *priv = dev_get_drvdata(dev);

--- a/nvidia-oot/max96724.h
+++ b/nvidia-oot/max96724.h
@@ -81,6 +81,20 @@ int max96724_setup_control(struct device *dev, struct device *s_dev);
 int max96724_reset_control(struct device *dev, struct device *s_dev);
 
 /**
+ * @brief  Restores one serializer link after a remote power cycle.
+ *
+ * The target link is selected from the serializer's assigned I2C address.
+ * Other enabled links are briefly gated for address isolation, then restored;
+ * the shared deserializer is not reset or fully reconfigured.
+ *
+ * @param  [in]  dev          The deserializer device handle.
+ * @param  [in]  ser_dev      The serializer device handle.
+ *
+ * @return  0 for success, or negative error code.
+ */
+int max96724_recover_link(struct device *dev, struct device *ser_dev, u32 link);
+
+/**
  * @brief  Registers a source sensor device with the deserializer.
  *
  * @param  [in]  dev          The deserializer device handle.


### PR DESCRIPTION
## Summary
- detect the physical camera PID from GVD during probe and cache it per camera module
- route HW reset opcode `0x20` through Host recovery only for D585 prototype PIDs `0x0C07` and `0x0C08`
- treat Depth/RGB/IR/IMU as four functions of one physical D585 prototype module and invalidate/recover them together
- keep media and V4L2 nodes bound during recovery, avoiding librealsense re-enumeration races
- preserve the existing D400 and final D585 reset behavior and leave `ds5_gmsl_serdes_setup()` unchanged

## SerDes recovery

Both supported D585 prototype combinations use the same target-link recovery contract:
- MAX96717 -> MAX96712 pixel mode
- MAX96717 -> MAX96724 tunnel mode

For either deserializer, recovery:
- identifies the physical GMSL link from the target serializer assigned alias (`0x40 + link`)
- temporarily selects only that link so a reset serializer at default address `0x40` cannot collide with another module
- retrains the target link and restores its serializer alias when required
- restores the configured deserializer link mask on success and failure
- reapplies only the target MAX96717 control and initialization settings
- restores HKR MIPI TX runtime configuration after HKR reboot

The shared deserializer is not power-cycled or globally reinitialized. Other physical camera modules are not reset, reconfigured, unbound, or re-enumerated. Their active links can be briefly interrupted while the target default address is isolated.

## Scope
The serializer power-cycle workaround is enabled only for D585 prototype PIDs `0x0C07` and `0x0C08`. Final D585 PIDs `0x0C04`, `0x0C05`, and `0x0C06` remain on the existing reset path. If GVD PID detection fails, the driver does not assume prototype hardware.

This PR does not include RAW16 compatibility or unrelated build changes, add delayed work, unbind the camera driver, or modify librealsense.

## Required HKR change
Use together with RealSenseAI-Internal/soc-rs-soc-device-mgr#484. HKR handles opcode `0x20`, reboots the selected module, power-cycles its serializer, and restarts its GMSL state machine.

## Validation
- current d4xx ARM64 translation unit compiles successfully with `-Werror`
- MAX96712 patches apply cleanly to JP5.0.2 (`jetson_35.1`), JP5.1.2 (`jetson_35.4.1`), and JP6 (`jetson_36.3`) source baselines
- focused current-diff `checkpatch.pl`: 0 errors, 0 warnings
- `git diff --check` and patch parser checks passed
- the recovery sequence was previously validated on single-camera MAX96712 pixel mode and MAX96724 tunnel mode; the new PID gate was not hardware-tested because no board is currently available
- MAX96712/MAX96724 multi-camera hardware regression remains required

## Commit policy
The PR branch contains one commit. Follow-up updates will amend and force-with-lease this commit.