### PR TITLE
[RSDSO-21887] enable generic vc mapping

### DIFF
--- a/docs/gmsl-vc-remap.md
+++ b/docs/gmsl-vc-remap.md
@@ -1,0 +1,129 @@
+# GMSL virtual-channel remapping (MAX96712)
+
+Lets a device tree state, per GMSL link, which deserializer CSI virtual channel
+each serializer virtual channel comes out on. Before this, the mapping was
+hardcoded as `dser_vc = link * 4 + ser_vc`, and the link itself was derived from
+the camera's `vc-id` — so VC assignment and link topology could not be chosen
+independently.
+
+Applies to **max96712 only**. max9296 and max96724 are currently single-link in practice
+and keep using the value d4xx passes them unchanged (TODO: max96724 multi-link).
+
+## Device tree
+
+Two properties. The serializer states its link; the deserializer states the map.
+
+```dts
+	dser: max96712@29 {
+		compatible = "maxim,max96712";
+		link-mask = <0x3>;
+		/* <serializer-vc deserializer-vc> */
+		maxim,link0-vc-remap = <0 0>, <1 1>, <2 2>, <3 3>;
+		maxim,link1-vc-remap = <0 4>, <1 5>, <2 6>, <3 7>;
+	};
+
+	ser_a: max96717@40 {
+		maxim,gmsl-link-id = <0>;
+		maxim,gmsl-dser-device = <&dser>;
+	};
+
+	ser_b: max9295_b@41 {
+		maxim,gmsl-link-id = <1>;
+		maxim,gmsl-dser-device = <&dser>;
+	};
+```
+
+The tuple grouping is cosmetic — `<0 0>, <1 1>` and `<0 0 1 1>` compile to the
+same cell array. The driver enforces the stride of 2.
+
+### Rules
+
+- **No table for a link** → unity map, all 8 serializer VCs map to themselves.
+  Usable as-is only on a single-link deserializer.
+- **A table for a link** → it replaces the unity default outright. VCs the table
+  does not list are left *unmapped* and rejected at stream start. Declare exactly
+  the streams the camera uses (today: 4).
+- **A multi-link deserializer must declare a table for every enabled link.** Two
+  links both emitting VC 0-3 would be indistinguishable on the shared CSI output,
+  so the unity default cannot work there. Probe fails with
+  `dser VC <n> mapped more than once`.
+- Deserializer VCs are 5-bit (0-31); serializer VCs are 0-7.
+- `maxim,gmsl-link-id` is optional. Without it d4xx falls back to
+  `vc-id / 4` and logs `no maxim,gmsl-link-id, using link N from vc-id M`,
+  which keeps pre-existing overlays working.
+
+## The deserializer VC appears four times per stream
+
+A remap is only correct if all four agree. Changing the table alone does nothing
+useful — the Tegra side still demultiplexes on the old VC.
+
+| where | consumer |
+|---|---|
+| `maxim,linkN-vc-remap` on the deserializer | max96712 register programming |
+| `ds5_N/ports/port@0/endpoint` `vc-id` | sensor's declared output VC |
+| `ds5_N/gmsl-link/vc-id` | d4xx `g_ctx.dst_vc` |
+| `tegra-capture-vi/ports/port@N/endpoint` `vc-id` | VI channel demux |
+
+The serializer VC never appears in DT. It is the stream index the camera itself
+uses — depth 0, RGB 1, IR 2, IMU 3 — and the driver recovers it by inverting the
+table.
+
+## Driver
+
+`dser_interface` ops take the link explicitly. `vc_id` in these calls is the
+**serializer** VC.
+
+| op | argument |
+|---|---|
+| `get_multi_vc_pipe_id` | `link` |
+| `bind_ser_to_dser_pipe` | `link` |
+| `set_pipe` | `link`, `vc_id` |
+| `reset_oneshot_link` | `link` |
+| `get_ser_vc_id` | `link`, `dser_vc` → serializer VC |
+
+`get_ser_vc_id` is the reverse lookup, and is `NULL` on deserializers that do not
+remap (where the two VCs are the same). d4xx uses it in `ds5_configure()` to
+resolve the serializer VC once per configure.
+
+In the max96712 registers the two VCs are separate fields: the `SRC_n_MAP`
+register carries the incoming serializer VC, `DST_n_MAP` the outgoing one, and
+`MIPI_TX_EXT<n>` carries the high bits of both — destination at bits 4:2, source
+at bits 7:5. They coincide only under the old `link * 4 + ser_vc` layout.
+
+**Camera-side registers use the serializer VC.** `DS5_*_STREAM_MD` is written to
+the camera, so its VC field is the serializer VC, not `dst_vc`. Getting this
+wrong is invisible under an identity map and breaks only the streams that carry
+embedded metadata (depth/RGB/IR, not IMU), because the metadata lands on a VC the
+deserializer has no matching source entry for and the VI channel waits for a line
+that never arrives.
+
+## Limits
+
+- The multi-VC pipe (MAX96717) programs all four of a camera's VCs from one
+  register table, so all four must be mapped. `set_pipe` returns `-EINVAL`
+  otherwise.
+- A duplicate *source* VC within one table is not diagnosed; the last pair wins.
+- Every generation shares one `d4xx.c`, so the max96712 change ships via
+  `nvidia-oot/6.0/0003` (JP6.1/6.2 and JP7 symlink it) and must be ported to the
+  JP5 carriers `kernel/nvidia/5.1.2/0007` and `5.0.2/0017`.
+
+## Example: swapping depth across two links
+
+Both cameras emit depth on their own serializer VC 0. To have link 0's depth
+leave on VC 4 and link 1's on VC 0:
+
+```dts
+	maxim,link0-vc-remap = <0 4>, <1 1>, <2 2>, <3 3>;
+	maxim,link1-vc-remap = <0 0>, <1 5>, <2 6>, <3 7>;
+```
+
+then set `vc-id` to 4 on link 0's depth `ds5` node (endpoint and `gmsl-link`) and
+on its VI channel, and to 0 on link 1's. The union of both tables stays 8 distinct
+VCs, so the collision check passes; swapping only one side would fail probe.
+
+Confirm from dmesg — `max96712_set_pipe` logs the resolved pair:
+
+```
+max96712_set_pipe pipe_id 0, ... link 0, vc_id 0 -> dser vc 4
+max96712_set_pipe pipe_id 1, ... link 1, vc_id 0 -> dser vc 0
+```

--- a/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-16ch-cams-0-1-2-3.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-16ch-cams-0-1-2-3.dts
@@ -704,12 +704,18 @@
 								link-mask = <0xf>;
 								channel = "a";
 								pwdn-gpios = <&gpio CAM0_PWDN GPIO_ACTIVE_HIGH>;
+								/* <serializer-vc deserializer-vc> */
+								maxim,link0-vc-remap = <0 0>, <1 1>, <2 2>, <3 3>;
+								maxim,link1-vc-remap = <0 4>, <1 5>, <2 6>, <3 7>;
+								maxim,link2-vc-remap = <0 8>, <1 9>, <2 10>, <3 11>;
+								maxim,link3-vc-remap = <0 12>, <1 13>, <2 14>, <3 15>;
 							};
 
 							ser_a: max9295_a@40 {
 								status = "okay";
 								compatible = "maxim,max9295";
 								reg = <0x40>;
+								maxim,gmsl-link-id = <0>;
 								maxim,gmsl-dser-device = <&dser>;
 								external_addr_reassign;
 							};
@@ -718,6 +724,7 @@
 								status = "okay";
 								compatible = "maxim,max9295";
 								reg = <0x41>;
+								maxim,gmsl-link-id = <1>;
 								maxim,gmsl-dser-device = <&dser>;
 								external_addr_reassign;
 							};
@@ -726,6 +733,7 @@
 								status = "okay";
 								compatible = "maxim,max9295";
 								reg = <0x42>;
+								maxim,gmsl-link-id = <2>;
 								maxim,gmsl-dser-device = <&dser>;
 								external_addr_reassign;
 							};
@@ -734,6 +742,7 @@
 								status = "okay";
 								compatible = "maxim,max9295";
 								reg = <0x43>;
+								maxim,gmsl-link-id = <3>;
 								maxim,gmsl-dser-device = <&dser>;
 								external_addr_reassign;
 							};

--- a/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-16ch-cams-0-1-2-3.dtso
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-16ch-cams-0-1-2-3.dtso
@@ -714,12 +714,18 @@
 								link-mask = <0xf>;
 								channel = "a";
 								pwdn-gpios = <&gpio CAM0_PWDN GPIO_ACTIVE_HIGH>;
+								/* <serializer-vc deserializer-vc> */
+								maxim,link0-vc-remap = <0 0>, <1 1>, <2 2>, <3 3>;
+								maxim,link1-vc-remap = <0 4>, <1 5>, <2 6>, <3 7>;
+								maxim,link2-vc-remap = <0 8>, <1 9>, <2 10>, <3 11>;
+								maxim,link3-vc-remap = <0 12>, <1 13>, <2 14>, <3 15>;
 							};
 
 							ser_a: max9295_a@40 {
 								status = "okay";
 								compatible = "maxim,max9295";
 								reg = <0x40>;
+								maxim,gmsl-link-id = <0>;
 								maxim,gmsl-dser-device = <&dser>;
 								external_addr_reassign;
 							};
@@ -728,6 +734,7 @@
 								status = "okay";
 								compatible = "maxim,max9295";
 								reg = <0x41>;
+								maxim,gmsl-link-id = <1>;
 								maxim,gmsl-dser-device = <&dser>;
 								external_addr_reassign;
 							};
@@ -736,6 +743,7 @@
 								status = "okay";
 								compatible = "maxim,max9295";
 								reg = <0x42>;
+								maxim,gmsl-link-id = <2>;
 								maxim,gmsl-dser-device = <&dser>;
 								external_addr_reassign;
 							};
@@ -744,6 +752,7 @@
 								status = "okay";
 								compatible = "maxim,max9295";
 								reg = <0x43>;
+								maxim,gmsl-link-id = <3>;
 								maxim,gmsl-dser-device = <&dser>;
 								external_addr_reassign;
 							};

--- a/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-16ch-cams-0-1-d5xx-d4xx.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-16ch-cams-0-1-d5xx-d4xx.dts
@@ -417,12 +417,16 @@
 								link-mask = <0x3>;
 								channel = "a";
 								pwdn-gpios = <&gpio CAM0_PWDN GPIO_ACTIVE_HIGH>;
+								/* <serializer-vc deserializer-vc> */
+								maxim,link0-vc-remap = <0 0>, <1 1>, <2 2>, <3 3>;
+								maxim,link1-vc-remap = <0 4>, <1 5>, <2 6>, <3 7>;
 							};
 
 							ser_a: max96717@40 {
 								status = "okay";
 								compatible = "maxim,max96717";
 								reg = <0x40>;
+								maxim,gmsl-link-id = <0>;
 								maxim,gmsl-dser-device = <&dser>;
 								external_addr_reassign;
 							};
@@ -431,6 +435,7 @@
 								status = "okay";
 								compatible = "maxim,max9295";
 								reg = <0x41>;
+								maxim,gmsl-link-id = <1>;
 								maxim,gmsl-dser-device = <&dser>;
 								external_addr_reassign;
 							};

--- a/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-16ch-cams-0-1.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-16ch-cams-0-1.dts
@@ -416,12 +416,16 @@
 								link-mask = <0x3>;
 								channel = "a";
 								pwdn-gpios = <&gpio CAM0_PWDN GPIO_ACTIVE_HIGH>;
+								/* <serializer-vc deserializer-vc> */
+								maxim,link0-vc-remap = <0 0>, <1 1>, <2 2>, <3 3>;
+								maxim,link1-vc-remap = <0 4>, <1 5>, <2 6>, <3 7>;
 							};
 
 							ser_a: max9295_a@40 {
 								status = "okay";
 								compatible = "maxim,max9295";
 								reg = <0x40>;
+								maxim,gmsl-link-id = <0>;
 								maxim,gmsl-dser-device = <&dser>;
 								external_addr_reassign;
 							};
@@ -430,6 +434,7 @@
 								status = "okay";
 								compatible = "maxim,max9295";
 								reg = <0x41>;
+								maxim,gmsl-link-id = <1>;
 								maxim,gmsl-dser-device = <&dser>;
 								external_addr_reassign;
 							};

--- a/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-16ch-d5xx.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-16ch-d5xx.dts
@@ -270,12 +270,15 @@
 								lane_cnt = <4>;
 								channel = "a";
 								pwdn-gpios = <&gpio CAM0_PWDN GPIO_ACTIVE_HIGH>;
+								/* <serializer-vc deserializer-vc> */
+								maxim,link0-vc-remap = <0 0>, <1 1>, <2 2>, <3 3>;
 							};
 
 							ser_a: max96717@40 {
 								status = "okay";
 								compatible = "maxim,max96717";
 								reg = <0x40>;
+								maxim,gmsl-link-id = <0>;
 								maxim,gmsl-dser-device = <&dser>;
 							};
 

--- a/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-4ch-cams-0-1-2-3.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-4ch-cams-0-1-2-3.dts
@@ -870,12 +870,18 @@
 						channel = "a";
 						fangzhu,fg12-reverse-lane-polarity;
 						fangzhu,fg12-poc-enable;
+						/* <serializer-vc deserializer-vc> */
+						maxim,link0-vc-remap = <0 0>, <1 1>, <2 2>, <3 3>;
+						maxim,link1-vc-remap = <0 4>, <1 5>, <2 6>, <3 7>;
+						maxim,link2-vc-remap = <0 8>, <1 9>, <2 10>, <3 11>;
+						maxim,link3-vc-remap = <0 12>, <1 13>, <2 14>, <3 15>;
 					};
 
 					ser_a: max9295_a@40 {
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x40>;
+						maxim,gmsl-link-id = <0>;
 						maxim,gmsl-dser-device = <&dser>;
 						external_addr_reassign;
 					};
@@ -884,6 +890,7 @@
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x41>;
+						maxim,gmsl-link-id = <1>;
 						maxim,gmsl-dser-device = <&dser>;
 						external_addr_reassign;
 					};
@@ -892,6 +899,7 @@
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x42>;
+						maxim,gmsl-link-id = <2>;
 						maxim,gmsl-dser-device = <&dser>;
 						external_addr_reassign;
 					};
@@ -900,6 +908,7 @@
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x43>;
+						maxim,gmsl-link-id = <3>;
 						maxim,gmsl-dser-device = <&dser>;
 						external_addr_reassign;
 					};

--- a/hardware/realsense/tegra234-camera-d4xx-overlay-max96712-EVB-cams-0-1.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-max96712-EVB-cams-0-1.dts
@@ -346,18 +346,23 @@
 								lane_cnt = <4>;
 								link-mask = <0x3>;
 								channel = "a";
+								/* <serializer-vc deserializer-vc> */
+								maxim,link0-vc-remap = <0 0>, <1 1>, <2 2>, <3 3>;
+								maxim,link1-vc-remap = <0 4>, <1 5>, <2 6>, <3 7>;
 							};
 
 							ser_a: max9295_a@40 {
 								status = "okay";
 								compatible = "maxim,max9295";
 								reg = <0x40>;
+								maxim,gmsl-link-id = <0>;
 								maxim,gmsl-dser-device = <&dser>;
 							};
 							ser_b: max9295_b@41 {
 								status = "okay";
 								compatible = "maxim,max9295";
 								reg = <0x41>;
+								maxim,gmsl-link-id = <1>;
 								maxim,gmsl-dser-device = <&dser>;
 							};
 

--- a/hardware/realsense/tegra234-camera-d4xx-overlay-seeed-cams-0-1-2-3.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-seeed-cams-0-1-2-3.dts
@@ -826,12 +826,18 @@
 						link-mask = <0xf>;
 						channel = "a";
 						force_clk0;
+						/* <serializer-vc deserializer-vc> */
+						maxim,link0-vc-remap = <0 0>, <1 1>, <2 2>, <3 3>;
+						maxim,link1-vc-remap = <0 4>, <1 5>, <2 6>, <3 7>;
+						maxim,link2-vc-remap = <0 8>, <1 9>, <2 10>, <3 11>;
+						maxim,link3-vc-remap = <0 12>, <1 13>, <2 14>, <3 15>;
 					};
 
 					ser_a: max9295_a@40 {
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x40>;
+						maxim,gmsl-link-id = <0>;
 						maxim,gmsl-dser-device = <&dser>;
 						external_addr_reassign;
 					};
@@ -840,6 +846,7 @@
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x41>;
+						maxim,gmsl-link-id = <1>;
 						maxim,gmsl-dser-device = <&dser>;
 						external_addr_reassign;
 					};
@@ -848,6 +855,7 @@
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x42>;
+						maxim,gmsl-link-id = <2>;
 						maxim,gmsl-dser-device = <&dser>;
 						external_addr_reassign;
 					};
@@ -856,6 +864,7 @@
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x43>;
+						maxim,gmsl-link-id = <3>;
 						maxim,gmsl-dser-device = <&dser>;
 						external_addr_reassign;
 					};

--- a/hardware/realsense/tegra234-camera-d4xx-overlay-seeed-cams-0-1-2.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-seeed-cams-0-1-2.dts
@@ -634,12 +634,17 @@
 						link-mask = <0x7>;
 						channel = "a";
 						force_clk0;
+						/* <serializer-vc deserializer-vc> */
+						maxim,link0-vc-remap = <0 0>, <1 1>, <2 2>, <3 3>;
+						maxim,link1-vc-remap = <0 4>, <1 5>, <2 6>, <3 7>;
+						maxim,link2-vc-remap = <0 8>, <1 9>, <2 10>, <3 11>;
 					};
 
 					ser_a: max9295_a@40 {
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x40>;
+						maxim,gmsl-link-id = <0>;
 						maxim,gmsl-dser-device = <&dser>;
 						external_addr_reassign;
 					};
@@ -648,6 +653,7 @@
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x41>;
+						maxim,gmsl-link-id = <1>;
 						maxim,gmsl-dser-device = <&dser>;
 						external_addr_reassign;
 					};
@@ -656,6 +662,7 @@
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x42>;
+						maxim,gmsl-link-id = <2>;
 						maxim,gmsl-dser-device = <&dser>;
 						external_addr_reassign;
 					};

--- a/hardware/realsense/tegra234-camera-d4xx-overlay-seeed-cams-0-1.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-seeed-cams-0-1.dts
@@ -442,12 +442,16 @@
 						link-mask = <0x3>;
 						channel = "a";
 						force_clk0;
+						/* <serializer-vc deserializer-vc> */
+						maxim,link0-vc-remap = <0 0>, <1 1>, <2 2>, <3 3>;
+						maxim,link1-vc-remap = <0 4>, <1 5>, <2 6>, <3 7>;
 					};
 
 					ser_a: max9295_a@40 {
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x40>;
+						maxim,gmsl-link-id = <0>;
 						maxim,gmsl-dser-device = <&dser>;
 						external_addr_reassign;
 					};
@@ -456,6 +460,7 @@
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x41>;
+						maxim,gmsl-link-id = <1>;
 						maxim,gmsl-dser-device = <&dser>;
 						external_addr_reassign;
 					};

--- a/hardware/realsense/tegra264-camera-d4xx-overlay-advantech-cams-0-1-2-3-4-5-6-7.dtso
+++ b/hardware/realsense/tegra264-camera-d4xx-overlay-advantech-cams-0-1-2-3-4-5-6-7.dtso
@@ -1599,12 +1599,18 @@
 						link-mask = <0xf>;
 						channel = "a";
 						force_clk0;
+						/* <serializer-vc deserializer-vc> */
+						maxim,link0-vc-remap = <0 0>, <1 1>, <2 2>, <3 3>;
+						maxim,link1-vc-remap = <0 4>, <1 5>, <2 6>, <3 7>;
+						maxim,link2-vc-remap = <0 8>, <1 9>, <2 10>, <3 11>;
+						maxim,link3-vc-remap = <0 12>, <1 13>, <2 14>, <3 15>;
 					};
 
 					ser_a: max9295_a@40 {
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x40>;
+						maxim,gmsl-link-id = <0>;
 						maxim,gmsl-dser-device = <&dser_a>;
 						external_addr_reassign;
 					};
@@ -1613,6 +1619,7 @@
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x41>;
+						maxim,gmsl-link-id = <1>;
 						maxim,gmsl-dser-device = <&dser_a>;
 						external_addr_reassign;
 					};
@@ -1621,6 +1628,7 @@
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x42>;
+						maxim,gmsl-link-id = <2>;
 						maxim,gmsl-dser-device = <&dser_a>;
 						external_addr_reassign;
 					};
@@ -1629,6 +1637,7 @@
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x43>;
+						maxim,gmsl-link-id = <3>;
 						maxim,gmsl-dser-device = <&dser_a>;
 						external_addr_reassign;
 					};
@@ -2416,12 +2425,18 @@
 						link-mask = <0xf>;
 						channel = "b";
 						force_clk0;
+						/* <serializer-vc deserializer-vc> */
+						maxim,link0-vc-remap = <0 0>, <1 1>, <2 2>, <3 3>;
+						maxim,link1-vc-remap = <0 4>, <1 5>, <2 6>, <3 7>;
+						maxim,link2-vc-remap = <0 8>, <1 9>, <2 10>, <3 11>;
+						maxim,link3-vc-remap = <0 12>, <1 13>, <2 14>, <3 15>;
 					};
 
 					ser_e: max9295_e@40 {
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x40>;
+						maxim,gmsl-link-id = <0>;
 						maxim,gmsl-dser-device = <&dser_b>;
 						external_addr_reassign;
 					};
@@ -2430,6 +2445,7 @@
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x41>;
+						maxim,gmsl-link-id = <1>;
 						maxim,gmsl-dser-device = <&dser_b>;
 						external_addr_reassign;
 					};
@@ -2438,6 +2454,7 @@
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x42>;
+						maxim,gmsl-link-id = <2>;
 						maxim,gmsl-dser-device = <&dser_b>;
 						external_addr_reassign;
 					};
@@ -2446,6 +2463,7 @@
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x43>;
+						maxim,gmsl-link-id = <3>;
 						maxim,gmsl-dser-device = <&dser_b>;
 						external_addr_reassign;
 					};

--- a/hardware/realsense/tegra264-camera-d4xx-overlay-advantech-cams-0-1-2-3-4-5.dtso
+++ b/hardware/realsense/tegra264-camera-d4xx-overlay-advantech-cams-0-1-2-3-4-5.dtso
@@ -1215,12 +1215,18 @@
 						link-mask = <0xf>;
 						channel = "a";
 						force_clk0;
+						/* <serializer-vc deserializer-vc> */
+						maxim,link0-vc-remap = <0 0>, <1 1>, <2 2>, <3 3>;
+						maxim,link1-vc-remap = <0 4>, <1 5>, <2 6>, <3 7>;
+						maxim,link2-vc-remap = <0 8>, <1 9>, <2 10>, <3 11>;
+						maxim,link3-vc-remap = <0 12>, <1 13>, <2 14>, <3 15>;
 					};
 
 					ser_a: max9295_a@40 {
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x40>;
+						maxim,gmsl-link-id = <0>;
 						maxim,gmsl-dser-device = <&dser_a>;
 						external_addr_reassign;
 					};
@@ -1229,6 +1235,7 @@
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x41>;
+						maxim,gmsl-link-id = <1>;
 						maxim,gmsl-dser-device = <&dser_a>;
 						external_addr_reassign;
 					};
@@ -1237,6 +1244,7 @@
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x42>;
+						maxim,gmsl-link-id = <2>;
 						maxim,gmsl-dser-device = <&dser_a>;
 						external_addr_reassign;
 					};
@@ -1245,6 +1253,7 @@
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x43>;
+						maxim,gmsl-link-id = <3>;
 						maxim,gmsl-dser-device = <&dser_a>;
 						external_addr_reassign;
 					};
@@ -2032,12 +2041,16 @@
 						link-mask = <0x3>;
 						channel = "b";
 						force_clk0;
+						/* <serializer-vc deserializer-vc> */
+						maxim,link0-vc-remap = <0 0>, <1 1>, <2 2>, <3 3>;
+						maxim,link1-vc-remap = <0 4>, <1 5>, <2 6>, <3 7>;
 					};
 
 					ser_e: max9295_a@40 {
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x40>;
+						maxim,gmsl-link-id = <0>;
 						maxim,gmsl-dser-device = <&dser_b>;
 						external_addr_reassign;
 					};
@@ -2046,6 +2059,7 @@
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x41>;
+						maxim,gmsl-link-id = <1>;
 						maxim,gmsl-dser-device = <&dser_b>;
 						external_addr_reassign;
 					};

--- a/hardware/realsense/tegra264-camera-d4xx-overlay-advantech-cams-0-1-2-3.dtso
+++ b/hardware/realsense/tegra264-camera-d4xx-overlay-advantech-cams-0-1-2-3.dtso
@@ -824,12 +824,18 @@
 						link-mask = <0xf>;
 						channel = "a";
 						force_clk0;
+						/* <serializer-vc deserializer-vc> */
+						maxim,link0-vc-remap = <0 0>, <1 1>, <2 2>, <3 3>;
+						maxim,link1-vc-remap = <0 4>, <1 5>, <2 6>, <3 7>;
+						maxim,link2-vc-remap = <0 8>, <1 9>, <2 10>, <3 11>;
+						maxim,link3-vc-remap = <0 12>, <1 13>, <2 14>, <3 15>;
 					};
 
 					ser_a: max9295_a@40 {
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x40>;
+						maxim,gmsl-link-id = <0>;
 						maxim,gmsl-dser-device = <&dser>;
 						external_addr_reassign;
 					};
@@ -838,6 +844,7 @@
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x41>;
+						maxim,gmsl-link-id = <1>;
 						maxim,gmsl-dser-device = <&dser>;
 						external_addr_reassign;
 					};
@@ -846,6 +853,7 @@
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x42>;
+						maxim,gmsl-link-id = <2>;
 						maxim,gmsl-dser-device = <&dser>;
 						external_addr_reassign;
 					};
@@ -854,6 +862,7 @@
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x43>;
+						maxim,gmsl-link-id = <3>;
 						maxim,gmsl-dser-device = <&dser>;
 						external_addr_reassign;
 					};

--- a/hardware/realsense/tegra264-camera-d4xx-overlay-advantech-cams-4-5-6-7.dtso
+++ b/hardware/realsense/tegra264-camera-d4xx-overlay-advantech-cams-4-5-6-7.dtso
@@ -824,12 +824,18 @@
 						link-mask = <0xf>;
 						channel = "a";
 						force_clk0;
+						/* <serializer-vc deserializer-vc> */
+						maxim,link0-vc-remap = <0 0>, <1 1>, <2 2>, <3 3>;
+						maxim,link1-vc-remap = <0 4>, <1 5>, <2 6>, <3 7>;
+						maxim,link2-vc-remap = <0 8>, <1 9>, <2 10>, <3 11>;
+						maxim,link3-vc-remap = <0 12>, <1 13>, <2 14>, <3 15>;
 					};
 
 					ser_a: max9295_a@40 {
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x40>;
+						maxim,gmsl-link-id = <0>;
 						maxim,gmsl-dser-device = <&dser_a>;
 						external_addr_reassign;
 					};
@@ -838,6 +844,7 @@
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x41>;
+						maxim,gmsl-link-id = <1>;
 						maxim,gmsl-dser-device = <&dser_a>;
 						external_addr_reassign;
 					};
@@ -846,6 +853,7 @@
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x42>;
+						maxim,gmsl-link-id = <2>;
 						maxim,gmsl-dser-device = <&dser_a>;
 						external_addr_reassign;
 					};
@@ -854,6 +862,7 @@
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x43>;
+						maxim,gmsl-link-id = <3>;
 						maxim,gmsl-dser-device = <&dser_a>;
 						external_addr_reassign;
 					};

--- a/hardware/realsense/tegra264-camera-d4xx-overlay-advantech-cams-4-5.dtso
+++ b/hardware/realsense/tegra264-camera-d4xx-overlay-advantech-cams-4-5.dtso
@@ -440,12 +440,16 @@
 						link-mask = <0x3>;
 						channel = "a";
 						force_clk0;
+						/* <serializer-vc deserializer-vc> */
+						maxim,link0-vc-remap = <0 0>, <1 1>, <2 2>, <3 3>;
+						maxim,link1-vc-remap = <0 4>, <1 5>, <2 6>, <3 7>;
 					};
 
 					ser_a: max9295_a@40 {
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x40>;
+						maxim,gmsl-link-id = <0>;
 						maxim,gmsl-dser-device = <&dser>;
 						external_addr_reassign;
 					};
@@ -454,6 +458,7 @@
 						status = "okay";
 						compatible = "maxim,max9295";
 						reg = <0x41>;
+						maxim,gmsl-link-id = <1>;
 						maxim,gmsl-dser-device = <&dser>;
 						external_addr_reassign;
 					};

--- a/kernel/nvidia/5.0.2/0017-Adding-max96712-support-for-D4xx.patch
+++ b/kernel/nvidia/5.0.2/0017-Adding-max96712-support-for-D4xx.patch
@@ -7,14 +7,14 @@ Add MAX96712 deserializer driver support for D4XX cameras.
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- drivers/media/i2c/max96712.c | 911 ++++++++++++++++++++++++++++++++++++++++++-
- 1 file changed, 908 insertions(+), 3 deletions(-)
+ drivers/media/i2c/max96712.c | 1106 +++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 1103 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/media/i2c/max96712.c b/drivers/media/i2c/max96712.c
-index 8081385f0..aaa115696 100644
+index 8081385f0..9f1816fbf 100644
 --- a/drivers/media/i2c/max96712.c
 +++ b/drivers/media/i2c/max96712.c
-@@ -21,18 +21,148 @@
+@@ -21,18 +21,168 @@
  #include <linux/debugfs.h>
  #include <media/camera_common.h>
  #include <linux/module.h>
@@ -60,6 +60,7 @@ index 8081385f0..aaa115696 100644
 +#define MAX96712_MIPI_TX_EXT12_ADDR 0x80c
 +#define MAX96712_MIPI_TX_EXT13_ADDR 0x80d
 +#define MAX96712_MIPI_TX_EXT14_ADDR 0x80e
++#define MAX96712_MIPI_TX_EXT15_ADDR 0x80f
 +
 +#define MAX96712_MIPI_PHY0_ADDR 0x8A0
 +#define MAX96712_MIPI_PHY2_ADDR 0x8A2
@@ -128,7 +129,22 @@ index 8081385f0..aaa115696 100644
 +/* data defines */
 +#define MAX96712_MAX_LINKS 4
 +#define MAX96712_MAX_PIPES 8
-+#define MAX9295_MAX_STREAMS 4
++/* Extended CSI VC: two low bits live in the SRC/DST map regs, three high bits
++ * in MIPI_TX_EXT<n> - DST at bits 4:2, SRC at bits 7:5. */
++#define MAX96712_MAX_VCS 32
++#define MAX96712_EXT_VC_DST_SHIFT 2
++#define MAX96712_EXT_VC_SRC_SHIFT 5
++/* Serializer VCs a link may present, i.e. the streams one camera can carry. */
++#define MAX96712_MAX_SER_VCS 8
++#define MAX96712_VC_UNMAPPED 0xFF
++#define MAX96712_VC_REMAP_CELLS 2
++
++/* MIPI_TX_EXT<n>: high bits of the source and destination virtual channels. */
++static inline u8 max96712_ext_vc(u32 src_vc, u32 dst_vc)
++{
++	return ((src_vc >> 2) << MAX96712_EXT_VC_SRC_SHIFT) |
++	       ((dst_vc >> 2) << MAX96712_EXT_VC_DST_SHIFT);
++}
  
  struct max96712 {
  	struct i2c_client *i2c_client;
@@ -150,6 +166,10 @@ index 8081385f0..aaa115696 100644
 +	 */
 +	int link_multi_vc_pipe[MAX96712_MAX_LINKS];
 +	bool multi_vc_configured[MAX96712_MAX_PIPES];
++	/* Serializer VC -> deserializer VC, or MAX96712_VC_UNMAPPED. A link with
++	 * no maxim,linkN-vc-remap gets a unity map; one with a table gets only
++	 * the VCs that table declares. */
++	u8 vc_remap[MAX96712_MAX_LINKS][MAX96712_MAX_SER_VCS];
 +	bool force_clk0;
 +	int lane_cnt;
 +	bool fangzhu_fg12_reverse_lane_polarity;
@@ -164,7 +184,7 @@ index 8081385f0..aaa115696 100644
  {
  	struct i2c_client *i2c_client = NULL;
  	int bak = 0;
-@@ -85,6 +215,52 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
+@@ -85,6 +235,52 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
  
  EXPORT_SYMBOL(max96712_read_reg_Dser);
  
@@ -217,7 +237,7 @@ index 8081385f0..aaa115696 100644
  static int max96712_read_reg(struct max96712 *priv,
  			u16 addr, unsigned int *val)
  {
-@@ -99,6 +275,20 @@ static int max96712_read_reg(struct max96712 *priv,
+@@ -99,6 +295,20 @@ static int max96712_read_reg(struct max96712 *priv,
  	return err;
  }
  
@@ -238,7 +258,7 @@ index 8081385f0..aaa115696 100644
  
  static int max96712_stats_show(struct seq_file *s, void *data)
  {
-@@ -169,7 +359,10 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -169,7 +379,10 @@ static int max96712_debugfs_init(const char *dir_name,
  	if (np) {
  		err = of_property_read_string(np, "channel", &priv->channel);
  		if (err)
@@ -249,7 +269,7 @@ index 8081385f0..aaa115696 100644
  
  		err = snprintf(dev_name, sizeof(dev_name), "max96712_%s", priv->channel);
  		if (err < 0)
-@@ -208,7 +401,8 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -208,18 +421,121 @@ static int max96712_debugfs_init(const char *dir_name,
  static  struct regmap_config max96712_regmap_config = {
  	.reg_bits = 16,
  	.val_bits = 8,
@@ -258,8 +278,104 @@ index 8081385f0..aaa115696 100644
 +	.cache_type = REGCACHE_NONE,
  };
  
++/*
++ * Parse the optional per-link "maxim,linkN-vc-remap" tables, each a list of
++ * <serializer-vc deserializer-vc> pairs. A link with no table keeps the unity
++ * map; a link with one, maps exactly the VCs it lists and leaves the rest
++ * unmapped, so every link of a multi-link deserializer has to declare a table.
++ */
++static int max96712_parse_vc_remap(struct max96712 *priv, struct device_node *np)
++{
++	struct device *dev = &priv->i2c_client->dev;
++	unsigned int link;
++	u32 dser_vc_seen_mask = 0;
++	int map_elems, err, i;
++
++	/* Default unity mapping table */
++	for (link = 0; link < MAX96712_MAX_LINKS; link++) {
++		for (i = 0; i < MAX96712_MAX_SER_VCS; i++) {
++			priv->vc_remap[link][i] = i;
++		}
++	}
++
++	if (!np) {
++		return 0;
++	}
++
++	for (link = 0; link < MAX96712_MAX_LINKS; link++) {
++		char link_map_prop[32];
++		u32 src, dst;
++
++		snprintf(link_map_prop, sizeof(link_map_prop), "maxim,link%u-vc-remap", link);
++
++		map_elems = of_property_count_u32_elems(np, link_map_prop);
++		/* -EINVAL means absent; anything else negative is malformed. */
++		if (map_elems == -EINVAL)
++			continue;
++		if (map_elems < 0) {
++			dev_err(dev, "%s: unreadable (%d)\n", link_map_prop, map_elems);
++			return map_elems;
++		}
++		if (!(priv->link_mask & (1 << link))) {
++			dev_err(dev, "%s: link not enabled by link-mask 0x%x\n",
++				link_map_prop, priv->link_mask);
++			return -EINVAL;
++		}
++		if (map_elems % MAX96712_VC_REMAP_CELLS ||
++		    map_elems > MAX96712_MAX_SER_VCS * MAX96712_VC_REMAP_CELLS) {
++			dev_err(dev, "%s: %d cells, expected up to %d <ser dser> pairs\n",
++				link_map_prop, map_elems, MAX96712_MAX_SER_VCS);
++			return -EINVAL;
++		}
++
++		/* An explicit table replaces the unity default outright: VCs it
++		 * does not list stay unmapped. */
++		for (i = 0; i < MAX96712_MAX_SER_VCS; i++) {
++			priv->vc_remap[link][i] = MAX96712_VC_UNMAPPED;
++		}
++
++		/* Start filling the map */
++		for (i = 0; i < map_elems; i += MAX96712_VC_REMAP_CELLS) {
++			err = of_property_read_u32_index(np, link_map_prop, i, &src);
++			if (!err)
++				err = of_property_read_u32_index(np, link_map_prop, i + 1, &dst);
++			if (err) {
++				dev_err(dev, "%s: read failed (%d)\n", link_map_prop, err);
++				return err;
++			}
++			if (src >= MAX96712_MAX_SER_VCS || dst >= MAX96712_MAX_VCS) {
++				dev_err(dev, "%s: illegal pair <%u %u>\n", link_map_prop, src, dst);
++				return -EINVAL;
++			}
++			priv->vc_remap[link][src] = dst;
++		}
++	}
++
++	/* Validation loop - Making sure there are no dst vc collisions */
++	for (link = 0; link < MAX96712_MAX_LINKS; link++) {
++		if (!(priv->link_mask & (1 << link)))
++			continue;
++		for (i = 0; i < MAX96712_MAX_SER_VCS; i++) {
++			u8 vc = priv->vc_remap[link][i];
++
++			if (vc == MAX96712_VC_UNMAPPED)
++				continue;
++			if (dser_vc_seen_mask & (1u << vc)) {
++				dev_err(dev,
++					"dser VC %u mapped more than once, output VCs must be unique\n",
++					vc);
++				return -EINVAL;
++			}
++			dser_vc_seen_mask |= 1u << vc;
++			dev_dbg(dev, "link %u src_vc: %u dst_vc: %u\n", link, i, priv->vc_remap[link][i]);
++		}
++	}
++
++	return 0;
++}
++
  static int max96712_probe(struct i2c_client *client,
-@@ -216,10 +410,16 @@ static int max96712_probe(struct i2c_client *client,
+ 				const struct i2c_device_id *id)
  {
  	struct max96712 *priv;
  	int err = 0;
@@ -276,7 +392,7 @@ index 8081385f0..aaa115696 100644
  	priv->i2c_client = client;
  	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
  				&max96712_regmap_config);
-@@ -228,10 +428,60 @@ static int max96712_probe(struct i2c_client *client,
+@@ -228,10 +544,64 @@ static int max96712_probe(struct i2c_client *client,
  			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
  		return -ENODEV;
  	}
@@ -327,6 +443,10 @@ index 8081385f0..aaa115696 100644
 +			of_property_read_bool(np, "fangzhu,fg12-poc-enable");
 +	}
 +
++	err = max96712_parse_vc_remap(priv, np);
++	if (err)
++		return err;
++
 +	dev_set_drvdata(&client->dev, priv);
  
  	err = max96712_debugfs_init(NULL, NULL, NULL, priv);
@@ -337,7 +457,7 @@ index 8081385f0..aaa115696 100644
  
  	/*set daymode by fault*/
  	dev_info(&client->dev, "%s:  success\n", __func__);
-@@ -243,8 +493,12 @@ static int max96712_probe(struct i2c_client *client,
+@@ -243,8 +613,12 @@ static int max96712_probe(struct i2c_client *client,
  static int
  max96712_remove(struct i2c_client *client)
  {
@@ -350,7 +470,7 @@ index 8081385f0..aaa115696 100644
  		i2c_unregister_device(client);
  		client = NULL;
  	}
-@@ -252,13 +506,663 @@ max96712_remove(struct i2c_client *client)
+@@ -252,13 +626,738 @@ max96712_remove(struct i2c_client *client)
  	return 0;
  }
  
@@ -443,20 +563,19 @@ index 8081385f0..aaa115696 100644
 +}
 +
 +/*
-+ * Allocate (or return the already-allocated) multi-VC pipe for the link that
-+ * owns vc_id. Used for MAX96717 serializers, which route all of a camera's
++ * Allocate (or return the already-allocated) multi-VC pipe for a link. Used
++ * for MAX96717 serializers, which route all of a camera's
 + * virtual channels through a single serializer pipe. The pipe is dedicated to
 + * the link for the driver's lifetime: every stream of that camera reuses it and
 + * max96712_release_pipe() never frees it.
 + */
-+int max96712_get_multi_vc_pipe_id(struct device *dev, int vc_id)
++int max96712_get_multi_vc_pipe_id(struct device *dev, u32 link)
 +{
 +	struct max96712 *priv = dev_get_drvdata(dev);
-+	int link = vc_id / MAX9295_MAX_STREAMS;
 +	int pipe_id = -ENOSR;
 +	int i;
 +
-+	if (link < 0 || link >= MAX96712_MAX_LINKS)
++	if (link >= MAX96712_MAX_LINKS)
 +		return -EINVAL;
 +
 +	mutex_lock(&priv->lock);
@@ -483,11 +602,11 @@ index 8081385f0..aaa115696 100644
 +}
 +EXPORT_SYMBOL(max96712_get_multi_vc_pipe_id);
 +
-+static int __max96712_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id)
++static int __max96712_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
++					    int ser_pipe_id, u32 link_id)
 +{
 +	struct max96712 *priv = dev_get_drvdata(dev);
 +	unsigned int pipe_sel_val = 0;
-+	u32 link_id = vc_id / MAX9295_MAX_STREAMS;
 +	int err = 0;
 +
 +	/* dser_pipe_id will be connected to ser_pipe_id of link_id */
@@ -513,6 +632,28 @@ index 8081385f0..aaa115696 100644
 +
 +	return err;
 +}
++
++/*
++ * Reverse the link's VC map: which serializer VC arrives as dser_vc.
++ * vc_remap is written once at probe, so this needs no lock.
++ */
++int max96712_get_ser_vc_id(struct device *dev, u32 link, u32 dser_vc)
++{
++	struct max96712 *priv = dev_get_drvdata(dev);
++	int i;
++
++	if (link >= MAX96712_MAX_LINKS)
++		return -EINVAL;
++
++	for (i = 0; i < MAX96712_MAX_SER_VCS; i++)
++		if (priv->vc_remap[link][i] != MAX96712_VC_UNMAPPED &&
++		    priv->vc_remap[link][i] == dser_vc)
++			return i;
++
++	dev_err(dev, "link %u has no serializer VC mapped to dser VC %u\n", link, dser_vc);
++	return -EINVAL;
++}
++EXPORT_SYMBOL(max96712_get_ser_vc_id);
 +
 +int max96712_release_pipe(struct device *dev, int pipe_id)
 +{
@@ -574,12 +715,16 @@ index 8081385f0..aaa115696 100644
 +}
 +EXPORT_SYMBOL(max96712_reset_oneshot);
 +
-+/* RSDEV-12608: one-shot flush of the link carrying vc_id (link = vc_id / MAX9295_MAX_STREAMS).
-+ * Called from d4xx HW-reset recovery to drop the stale post-reset partial frame. */
-+void max96712_reset_oneshot_link(struct device *dev, u32 vc_id)
++/* RSDEV-12608: one-shot flush of a single link's pixel line buffer. Called from
++ * d4xx HW-reset recovery to drop the stale post-reset partial frame. */
++void max96712_reset_oneshot_link(struct device *dev, u32 link_id)
 +{
 +	struct max96712 *priv = dev_get_drvdata(dev);
-+	unsigned int link_id = vc_id / MAX9295_MAX_STREAMS;
++
++	if (link_id >= MAX96712_MAX_LINKS) {
++		dev_err(dev, "%s: illegal link %u\n", __func__, link_id);
++		return;
++	}
 +
 +	dev_info(dev, "RSDEV-12608: link %u line-buffer flush (post-HW-reset)\n", link_id);
 +	max96712_reset_oneshot_link_mask(priv, 1 << link_id);
@@ -587,37 +732,41 @@ index 8081385f0..aaa115696 100644
 +EXPORT_SYMBOL(max96712_reset_oneshot_link);
 +
 +static int __max96712_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
-+			      u8 data_type2, u32 vc_id)
++			      u8 data_type2, u32 link, u32 vc_id)
 +{
 +	int err = 0;
 +	struct max96712 *priv = dev_get_drvdata(dev);
-+	int vc_id_lsb = vc_id & 0x3;
-+	int vc_id_msb = vc_id >> 2;
++	u32 dser_vc = priv->vc_remap[link][vc_id];
++	/* SRC is the VC arriving from the serializer, DST the VC leaving on CSI;
++	 * they diverge whenever the link's remap table is not the identity. */
++	int src_vc_lsb = vc_id & 0x3;
++	int dst_vc_lsb = dser_vc & 0x3;
++	u8 ext_vc = max96712_ext_vc(vc_id, dser_vc);
 +	unsigned int pipe_en_val = 0;
 +
 +	struct reg_pair map_pipe_control[] = {
 +		// Enable 3/4 mappings for video pipe (4 if metadata enabled)
 +		{MAX96712_MIPI_TX11_ADDR + (0x40 * pipe_id), (data_type2 == 0) ? 0x07 : 0x0F},
 +		// Map data_type1 on vc_id
-+		{MAX96712_MIPI_TX13_SRC_0_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | data_type1},
-+		{MAX96712_MIPI_TX14_DST_0_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | data_type1},
++		{MAX96712_MIPI_TX13_SRC_0_MAP_ADDR + (0x40 * pipe_id), (src_vc_lsb << 6) | data_type1},
++		{MAX96712_MIPI_TX14_DST_0_MAP_ADDR + (0x40 * pipe_id), (dst_vc_lsb << 6) | data_type1},
 +		// Map frame_start on vc_id
-+		{MAX96712_MIPI_TX15_SRC_1_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | 0x00},
-+		{MAX96712_MIPI_TX16_DST_1_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | 0x00},
++		{MAX96712_MIPI_TX15_SRC_1_MAP_ADDR + (0x40 * pipe_id), (src_vc_lsb << 6) | 0x00},
++		{MAX96712_MIPI_TX16_DST_1_MAP_ADDR + (0x40 * pipe_id), (dst_vc_lsb << 6) | 0x00},
 +		// Map frame end on vc_id
-+		{MAX96712_MIPI_TX17_SRC_2_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | 0x01},
-+		{MAX96712_MIPI_TX18_DST_2_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | 0x01},
++		{MAX96712_MIPI_TX17_SRC_2_MAP_ADDR + (0x40 * pipe_id), (src_vc_lsb << 6) | 0x01},
++		{MAX96712_MIPI_TX18_DST_2_MAP_ADDR + (0x40 * pipe_id), (dst_vc_lsb << 6) | 0x01},
 +		// Map data_type2 on vc_id
-+		{MAX96712_MIPI_TX19_SRC_3_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | data_type2},
-+		{MAX96712_MIPI_TX20_DST_3_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | data_type2},
++		{MAX96712_MIPI_TX19_SRC_3_MAP_ADDR + (0x40 * pipe_id), (src_vc_lsb << 6) | data_type2},
++		{MAX96712_MIPI_TX20_DST_3_MAP_ADDR + (0x40 * pipe_id), (dst_vc_lsb << 6) | data_type2},
 +		// Extended dst vc_id mapping 0
-+		{MAX96712_MIPI_TX_EXT0_ADDR + (0x10 * pipe_id), vc_id_msb << 2},
++		{MAX96712_MIPI_TX_EXT0_ADDR + (0x10 * pipe_id), ext_vc},
 +		// Extended dst vc_id mapping 1
-+		{MAX96712_MIPI_TX_EXT1_ADDR + (0x10 * pipe_id), vc_id_msb << 2},
++		{MAX96712_MIPI_TX_EXT1_ADDR + (0x10 * pipe_id), ext_vc},
 +		// Extended dst vc_id mapping 2
-+		{MAX96712_MIPI_TX_EXT2_ADDR + (0x10 * pipe_id), vc_id_msb << 2},
++		{MAX96712_MIPI_TX_EXT2_ADDR + (0x10 * pipe_id), ext_vc},
 +		// Extended dst vc_id mapping 3
-+		{MAX96712_MIPI_TX_EXT3_ADDR + (0x10 * pipe_id), vc_id_msb << 2},
++		{MAX96712_MIPI_TX_EXT3_ADDR + (0x10 * pipe_id), ext_vc},
 +		// All mappings to PHY1 (master for port A)
 +		{MAX96712_MIPI_TX45_MAP_DPHY_DEST_ADDR + (0x40 * pipe_id), 0x55},
 +		// SEQ_MISS_EN: Disabled / DIS_PKT_DET: Disabled
@@ -707,14 +856,15 @@ index 8081385f0..aaa115696 100644
 +}
 +EXPORT_SYMBOL(max96712_init_settings);
 +
-+int max96712_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id)
++int max96712_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
++				   int ser_pipe_id, u32 link)
 +{
 +	struct max96712 *priv = dev_get_drvdata(dev);
 +	int err = 0;
 +
 +	mutex_lock(&priv->lock);
 +
-+	err = __max96712_bind_ser_to_dser_pipe(dev, dser_pipe_id, ser_pipe_id, vc_id);
++	err = __max96712_bind_ser_to_dser_pipe(dev, dser_pipe_id, ser_pipe_id, link);
 +
 +	mutex_unlock(&priv->lock);
 +
@@ -724,63 +874,92 @@ index 8081385f0..aaa115696 100644
 +
 +/*
 + * Configure a multi-VC pipe (MAX96717) in one shot. Unlike __max96712_set_pipe(),
-+ * which dedicates a pipe to a single VC, this maps all four local virtual
++ * which dedicates a pipe to a single VC, this maps all four serializer virtual
 + * channels of the link (depth/RGB/IR/IMU) through one deserializer pipe, matching
 + * the way a MAX96717 funnels a camera's streams through a single serializer pipe.
 + * Called with priv->lock held.
 + */
-+static int __max96712_set_multi_vc_pipe(struct device *dev, int pipe_id, u32 vc_id)
++static int __max96712_set_multi_vc_pipe(struct device *dev, int pipe_id, u32 link)
 +{
 +	int err = 0;
-+	int iter;
++	int vc;
 +	struct max96712 *priv = dev_get_drvdata(dev);
-+	int link_id = vc_id / MAX9295_MAX_STREAMS;
 +	uint32_t map_pipe_offs = 0x40 * pipe_id;
 +	uint32_t ext_vc_offs = 0x10 * pipe_id;
++	/* SRC is the serializer VC arriving on the link, DST the remapped VC
++	 * leaving on CSI; EXT carries the high bits of both. */
++	u8 src_vc0 = 0 << 6;
++	u8 src_vc1 = 1 << 6;
++	u8 src_vc2 = 2 << 6;
++	u8 src_vc3 = 3 << 6;
++	u8 dst_vc0 = (priv->vc_remap[link][0] & 0x3) << 6;
++	u8 dst_vc1 = (priv->vc_remap[link][1] & 0x3) << 6;
++	u8 dst_vc2 = (priv->vc_remap[link][2] & 0x3) << 6;
++	u8 dst_vc3 = (priv->vc_remap[link][3] & 0x3) << 6;
++	u8 ext_vc0 = max96712_ext_vc(0, priv->vc_remap[link][0]);
++	u8 ext_vc1 = max96712_ext_vc(1, priv->vc_remap[link][1]);
++	u8 ext_vc2 = max96712_ext_vc(2, priv->vc_remap[link][2]);
++	u8 ext_vc3 = max96712_ext_vc(3, priv->vc_remap[link][3]);
 +
 +	struct reg_pair map_pipe_control[] = {
 +		// Enable all static mappings
 +		{MAX96712_MIPI_TX11_ADDR + map_pipe_offs, 0xFF},
 +		{MAX96712_MIPI_TX12_ADDR + map_pipe_offs, 0xFF},
 +		// Map vc_id 0 formats (depth)
-+		{MAX96712_MIPI_TX13_SRC_0_MAP_ADDR + map_pipe_offs, GMSL_CSI_DT_YUV422_8},
-+		{MAX96712_MIPI_TX14_DST_0_MAP_ADDR + map_pipe_offs, GMSL_CSI_DT_YUV422_8},
-+		{MAX96712_MIPI_TX15_SRC_1_MAP_ADDR + map_pipe_offs, 0x00},
-+		{MAX96712_MIPI_TX16_DST_1_MAP_ADDR + map_pipe_offs, 0x00},
-+		{MAX96712_MIPI_TX17_SRC_2_MAP_ADDR + map_pipe_offs, 0x01},
-+		{MAX96712_MIPI_TX18_DST_2_MAP_ADDR + map_pipe_offs, 0x01},
-+		{MAX96712_MIPI_TX19_SRC_3_MAP_ADDR + map_pipe_offs, GMSL_CSI_DT_EMBED},
-+		{MAX96712_MIPI_TX20_DST_3_MAP_ADDR + map_pipe_offs, GMSL_CSI_DT_EMBED},
++		{MAX96712_MIPI_TX13_SRC_0_MAP_ADDR + map_pipe_offs, src_vc0 | GMSL_CSI_DT_YUV422_8},
++		{MAX96712_MIPI_TX14_DST_0_MAP_ADDR + map_pipe_offs, dst_vc0 | GMSL_CSI_DT_YUV422_8},
++		{MAX96712_MIPI_TX_EXT0_ADDR + ext_vc_offs, ext_vc0},
++		{MAX96712_MIPI_TX15_SRC_1_MAP_ADDR + map_pipe_offs, src_vc0 | 0x00},
++		{MAX96712_MIPI_TX16_DST_1_MAP_ADDR + map_pipe_offs, dst_vc0 | 0x00},
++		{MAX96712_MIPI_TX_EXT1_ADDR + ext_vc_offs, ext_vc0},
++		{MAX96712_MIPI_TX17_SRC_2_MAP_ADDR + map_pipe_offs, src_vc0 | 0x01},
++		{MAX96712_MIPI_TX18_DST_2_MAP_ADDR + map_pipe_offs, dst_vc0 | 0x01},
++		{MAX96712_MIPI_TX_EXT2_ADDR + ext_vc_offs, ext_vc0},
++		{MAX96712_MIPI_TX19_SRC_3_MAP_ADDR + map_pipe_offs, src_vc0 | GMSL_CSI_DT_EMBED},
++		{MAX96712_MIPI_TX20_DST_3_MAP_ADDR + map_pipe_offs, dst_vc0 | GMSL_CSI_DT_EMBED},
++		{MAX96712_MIPI_TX_EXT3_ADDR + ext_vc_offs, ext_vc0},
 +
 +		// Map vc_id 1 formats (RGB)
-+		{MAX96712_MIPI_TX21_SRC_4_MAP_ADDR + map_pipe_offs, (1 << 6) | GMSL_CSI_DT_YUV422_8},
-+		{MAX96712_MIPI_TX22_DST_4_MAP_ADDR + map_pipe_offs, (1 << 6) | GMSL_CSI_DT_YUV422_8},
-+		{MAX96712_MIPI_TX23_SRC_5_MAP_ADDR + map_pipe_offs, (1 << 6) | 0x00},
-+		{MAX96712_MIPI_TX24_DST_5_MAP_ADDR + map_pipe_offs, (1 << 6) | 0x00},
-+		{MAX96712_MIPI_TX25_SRC_6_MAP_ADDR + map_pipe_offs, (1 << 6) | 0x01},
-+		{MAX96712_MIPI_TX26_DST_6_MAP_ADDR + map_pipe_offs, (1 << 6) | 0x01},
-+		{MAX96712_MIPI_TX27_SRC_7_MAP_ADDR + map_pipe_offs, (1 << 6) | GMSL_CSI_DT_EMBED},
-+		{MAX96712_MIPI_TX28_DST_7_MAP_ADDR + map_pipe_offs, (1 << 6) | GMSL_CSI_DT_EMBED},
++		{MAX96712_MIPI_TX21_SRC_4_MAP_ADDR + map_pipe_offs, src_vc1 | GMSL_CSI_DT_YUV422_8},
++		{MAX96712_MIPI_TX22_DST_4_MAP_ADDR + map_pipe_offs, dst_vc1 | GMSL_CSI_DT_YUV422_8},
++		{MAX96712_MIPI_TX_EXT4_ADDR + ext_vc_offs, ext_vc1},
++		{MAX96712_MIPI_TX23_SRC_5_MAP_ADDR + map_pipe_offs, src_vc1 | 0x00},
++		{MAX96712_MIPI_TX24_DST_5_MAP_ADDR + map_pipe_offs, dst_vc1 | 0x00},
++		{MAX96712_MIPI_TX_EXT5_ADDR + ext_vc_offs, ext_vc1},
++		{MAX96712_MIPI_TX25_SRC_6_MAP_ADDR + map_pipe_offs, src_vc1 | 0x01},
++		{MAX96712_MIPI_TX26_DST_6_MAP_ADDR + map_pipe_offs, dst_vc1 | 0x01},
++		{MAX96712_MIPI_TX_EXT6_ADDR + ext_vc_offs, ext_vc1},
++		{MAX96712_MIPI_TX27_SRC_7_MAP_ADDR + map_pipe_offs, src_vc1 | GMSL_CSI_DT_EMBED},
++		{MAX96712_MIPI_TX28_DST_7_MAP_ADDR + map_pipe_offs, dst_vc1 | GMSL_CSI_DT_EMBED},
++		{MAX96712_MIPI_TX_EXT7_ADDR + ext_vc_offs, ext_vc1},
 +
 +		// Map vc_id 2 formats (IR)
-+		{MAX96712_MIPI_TX29_SRC_8_MAP_ADDR + map_pipe_offs, (2 << 6) | GMSL_CSI_DT_YUV422_8},
-+		{MAX96712_MIPI_TX30_DST_8_MAP_ADDR + map_pipe_offs, (2 << 6) | GMSL_CSI_DT_YUV422_8},
-+		{MAX96712_MIPI_TX31_SRC_9_MAP_ADDR + map_pipe_offs, (2 << 6) | 0x00},
-+		{MAX96712_MIPI_TX32_DST_9_MAP_ADDR + map_pipe_offs, (2 << 6) | 0x00},
-+		{MAX96712_MIPI_TX33_SRC_10_MAP_ADDR + map_pipe_offs, (2 << 6) | 0x01},
-+		{MAX96712_MIPI_TX34_DST_10_MAP_ADDR + map_pipe_offs, (2 << 6) | 0x01},
-+		{MAX96712_MIPI_TX35_SRC_11_MAP_ADDR + map_pipe_offs, (2 << 6) | GMSL_CSI_DT_EMBED},
-+		{MAX96712_MIPI_TX36_DST_11_MAP_ADDR + map_pipe_offs, (2 << 6) | GMSL_CSI_DT_EMBED},
-+		{MAX96712_MIPI_TX37_SRC_12_MAP_ADDR + map_pipe_offs, (2 << 6) | GMSL_CSI_DT_RAW_16},
-+		{MAX96712_MIPI_TX38_DST_12_MAP_ADDR + map_pipe_offs, (2 << 6) | GMSL_CSI_DT_RAW_16},
++		{MAX96712_MIPI_TX29_SRC_8_MAP_ADDR + map_pipe_offs, src_vc2 | GMSL_CSI_DT_YUV422_8},
++		{MAX96712_MIPI_TX30_DST_8_MAP_ADDR + map_pipe_offs, dst_vc2 | GMSL_CSI_DT_YUV422_8},
++		{MAX96712_MIPI_TX_EXT8_ADDR + ext_vc_offs, ext_vc2},
++		{MAX96712_MIPI_TX31_SRC_9_MAP_ADDR + map_pipe_offs, src_vc2 | 0x00},
++		{MAX96712_MIPI_TX32_DST_9_MAP_ADDR + map_pipe_offs, dst_vc2 | 0x00},
++		{MAX96712_MIPI_TX_EXT9_ADDR + ext_vc_offs, ext_vc2},
++		{MAX96712_MIPI_TX33_SRC_10_MAP_ADDR + map_pipe_offs, src_vc2 | 0x01},
++		{MAX96712_MIPI_TX34_DST_10_MAP_ADDR + map_pipe_offs, dst_vc2 | 0x01},
++		{MAX96712_MIPI_TX_EXT10_ADDR + ext_vc_offs, ext_vc2},
++		{MAX96712_MIPI_TX35_SRC_11_MAP_ADDR + map_pipe_offs, src_vc2 | GMSL_CSI_DT_EMBED},
++		{MAX96712_MIPI_TX36_DST_11_MAP_ADDR + map_pipe_offs, dst_vc2 | GMSL_CSI_DT_EMBED},
++		{MAX96712_MIPI_TX_EXT11_ADDR + ext_vc_offs, ext_vc2},
++		{MAX96712_MIPI_TX37_SRC_12_MAP_ADDR + map_pipe_offs, src_vc2 | GMSL_CSI_DT_RAW_16},
++		{MAX96712_MIPI_TX38_DST_12_MAP_ADDR + map_pipe_offs, dst_vc2 | GMSL_CSI_DT_RAW_16},
++		{MAX96712_MIPI_TX_EXT12_ADDR + ext_vc_offs, ext_vc2},
 +
 +		// Map vc_id 3 formats (IMU)
-+		{MAX96712_MIPI_TX39_SRC_13_MAP_ADDR + map_pipe_offs, (3 << 6) | GMSL_CSI_DT_RAW_8},
-+		{MAX96712_MIPI_TX40_DST_13_MAP_ADDR + map_pipe_offs, (3 << 6) | GMSL_CSI_DT_RAW_8},
-+		{MAX96712_MIPI_TX41_SRC_14_MAP_ADDR + map_pipe_offs, (3 << 6) | 0x00},
-+		{MAX96712_MIPI_TX42_DST_14_MAP_ADDR + map_pipe_offs, (3 << 6) | 0x00},
-+		{MAX96712_MIPI_TX43_SRC_15_MAP_ADDR + map_pipe_offs, (3 << 6) | 0x01},
-+		{MAX96712_MIPI_TX44_DST_15_MAP_ADDR + map_pipe_offs, (3 << 6) | 0x01},
++		{MAX96712_MIPI_TX39_SRC_13_MAP_ADDR + map_pipe_offs, src_vc3 | GMSL_CSI_DT_RAW_8},
++		{MAX96712_MIPI_TX40_DST_13_MAP_ADDR + map_pipe_offs, dst_vc3 | GMSL_CSI_DT_RAW_8},
++		{MAX96712_MIPI_TX_EXT13_ADDR + ext_vc_offs, ext_vc3},
++		{MAX96712_MIPI_TX41_SRC_14_MAP_ADDR + map_pipe_offs, src_vc3 | 0x00},
++		{MAX96712_MIPI_TX42_DST_14_MAP_ADDR + map_pipe_offs, dst_vc3 | 0x00},
++		{MAX96712_MIPI_TX_EXT14_ADDR + ext_vc_offs, ext_vc3},
++		{MAX96712_MIPI_TX43_SRC_15_MAP_ADDR + map_pipe_offs, src_vc3 | 0x01},
++		{MAX96712_MIPI_TX44_DST_15_MAP_ADDR + map_pipe_offs, dst_vc3 | 0x01},
++		{MAX96712_MIPI_TX_EXT15_ADDR + ext_vc_offs, ext_vc3},
 +
 +		// All mappings to PHY1 (master for port A)
 +		{MAX96712_MIPI_TX45_MAP_DPHY_DEST_ADDR + map_pipe_offs, 0x55},
@@ -793,13 +972,18 @@ index 8081385f0..aaa115696 100644
 +		{MAX96712_VIDEO_RX0_ADDR + (0x12 * pipe_id) + ((pipe_id >= 5) ? 6 : 0), 0x23},
 +	};
 +
++	/* This table maps all four of the camera's VCs in one shot, so the link
++	 * must declare a deserializer VC for every one of them. */
++	for (vc = 0; vc < 4; vc++) {
++		if (priv->vc_remap[link][vc] == MAX96712_VC_UNMAPPED) {
++			dev_err(dev, "%s: link %u serializer vc %d unmapped\n",
++				__func__, link, vc);
++			return -EINVAL;
++		}
++	}
++
 +	err |= max96712_set_registers(priv, map_pipe_control,
 +					ARRAY_SIZE(map_pipe_control));
-+
-+	/* Configuring the mapping's extended VC */
-+	for (iter = 0; iter < 16; iter++) {
-+		err |= max96712_write_reg(priv, MAX96712_MIPI_TX_EXT0_ADDR + iter + ext_vc_offs, link_id << 2);
-+	}
 +
 +	if (err) {
 +		return err;
@@ -811,7 +995,8 @@ index 8081385f0..aaa115696 100644
 +}
 +
 +/* Update mapping table entries that can change in runtime */
-+static int __max96712_update_multi_vc_pipe(struct device *dev, int pipe_id, u32 vc_id, u8 data_type1)
++static int __max96712_update_multi_vc_pipe(struct device *dev, int pipe_id,
++					  u32 link, u32 vc_id, u8 data_type1)
 +{
 +	int err = 0;
 +
@@ -819,17 +1004,19 @@ index 8081385f0..aaa115696 100644
 +	if (vc_id == 1) {
 +		struct max96712 *priv = dev_get_drvdata(dev);
 +		uint32_t map_pipe_offs = 0x40 * pipe_id;
++		u8 src_vc = vc_id << 6;
++		u8 dst_vc = (priv->vc_remap[link][vc_id] & 0x3) << 6;
 +
 +		struct reg_pair map_pipe_control[] = {
 +			// Update vc_id 1 formats (RGB)
-+			{MAX96712_MIPI_TX21_SRC_4_MAP_ADDR + map_pipe_offs, (vc_id << 6) | data_type1},
-+			{MAX96712_MIPI_TX22_DST_4_MAP_ADDR + map_pipe_offs, (vc_id << 6) | data_type1},
++			{MAX96712_MIPI_TX21_SRC_4_MAP_ADDR + map_pipe_offs, src_vc | data_type1},
++			{MAX96712_MIPI_TX22_DST_4_MAP_ADDR + map_pipe_offs, dst_vc | data_type1},
 +		};
 +		dev_dbg(dev, "%s: Updating vc_id %u on pipe %u to data type 0x%x\n",
 +				__func__, vc_id, pipe_id, data_type1);
 +		err |= max96712_set_registers(priv, map_pipe_control,
 +						ARRAY_SIZE(map_pipe_control));
-+	
++
 +		if (err) {
 +			return err;
 +		}
@@ -839,7 +1026,7 @@ index 8081385f0..aaa115696 100644
 +}
 +
 +int max96712_set_pipe(struct device *dev, int pipe_id,
-+		     u8 data_type1, u8 data_type2, u32 vc_id)
++		     u8 data_type1, u8 data_type2, u32 link, u32 vc_id)
 +{
 +	struct max96712 *priv = dev_get_drvdata(dev);
 +	int err = 0;
@@ -850,8 +1037,16 @@ index 8081385f0..aaa115696 100644
 +		return -EINVAL;
 +	}
 +
-+	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
-+		__func__, pipe_id, data_type1, data_type2, vc_id);
++	if (link >= MAX96712_MAX_LINKS || vc_id >= MAX96712_MAX_SER_VCS ||
++	    priv->vc_remap[link][vc_id] == MAX96712_VC_UNMAPPED) {
++		dev_err(dev, "%s: link %u serializer vc %u has no deserializer VC\n",
++			__func__, link, vc_id);
++		return -EINVAL;
++	}
++
++	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, link %u, vc_id %u -> dser vc %u\n",
++		__func__, pipe_id, data_type1, data_type2, link, vc_id,
++		priv->vc_remap[link][vc_id]);
 +
 +	mutex_lock(&priv->lock);
 +
@@ -862,14 +1057,14 @@ index 8081385f0..aaa115696 100644
 +		 * config-retry loop) reuse the existing mapping unchanged.
 +		 */
 +		if (!priv->multi_vc_configured[pipe_id]) {
-+			err = __max96712_set_multi_vc_pipe(dev, pipe_id, vc_id);
++			err = __max96712_set_multi_vc_pipe(dev, pipe_id, link);
 +			if (!err)
 +				priv->multi_vc_configured[pipe_id] = true;
 +		}
 +		if (!err)
-+			err = __max96712_update_multi_vc_pipe(dev, pipe_id, vc_id, data_type1);
++			err = __max96712_update_multi_vc_pipe(dev, pipe_id, link, vc_id, data_type1);
 +	} else {
-+		err = __max96712_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
++		err = __max96712_set_pipe(dev, pipe_id, data_type1, data_type2, link, vc_id);
 +	}
 +
 +	mutex_unlock(&priv->lock);
@@ -1015,7 +1210,7 @@ index 8081385f0..aaa115696 100644
  	{ },
  };
  
-@@ -268,6 +1172,7 @@ static struct i2c_driver max96712_i2c_driver = {
+@@ -268,6 +1367,7 @@ static struct i2c_driver max96712_i2c_driver = {
  	.driver = {
  		.name = "max96712",
  		.owner = THIS_MODULE,

--- a/kernel/nvidia/5.0.2/0019-Align-max9296-api-to-max96712.patch
+++ b/kernel/nvidia/5.0.2/0019-Align-max9296-api-to-max96712.patch
@@ -5,19 +5,19 @@ Subject: [PATCH] Align max9296 api to max96712
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- drivers/media/i2c/max9296.c | 7 ++++++++++++++
- include/media/max9296.h     | 13 ++++++++++++++
- 2 files changed, 28 insertions(+)
+ drivers/media/i2c/max9296.c |  8 +++++++-
+ include/media/max9296.h     | 15 ++++++++++++++-
+ 2 files changed, 22 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/media/i2c/max9296.c b/drivers/media/i2c/max9296.c
 index 829657bca..b4a18c5a3 100644
 --- a/drivers/media/i2c/max9296.c
 +++ b/drivers/media/i2c/max9296.c
-@@ -948,6 +955,13 @@ int max9296_init_settings(struct device *dev)
+@@ -948,8 +955,15 @@ int max9296_init_settings(struct device *dev)
  }
  EXPORT_SYMBOL(max9296_init_settings);
  
-+int max9296_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id)
++int max9296_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 link)
 +{
 +	/* pipe id's are 1:1 in this deserializer */
 +	return 0;
@@ -25,12 +25,24 @@ index 829657bca..b4a18c5a3 100644
 +EXPORT_SYMBOL(max9296_bind_ser_to_dser_pipe);
 +
  int max9296_set_pipe(struct device *dev, int pipe_id,
- 		     u8 data_type1, u8 data_type2, u32 vc_id)
+-		     u8 data_type1, u8 data_type2, u32 vc_id)
++		     u8 data_type1, u8 data_type2, u32 link, u32 vc_id)
  {
+ 	struct max9296 *priv = dev_get_drvdata(dev);
+ 	int err = 0;
 diff --git a/include/media/max9296.h b/include/media/max9296.h
 index 20f3a6657..5d12d3108 100644
 --- a/include/media/max9296.h
 +++ b/include/media/max9296.h
+@@ -37,7 +37,7 @@
+ 
+ int max9296_get_available_pipe_id(struct device *dev, int vc_id);
+ int max9296_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
+-		     u8 data_type2, u32 vc_id);
++		     u8 data_type2, u32 link, u32 vc_id);
+ int max9296_release_pipe(struct device *dev, int pipe_id);
+ void max9296_reset_oneshot(struct device *dev);
+ 
 @@ -166,6 +166,19 @@ int max9296_power_on(struct device *dev);
  void max9296_power_off(struct device *dev);
  
@@ -44,9 +56,9 @@ index 20f3a6657..5d12d3108 100644
 + * @param [in]  dev             The deserializer device handle.
 + * @param [in]  dser_pipe_id    Deserializer pipe id.
 + * @param [in]  ser_pipe_id     Serializer pipe id.
-+ * @param [in]  vc_id           vc_id associated with this pipe path.
++ * @param [in]  link            GMSL link the serializer pipe lives on.
 + */
-+int max9296_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id);
++int max9296_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 link);
 +
  /** @} */
  

--- a/kernel/nvidia/5.1.2/0007-Adding-max96712-support-for-D4xx.patch
+++ b/kernel/nvidia/5.1.2/0007-Adding-max96712-support-for-D4xx.patch
@@ -7,14 +7,14 @@ Add MAX96712 deserializer driver support for D4XX cameras.
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- drivers/media/i2c/max96712.c | 956 +++++++++++++++++++++++++++++++++++++++++--
- 1 file changed, 916 insertions(+), 40 deletions(-)
+ drivers/media/i2c/max96712.c | 1151 ++++++++++++++++++++++++++++++++++++++++--
+ 1 file changed, 1111 insertions(+), 40 deletions(-)
 
 diff --git a/drivers/media/i2c/max96712.c b/drivers/media/i2c/max96712.c
-index 329a10dfd..688f86fb8 100644
+index 329a10dfd..63a6156cc 100644
 --- a/drivers/media/i2c/max96712.c
 +++ b/drivers/media/i2c/max96712.c
-@@ -21,32 +21,156 @@
+@@ -21,32 +21,176 @@
  #include <linux/debugfs.h>
  #include <media/camera_common.h>
  #include <linux/module.h>
@@ -62,6 +62,7 @@ index 329a10dfd..688f86fb8 100644
 +#define MAX96712_MIPI_TX_EXT12_ADDR 0x80c
 +#define MAX96712_MIPI_TX_EXT13_ADDR 0x80d
 +#define MAX96712_MIPI_TX_EXT14_ADDR 0x80e
++#define MAX96712_MIPI_TX_EXT15_ADDR 0x80f
 +
 +#define MAX96712_MIPI_PHY0_ADDR 0x8A0
 +#define MAX96712_MIPI_PHY2_ADDR 0x8A2
@@ -130,7 +131,22 @@ index 329a10dfd..688f86fb8 100644
 +/* data defines */
 +#define MAX96712_MAX_LINKS 4
 +#define MAX96712_MAX_PIPES 8
-+#define MAX9295_MAX_STREAMS 4
++/* Extended CSI VC: two low bits live in the SRC/DST map regs, three high bits
++ * in MIPI_TX_EXT<n> - DST at bits 4:2, SRC at bits 7:5. */
++#define MAX96712_MAX_VCS 32
++#define MAX96712_EXT_VC_DST_SHIFT 2
++#define MAX96712_EXT_VC_SRC_SHIFT 5
++/* Serializer VCs a link may present, i.e. the streams one camera can carry. */
++#define MAX96712_MAX_SER_VCS 8
++#define MAX96712_VC_UNMAPPED 0xFF
++#define MAX96712_VC_REMAP_CELLS 2
++
++/* MIPI_TX_EXT<n>: high bits of the source and destination virtual channels. */
++static inline u8 max96712_ext_vc(u32 src_vc, u32 dst_vc)
++{
++	return ((src_vc >> 2) << MAX96712_EXT_VC_SRC_SHIFT) |
++	       ((dst_vc >> 2) << MAX96712_EXT_VC_DST_SHIFT);
++}
  
  struct max96712 {
  	struct i2c_client *i2c_client;
@@ -152,6 +168,10 @@ index 329a10dfd..688f86fb8 100644
 +	 */
 +	int link_multi_vc_pipe[MAX96712_MAX_LINKS];
 +	bool multi_vc_configured[MAX96712_MAX_PIPES];
++	/* Serializer VC -> deserializer VC, or MAX96712_VC_UNMAPPED. A link with
++	 * no maxim,linkN-vc-remap gets a unity map; one with a table gets only
++	 * the VCs that table declares. */
++	u8 vc_remap[MAX96712_MAX_LINKS][MAX96712_MAX_SER_VCS];
 +	bool force_clk0;
 +	int lane_cnt;
 +	bool fangzhu_fg12_reverse_lane_polarity;
@@ -178,7 +198,7 @@ index 329a10dfd..688f86fb8 100644
  	i2c_client = global_priv[channel]->i2c_client;
  	bak = i2c_client->addr;
  
-@@ -58,9 +182,9 @@ int max96712_write_reg_Dser(int slaveAddr,int channel,
+@@ -58,9 +202,9 @@ int max96712_write_reg_Dser(int slaveAddr,int channel,
  	{
  		dev_err(&i2c_client->dev, "%s: addr = 0x%x, val = 0x%x\n",
  				__func__, addr, val);
@@ -190,7 +210,7 @@ index 329a10dfd..688f86fb8 100644
  }
  
  EXPORT_SYMBOL(max96712_write_reg_Dser);
-@@ -71,11 +195,9 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
+@@ -71,11 +215,9 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
  {
  	struct i2c_client *i2c_client = NULL;
  	int bak = 0;
@@ -203,7 +223,7 @@ index 329a10dfd..688f86fb8 100644
  	i2c_client = global_priv[channel]->i2c_client;
  	bak = i2c_client->addr;
  	i2c_client->addr = slaveAddr / 2;
-@@ -85,13 +207,60 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
+@@ -85,13 +227,60 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
  	{
  		dev_err(&i2c_client->dev, "%s: addr = 0x%x, val = 0x%x\n",
  				__func__, addr, *val);
@@ -266,7 +286,7 @@ index 329a10dfd..688f86fb8 100644
  static int max96712_read_reg(struct max96712 *priv,
  			u16 addr, unsigned int *val)
  {
-@@ -106,6 +275,20 @@ static int max96712_read_reg(struct max96712 *priv,
+@@ -106,6 +295,20 @@ static int max96712_read_reg(struct max96712 *priv,
  	return err;
  }
  
@@ -287,7 +307,7 @@ index 329a10dfd..688f86fb8 100644
  
  static int max96712_stats_show(struct seq_file *s, void *data)
  {
-@@ -161,24 +344,6 @@ static const struct file_operations max96712_debugfs_fops = {
+@@ -161,24 +364,6 @@ static const struct file_operations max96712_debugfs_fops = {
  	.release = single_release,
  };
  
@@ -312,7 +332,7 @@ index 329a10dfd..688f86fb8 100644
  static int max96712_debugfs_init(const char *dir_name,
  				struct dentry **d_entry,
  				struct dentry **f_entry,
-@@ -194,7 +359,10 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -194,7 +379,10 @@ static int max96712_debugfs_init(const char *dir_name,
  	if (np) {
  		err = of_property_read_string(np, "channel", &priv->channel);
  		if (err)
@@ -323,7 +343,7 @@ index 329a10dfd..688f86fb8 100644
  
  		err = snprintf(dev_name, sizeof(dev_name), "max96712_%s", priv->channel);
  		if (err < 0)
-@@ -233,7 +401,8 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -233,17 +421,116 @@ static int max96712_debugfs_init(const char *dir_name,
  static  struct regmap_config max96712_regmap_config = {
  	.reg_bits = 16,
  	.val_bits = 8,
@@ -332,8 +352,104 @@ index 329a10dfd..688f86fb8 100644
 +	.cache_type = REGCACHE_NONE,
  };
  
++/*
++ * Parse the optional per-link "maxim,linkN-vc-remap" tables, each a list of
++ * <serializer-vc deserializer-vc> pairs. A link with no table keeps the unity
++ * map; a link with one, maps exactly the VCs it lists and leaves the rest
++ * unmapped, so every link of a multi-link deserializer has to declare a table.
++ */
++static int max96712_parse_vc_remap(struct max96712 *priv, struct device_node *np)
++{
++	struct device *dev = &priv->i2c_client->dev;
++	unsigned int link;
++	u32 dser_vc_seen_mask = 0;
++	int map_elems, err, i;
++
++	/* Default unity mapping table */
++	for (link = 0; link < MAX96712_MAX_LINKS; link++) {
++		for (i = 0; i < MAX96712_MAX_SER_VCS; i++) {
++			priv->vc_remap[link][i] = i;
++		}
++	}
++
++	if (!np) {
++		return 0;
++	}
++
++	for (link = 0; link < MAX96712_MAX_LINKS; link++) {
++		char link_map_prop[32];
++		u32 src, dst;
++
++		snprintf(link_map_prop, sizeof(link_map_prop), "maxim,link%u-vc-remap", link);
++
++		map_elems = of_property_count_u32_elems(np, link_map_prop);
++		/* -EINVAL means absent; anything else negative is malformed. */
++		if (map_elems == -EINVAL)
++			continue;
++		if (map_elems < 0) {
++			dev_err(dev, "%s: unreadable (%d)\n", link_map_prop, map_elems);
++			return map_elems;
++		}
++		if (!(priv->link_mask & (1 << link))) {
++			dev_err(dev, "%s: link not enabled by link-mask 0x%x\n",
++				link_map_prop, priv->link_mask);
++			return -EINVAL;
++		}
++		if (map_elems % MAX96712_VC_REMAP_CELLS ||
++		    map_elems > MAX96712_MAX_SER_VCS * MAX96712_VC_REMAP_CELLS) {
++			dev_err(dev, "%s: %d cells, expected up to %d <ser dser> pairs\n",
++				link_map_prop, map_elems, MAX96712_MAX_SER_VCS);
++			return -EINVAL;
++		}
++
++		/* An explicit table replaces the unity default outright: VCs it
++		 * does not list stay unmapped. */
++		for (i = 0; i < MAX96712_MAX_SER_VCS; i++) {
++			priv->vc_remap[link][i] = MAX96712_VC_UNMAPPED;
++		}
++
++		/* Start filling the map */
++		for (i = 0; i < map_elems; i += MAX96712_VC_REMAP_CELLS) {
++			err = of_property_read_u32_index(np, link_map_prop, i, &src);
++			if (!err)
++				err = of_property_read_u32_index(np, link_map_prop, i + 1, &dst);
++			if (err) {
++				dev_err(dev, "%s: read failed (%d)\n", link_map_prop, err);
++				return err;
++			}
++			if (src >= MAX96712_MAX_SER_VCS || dst >= MAX96712_MAX_VCS) {
++				dev_err(dev, "%s: illegal pair <%u %u>\n", link_map_prop, src, dst);
++				return -EINVAL;
++			}
++			priv->vc_remap[link][src] = dst;
++		}
++	}
++
++	/* Validation loop - Making sure there are no dst vc collisions */
++	for (link = 0; link < MAX96712_MAX_LINKS; link++) {
++		if (!(priv->link_mask & (1 << link)))
++			continue;
++		for (i = 0; i < MAX96712_MAX_SER_VCS; i++) {
++			u8 vc = priv->vc_remap[link][i];
++
++			if (vc == MAX96712_VC_UNMAPPED)
++				continue;
++			if (dser_vc_seen_mask & (1u << vc)) {
++				dev_err(dev,
++					"dser VC %u mapped more than once, output VCs must be unique\n",
++					vc);
++				return -EINVAL;
++			}
++			dser_vc_seen_mask |= 1u << vc;
++			dev_dbg(dev, "link %u src_vc: %u dst_vc: %u\n", link, i, priv->vc_remap[link][i]);
++		}
++	}
++
++	return 0;
++}
++
  static int max96712_probe(struct i2c_client *client,
-@@ -241,9 +410,11 @@ static int max96712_probe(struct i2c_client *client,
+ 				const struct i2c_device_id *id)
  {
  	struct max96712 *priv;
  	int err = 0;
@@ -346,7 +462,7 @@ index 329a10dfd..688f86fb8 100644
  	priv = devm_kzalloc(&client->dev, sizeof(*priv), GFP_KERNEL);
  	priv->i2c_client = client;
  	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
-@@ -253,18 +424,68 @@ static int max96712_probe(struct i2c_client *client,
+@@ -253,18 +540,72 @@ static int max96712_probe(struct i2c_client *client,
  			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
  		return -ENODEV;
  	}
@@ -363,8 +479,8 @@ index 329a10dfd..688f86fb8 100644
 -		return err;
 +		for (i = 0; i < MAX96712_MAX_LINKS; i++)
 +			priv->link_multi_vc_pipe[i] = -1;
- 	}
- 
++	}
++
 +	np = client->dev.of_node;
 +	if (np) {
 +		priv->pwdn_gpio = of_get_named_gpio(np, "pwdn-gpios", 0);
@@ -408,7 +524,11 @@ index 329a10dfd..688f86fb8 100644
 +			of_property_read_bool(np, "fangzhu,fg12-reverse-lane-polarity");
 +		priv->fangzhu_fg12_poc_enable =
 +			of_property_read_bool(np, "fangzhu,fg12-poc-enable");
-+	}
+ 	}
+ 
++	err = max96712_parse_vc_remap(priv, np);
++	if (err)
++		return err;
 +
 +	dev_set_drvdata(&client->dev, priv);
 +
@@ -420,7 +540,7 @@ index 329a10dfd..688f86fb8 100644
  
  	/*set daymode by fault*/
  	dev_info(&client->dev, "%s:  success\n", __func__);
-@@ -276,8 +497,12 @@ static int max96712_probe(struct i2c_client *client,
+@@ -276,8 +617,12 @@ static int max96712_probe(struct i2c_client *client,
  static int
  max96712_remove(struct i2c_client *client)
  {
@@ -433,7 +553,7 @@ index 329a10dfd..688f86fb8 100644
  		i2c_unregister_device(client);
  		client = NULL;
  	}
-@@ -285,13 +510,663 @@ max96712_remove(struct i2c_client *client)
+@@ -285,13 +630,738 @@ max96712_remove(struct i2c_client *client)
  	return 0;
  }
  
@@ -526,20 +646,19 @@ index 329a10dfd..688f86fb8 100644
 +}
 +
 +/*
-+ * Allocate (or return the already-allocated) multi-VC pipe for the link that
-+ * owns vc_id. Used for MAX96717 serializers, which route all of a camera's
++ * Allocate (or return the already-allocated) multi-VC pipe for a link. Used
++ * for MAX96717 serializers, which route all of a camera's
 + * virtual channels through a single serializer pipe. The pipe is dedicated to
 + * the link for the driver's lifetime: every stream of that camera reuses it and
 + * max96712_release_pipe() never frees it.
 + */
-+int max96712_get_multi_vc_pipe_id(struct device *dev, int vc_id)
++int max96712_get_multi_vc_pipe_id(struct device *dev, u32 link)
 +{
 +	struct max96712 *priv = dev_get_drvdata(dev);
-+	int link = vc_id / MAX9295_MAX_STREAMS;
 +	int pipe_id = -ENOSR;
 +	int i;
 +
-+	if (link < 0 || link >= MAX96712_MAX_LINKS)
++	if (link >= MAX96712_MAX_LINKS)
 +		return -EINVAL;
 +
 +	mutex_lock(&priv->lock);
@@ -566,11 +685,11 @@ index 329a10dfd..688f86fb8 100644
 +}
 +EXPORT_SYMBOL(max96712_get_multi_vc_pipe_id);
 +
-+static int __max96712_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id)
++static int __max96712_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
++					    int ser_pipe_id, u32 link_id)
 +{
 +	struct max96712 *priv = dev_get_drvdata(dev);
 +	unsigned int pipe_sel_val = 0;
-+	u32 link_id = vc_id / MAX9295_MAX_STREAMS;
 +	int err = 0;
 +
 +	/* dser_pipe_id will be connected to ser_pipe_id of link_id */
@@ -596,6 +715,28 @@ index 329a10dfd..688f86fb8 100644
 +
 +	return err;
 +}
++
++/*
++ * Reverse the link's VC map: which serializer VC arrives as dser_vc.
++ * vc_remap is written once at probe, so this needs no lock.
++ */
++int max96712_get_ser_vc_id(struct device *dev, u32 link, u32 dser_vc)
++{
++	struct max96712 *priv = dev_get_drvdata(dev);
++	int i;
++
++	if (link >= MAX96712_MAX_LINKS)
++		return -EINVAL;
++
++	for (i = 0; i < MAX96712_MAX_SER_VCS; i++)
++		if (priv->vc_remap[link][i] != MAX96712_VC_UNMAPPED &&
++		    priv->vc_remap[link][i] == dser_vc)
++			return i;
++
++	dev_err(dev, "link %u has no serializer VC mapped to dser VC %u\n", link, dser_vc);
++	return -EINVAL;
++}
++EXPORT_SYMBOL(max96712_get_ser_vc_id);
 +
 +int max96712_release_pipe(struct device *dev, int pipe_id)
 +{
@@ -657,12 +798,16 @@ index 329a10dfd..688f86fb8 100644
 +}
 +EXPORT_SYMBOL(max96712_reset_oneshot);
 +
-+/* RSDEV-12608: one-shot flush of the link carrying vc_id (link = vc_id / MAX9295_MAX_STREAMS).
-+ * Called from d4xx HW-reset recovery to drop the stale post-reset partial frame. */
-+void max96712_reset_oneshot_link(struct device *dev, u32 vc_id)
++/* RSDEV-12608: one-shot flush of a single link's pixel line buffer. Called from
++ * d4xx HW-reset recovery to drop the stale post-reset partial frame. */
++void max96712_reset_oneshot_link(struct device *dev, u32 link_id)
 +{
 +	struct max96712 *priv = dev_get_drvdata(dev);
-+	unsigned int link_id = vc_id / MAX9295_MAX_STREAMS;
++
++	if (link_id >= MAX96712_MAX_LINKS) {
++		dev_err(dev, "%s: illegal link %u\n", __func__, link_id);
++		return;
++	}
 +
 +	dev_info(dev, "RSDEV-12608: link %u line-buffer flush (post-HW-reset)\n", link_id);
 +	max96712_reset_oneshot_link_mask(priv, 1 << link_id);
@@ -670,37 +815,41 @@ index 329a10dfd..688f86fb8 100644
 +EXPORT_SYMBOL(max96712_reset_oneshot_link);
 +
 +static int __max96712_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
-+			      u8 data_type2, u32 vc_id)
++			      u8 data_type2, u32 link, u32 vc_id)
 +{
 +	int err = 0;
 +	struct max96712 *priv = dev_get_drvdata(dev);
-+	int vc_id_lsb = vc_id & 0x3;
-+	int vc_id_msb = vc_id >> 2;
++	u32 dser_vc = priv->vc_remap[link][vc_id];
++	/* SRC is the VC arriving from the serializer, DST the VC leaving on CSI;
++	 * they diverge whenever the link's remap table is not the identity. */
++	int src_vc_lsb = vc_id & 0x3;
++	int dst_vc_lsb = dser_vc & 0x3;
++	u8 ext_vc = max96712_ext_vc(vc_id, dser_vc);
 +	unsigned int pipe_en_val = 0;
 +
 +	struct reg_pair map_pipe_control[] = {
 +		// Enable 3/4 mappings for video pipe (4 if metadata enabled)
 +		{MAX96712_MIPI_TX11_ADDR + (0x40 * pipe_id), (data_type2 == 0) ? 0x07 : 0x0F},
 +		// Map data_type1 on vc_id
-+		{MAX96712_MIPI_TX13_SRC_0_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | data_type1},
-+		{MAX96712_MIPI_TX14_DST_0_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | data_type1},
++		{MAX96712_MIPI_TX13_SRC_0_MAP_ADDR + (0x40 * pipe_id), (src_vc_lsb << 6) | data_type1},
++		{MAX96712_MIPI_TX14_DST_0_MAP_ADDR + (0x40 * pipe_id), (dst_vc_lsb << 6) | data_type1},
 +		// Map frame_start on vc_id
-+		{MAX96712_MIPI_TX15_SRC_1_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | 0x00},
-+		{MAX96712_MIPI_TX16_DST_1_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | 0x00},
++		{MAX96712_MIPI_TX15_SRC_1_MAP_ADDR + (0x40 * pipe_id), (src_vc_lsb << 6) | 0x00},
++		{MAX96712_MIPI_TX16_DST_1_MAP_ADDR + (0x40 * pipe_id), (dst_vc_lsb << 6) | 0x00},
 +		// Map frame end on vc_id
-+		{MAX96712_MIPI_TX17_SRC_2_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | 0x01},
-+		{MAX96712_MIPI_TX18_DST_2_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | 0x01},
++		{MAX96712_MIPI_TX17_SRC_2_MAP_ADDR + (0x40 * pipe_id), (src_vc_lsb << 6) | 0x01},
++		{MAX96712_MIPI_TX18_DST_2_MAP_ADDR + (0x40 * pipe_id), (dst_vc_lsb << 6) | 0x01},
 +		// Map data_type2 on vc_id
-+		{MAX96712_MIPI_TX19_SRC_3_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | data_type2},
-+		{MAX96712_MIPI_TX20_DST_3_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | data_type2},
++		{MAX96712_MIPI_TX19_SRC_3_MAP_ADDR + (0x40 * pipe_id), (src_vc_lsb << 6) | data_type2},
++		{MAX96712_MIPI_TX20_DST_3_MAP_ADDR + (0x40 * pipe_id), (dst_vc_lsb << 6) | data_type2},
 +		// Extended dst vc_id mapping 0
-+		{MAX96712_MIPI_TX_EXT0_ADDR + (0x10 * pipe_id), vc_id_msb << 2},
++		{MAX96712_MIPI_TX_EXT0_ADDR + (0x10 * pipe_id), ext_vc},
 +		// Extended dst vc_id mapping 1
-+		{MAX96712_MIPI_TX_EXT1_ADDR + (0x10 * pipe_id), vc_id_msb << 2},
++		{MAX96712_MIPI_TX_EXT1_ADDR + (0x10 * pipe_id), ext_vc},
 +		// Extended dst vc_id mapping 2
-+		{MAX96712_MIPI_TX_EXT2_ADDR + (0x10 * pipe_id), vc_id_msb << 2},
++		{MAX96712_MIPI_TX_EXT2_ADDR + (0x10 * pipe_id), ext_vc},
 +		// Extended dst vc_id mapping 3
-+		{MAX96712_MIPI_TX_EXT3_ADDR + (0x10 * pipe_id), vc_id_msb << 2},
++		{MAX96712_MIPI_TX_EXT3_ADDR + (0x10 * pipe_id), ext_vc},
 +		// All mappings to PHY1 (master for port A)
 +		{MAX96712_MIPI_TX45_MAP_DPHY_DEST_ADDR + (0x40 * pipe_id), 0x55},
 +		// SEQ_MISS_EN: Disabled / DIS_PKT_DET: Disabled
@@ -790,14 +939,15 @@ index 329a10dfd..688f86fb8 100644
 +}
 +EXPORT_SYMBOL(max96712_init_settings);
 +
-+int max96712_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id)
++int max96712_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
++				   int ser_pipe_id, u32 link)
 +{
 +	struct max96712 *priv = dev_get_drvdata(dev);
 +	int err = 0;
 +
 +	mutex_lock(&priv->lock);
 +
-+	err = __max96712_bind_ser_to_dser_pipe(dev, dser_pipe_id, ser_pipe_id, vc_id);
++	err = __max96712_bind_ser_to_dser_pipe(dev, dser_pipe_id, ser_pipe_id, link);
 +
 +	mutex_unlock(&priv->lock);
 +
@@ -807,63 +957,92 @@ index 329a10dfd..688f86fb8 100644
 +
 +/*
 + * Configure a multi-VC pipe (MAX96717) in one shot. Unlike __max96712_set_pipe(),
-+ * which dedicates a pipe to a single VC, this maps all four local virtual
++ * which dedicates a pipe to a single VC, this maps all four serializer virtual
 + * channels of the link (depth/RGB/IR/IMU) through one deserializer pipe, matching
 + * the way a MAX96717 funnels a camera's streams through a single serializer pipe.
 + * Called with priv->lock held.
 + */
-+static int __max96712_set_multi_vc_pipe(struct device *dev, int pipe_id, u32 vc_id)
++static int __max96712_set_multi_vc_pipe(struct device *dev, int pipe_id, u32 link)
 +{
 +	int err = 0;
-+	int iter;
++	int vc;
 +	struct max96712 *priv = dev_get_drvdata(dev);
-+	int link_id = vc_id / MAX9295_MAX_STREAMS;
 +	uint32_t map_pipe_offs = 0x40 * pipe_id;
 +	uint32_t ext_vc_offs = 0x10 * pipe_id;
++	/* SRC is the serializer VC arriving on the link, DST the remapped VC
++	 * leaving on CSI; EXT carries the high bits of both. */
++	u8 src_vc0 = 0 << 6;
++	u8 src_vc1 = 1 << 6;
++	u8 src_vc2 = 2 << 6;
++	u8 src_vc3 = 3 << 6;
++	u8 dst_vc0 = (priv->vc_remap[link][0] & 0x3) << 6;
++	u8 dst_vc1 = (priv->vc_remap[link][1] & 0x3) << 6;
++	u8 dst_vc2 = (priv->vc_remap[link][2] & 0x3) << 6;
++	u8 dst_vc3 = (priv->vc_remap[link][3] & 0x3) << 6;
++	u8 ext_vc0 = max96712_ext_vc(0, priv->vc_remap[link][0]);
++	u8 ext_vc1 = max96712_ext_vc(1, priv->vc_remap[link][1]);
++	u8 ext_vc2 = max96712_ext_vc(2, priv->vc_remap[link][2]);
++	u8 ext_vc3 = max96712_ext_vc(3, priv->vc_remap[link][3]);
 +
 +	struct reg_pair map_pipe_control[] = {
 +		// Enable all static mappings
 +		{MAX96712_MIPI_TX11_ADDR + map_pipe_offs, 0xFF},
 +		{MAX96712_MIPI_TX12_ADDR + map_pipe_offs, 0xFF},
 +		// Map vc_id 0 formats (depth)
-+		{MAX96712_MIPI_TX13_SRC_0_MAP_ADDR + map_pipe_offs, GMSL_CSI_DT_YUV422_8},
-+		{MAX96712_MIPI_TX14_DST_0_MAP_ADDR + map_pipe_offs, GMSL_CSI_DT_YUV422_8},
-+		{MAX96712_MIPI_TX15_SRC_1_MAP_ADDR + map_pipe_offs, 0x00},
-+		{MAX96712_MIPI_TX16_DST_1_MAP_ADDR + map_pipe_offs, 0x00},
-+		{MAX96712_MIPI_TX17_SRC_2_MAP_ADDR + map_pipe_offs, 0x01},
-+		{MAX96712_MIPI_TX18_DST_2_MAP_ADDR + map_pipe_offs, 0x01},
-+		{MAX96712_MIPI_TX19_SRC_3_MAP_ADDR + map_pipe_offs, GMSL_CSI_DT_EMBED},
-+		{MAX96712_MIPI_TX20_DST_3_MAP_ADDR + map_pipe_offs, GMSL_CSI_DT_EMBED},
++		{MAX96712_MIPI_TX13_SRC_0_MAP_ADDR + map_pipe_offs, src_vc0 | GMSL_CSI_DT_YUV422_8},
++		{MAX96712_MIPI_TX14_DST_0_MAP_ADDR + map_pipe_offs, dst_vc0 | GMSL_CSI_DT_YUV422_8},
++		{MAX96712_MIPI_TX_EXT0_ADDR + ext_vc_offs, ext_vc0},
++		{MAX96712_MIPI_TX15_SRC_1_MAP_ADDR + map_pipe_offs, src_vc0 | 0x00},
++		{MAX96712_MIPI_TX16_DST_1_MAP_ADDR + map_pipe_offs, dst_vc0 | 0x00},
++		{MAX96712_MIPI_TX_EXT1_ADDR + ext_vc_offs, ext_vc0},
++		{MAX96712_MIPI_TX17_SRC_2_MAP_ADDR + map_pipe_offs, src_vc0 | 0x01},
++		{MAX96712_MIPI_TX18_DST_2_MAP_ADDR + map_pipe_offs, dst_vc0 | 0x01},
++		{MAX96712_MIPI_TX_EXT2_ADDR + ext_vc_offs, ext_vc0},
++		{MAX96712_MIPI_TX19_SRC_3_MAP_ADDR + map_pipe_offs, src_vc0 | GMSL_CSI_DT_EMBED},
++		{MAX96712_MIPI_TX20_DST_3_MAP_ADDR + map_pipe_offs, dst_vc0 | GMSL_CSI_DT_EMBED},
++		{MAX96712_MIPI_TX_EXT3_ADDR + ext_vc_offs, ext_vc0},
 +
 +		// Map vc_id 1 formats (RGB)
-+		{MAX96712_MIPI_TX21_SRC_4_MAP_ADDR + map_pipe_offs, (1 << 6) | GMSL_CSI_DT_YUV422_8},
-+		{MAX96712_MIPI_TX22_DST_4_MAP_ADDR + map_pipe_offs, (1 << 6) | GMSL_CSI_DT_YUV422_8},
-+		{MAX96712_MIPI_TX23_SRC_5_MAP_ADDR + map_pipe_offs, (1 << 6) | 0x00},
-+		{MAX96712_MIPI_TX24_DST_5_MAP_ADDR + map_pipe_offs, (1 << 6) | 0x00},
-+		{MAX96712_MIPI_TX25_SRC_6_MAP_ADDR + map_pipe_offs, (1 << 6) | 0x01},
-+		{MAX96712_MIPI_TX26_DST_6_MAP_ADDR + map_pipe_offs, (1 << 6) | 0x01},
-+		{MAX96712_MIPI_TX27_SRC_7_MAP_ADDR + map_pipe_offs, (1 << 6) | GMSL_CSI_DT_EMBED},
-+		{MAX96712_MIPI_TX28_DST_7_MAP_ADDR + map_pipe_offs, (1 << 6) | GMSL_CSI_DT_EMBED},
++		{MAX96712_MIPI_TX21_SRC_4_MAP_ADDR + map_pipe_offs, src_vc1 | GMSL_CSI_DT_YUV422_8},
++		{MAX96712_MIPI_TX22_DST_4_MAP_ADDR + map_pipe_offs, dst_vc1 | GMSL_CSI_DT_YUV422_8},
++		{MAX96712_MIPI_TX_EXT4_ADDR + ext_vc_offs, ext_vc1},
++		{MAX96712_MIPI_TX23_SRC_5_MAP_ADDR + map_pipe_offs, src_vc1 | 0x00},
++		{MAX96712_MIPI_TX24_DST_5_MAP_ADDR + map_pipe_offs, dst_vc1 | 0x00},
++		{MAX96712_MIPI_TX_EXT5_ADDR + ext_vc_offs, ext_vc1},
++		{MAX96712_MIPI_TX25_SRC_6_MAP_ADDR + map_pipe_offs, src_vc1 | 0x01},
++		{MAX96712_MIPI_TX26_DST_6_MAP_ADDR + map_pipe_offs, dst_vc1 | 0x01},
++		{MAX96712_MIPI_TX_EXT6_ADDR + ext_vc_offs, ext_vc1},
++		{MAX96712_MIPI_TX27_SRC_7_MAP_ADDR + map_pipe_offs, src_vc1 | GMSL_CSI_DT_EMBED},
++		{MAX96712_MIPI_TX28_DST_7_MAP_ADDR + map_pipe_offs, dst_vc1 | GMSL_CSI_DT_EMBED},
++		{MAX96712_MIPI_TX_EXT7_ADDR + ext_vc_offs, ext_vc1},
 +
 +		// Map vc_id 2 formats (IR)
-+		{MAX96712_MIPI_TX29_SRC_8_MAP_ADDR + map_pipe_offs, (2 << 6) | GMSL_CSI_DT_YUV422_8},
-+		{MAX96712_MIPI_TX30_DST_8_MAP_ADDR + map_pipe_offs, (2 << 6) | GMSL_CSI_DT_YUV422_8},
-+		{MAX96712_MIPI_TX31_SRC_9_MAP_ADDR + map_pipe_offs, (2 << 6) | 0x00},
-+		{MAX96712_MIPI_TX32_DST_9_MAP_ADDR + map_pipe_offs, (2 << 6) | 0x00},
-+		{MAX96712_MIPI_TX33_SRC_10_MAP_ADDR + map_pipe_offs, (2 << 6) | 0x01},
-+		{MAX96712_MIPI_TX34_DST_10_MAP_ADDR + map_pipe_offs, (2 << 6) | 0x01},
-+		{MAX96712_MIPI_TX35_SRC_11_MAP_ADDR + map_pipe_offs, (2 << 6) | GMSL_CSI_DT_EMBED},
-+		{MAX96712_MIPI_TX36_DST_11_MAP_ADDR + map_pipe_offs, (2 << 6) | GMSL_CSI_DT_EMBED},
-+		{MAX96712_MIPI_TX37_SRC_12_MAP_ADDR + map_pipe_offs, (2 << 6) | GMSL_CSI_DT_RAW_16},
-+		{MAX96712_MIPI_TX38_DST_12_MAP_ADDR + map_pipe_offs, (2 << 6) | GMSL_CSI_DT_RAW_16},
++		{MAX96712_MIPI_TX29_SRC_8_MAP_ADDR + map_pipe_offs, src_vc2 | GMSL_CSI_DT_YUV422_8},
++		{MAX96712_MIPI_TX30_DST_8_MAP_ADDR + map_pipe_offs, dst_vc2 | GMSL_CSI_DT_YUV422_8},
++		{MAX96712_MIPI_TX_EXT8_ADDR + ext_vc_offs, ext_vc2},
++		{MAX96712_MIPI_TX31_SRC_9_MAP_ADDR + map_pipe_offs, src_vc2 | 0x00},
++		{MAX96712_MIPI_TX32_DST_9_MAP_ADDR + map_pipe_offs, dst_vc2 | 0x00},
++		{MAX96712_MIPI_TX_EXT9_ADDR + ext_vc_offs, ext_vc2},
++		{MAX96712_MIPI_TX33_SRC_10_MAP_ADDR + map_pipe_offs, src_vc2 | 0x01},
++		{MAX96712_MIPI_TX34_DST_10_MAP_ADDR + map_pipe_offs, dst_vc2 | 0x01},
++		{MAX96712_MIPI_TX_EXT10_ADDR + ext_vc_offs, ext_vc2},
++		{MAX96712_MIPI_TX35_SRC_11_MAP_ADDR + map_pipe_offs, src_vc2 | GMSL_CSI_DT_EMBED},
++		{MAX96712_MIPI_TX36_DST_11_MAP_ADDR + map_pipe_offs, dst_vc2 | GMSL_CSI_DT_EMBED},
++		{MAX96712_MIPI_TX_EXT11_ADDR + ext_vc_offs, ext_vc2},
++		{MAX96712_MIPI_TX37_SRC_12_MAP_ADDR + map_pipe_offs, src_vc2 | GMSL_CSI_DT_RAW_16},
++		{MAX96712_MIPI_TX38_DST_12_MAP_ADDR + map_pipe_offs, dst_vc2 | GMSL_CSI_DT_RAW_16},
++		{MAX96712_MIPI_TX_EXT12_ADDR + ext_vc_offs, ext_vc2},
 +
 +		// Map vc_id 3 formats (IMU)
-+		{MAX96712_MIPI_TX39_SRC_13_MAP_ADDR + map_pipe_offs, (3 << 6) | GMSL_CSI_DT_RAW_8},
-+		{MAX96712_MIPI_TX40_DST_13_MAP_ADDR + map_pipe_offs, (3 << 6) | GMSL_CSI_DT_RAW_8},
-+		{MAX96712_MIPI_TX41_SRC_14_MAP_ADDR + map_pipe_offs, (3 << 6) | 0x00},
-+		{MAX96712_MIPI_TX42_DST_14_MAP_ADDR + map_pipe_offs, (3 << 6) | 0x00},
-+		{MAX96712_MIPI_TX43_SRC_15_MAP_ADDR + map_pipe_offs, (3 << 6) | 0x01},
-+		{MAX96712_MIPI_TX44_DST_15_MAP_ADDR + map_pipe_offs, (3 << 6) | 0x01},
++		{MAX96712_MIPI_TX39_SRC_13_MAP_ADDR + map_pipe_offs, src_vc3 | GMSL_CSI_DT_RAW_8},
++		{MAX96712_MIPI_TX40_DST_13_MAP_ADDR + map_pipe_offs, dst_vc3 | GMSL_CSI_DT_RAW_8},
++		{MAX96712_MIPI_TX_EXT13_ADDR + ext_vc_offs, ext_vc3},
++		{MAX96712_MIPI_TX41_SRC_14_MAP_ADDR + map_pipe_offs, src_vc3 | 0x00},
++		{MAX96712_MIPI_TX42_DST_14_MAP_ADDR + map_pipe_offs, dst_vc3 | 0x00},
++		{MAX96712_MIPI_TX_EXT14_ADDR + ext_vc_offs, ext_vc3},
++		{MAX96712_MIPI_TX43_SRC_15_MAP_ADDR + map_pipe_offs, src_vc3 | 0x01},
++		{MAX96712_MIPI_TX44_DST_15_MAP_ADDR + map_pipe_offs, dst_vc3 | 0x01},
++		{MAX96712_MIPI_TX_EXT15_ADDR + ext_vc_offs, ext_vc3},
 +
 +		// All mappings to PHY1 (master for port A)
 +		{MAX96712_MIPI_TX45_MAP_DPHY_DEST_ADDR + map_pipe_offs, 0x55},
@@ -876,13 +1055,18 @@ index 329a10dfd..688f86fb8 100644
 +		{MAX96712_VIDEO_RX0_ADDR + (0x12 * pipe_id) + ((pipe_id >= 5) ? 6 : 0), 0x23},
 +	};
 +
++	/* This table maps all four of the camera's VCs in one shot, so the link
++	 * must declare a deserializer VC for every one of them. */
++	for (vc = 0; vc < 4; vc++) {
++		if (priv->vc_remap[link][vc] == MAX96712_VC_UNMAPPED) {
++			dev_err(dev, "%s: link %u serializer vc %d unmapped\n",
++				__func__, link, vc);
++			return -EINVAL;
++		}
++	}
++
 +	err |= max96712_set_registers(priv, map_pipe_control,
 +					ARRAY_SIZE(map_pipe_control));
-+
-+	/* Configuring the mapping's extended VC */
-+	for (iter = 0; iter < 16; iter++) {
-+		err |= max96712_write_reg(priv, MAX96712_MIPI_TX_EXT0_ADDR + iter + ext_vc_offs, link_id << 2);
-+	}
 +
 +	if (err) {
 +		return err;
@@ -894,7 +1078,8 @@ index 329a10dfd..688f86fb8 100644
 +}
 +
 +/* Update mapping table entries that can change in runtime */
-+static int __max96712_update_multi_vc_pipe(struct device *dev, int pipe_id, u32 vc_id, u8 data_type1)
++static int __max96712_update_multi_vc_pipe(struct device *dev, int pipe_id,
++					  u32 link, u32 vc_id, u8 data_type1)
 +{
 +	int err = 0;
 +
@@ -902,17 +1087,19 @@ index 329a10dfd..688f86fb8 100644
 +	if (vc_id == 1) {
 +		struct max96712 *priv = dev_get_drvdata(dev);
 +		uint32_t map_pipe_offs = 0x40 * pipe_id;
++		u8 src_vc = vc_id << 6;
++		u8 dst_vc = (priv->vc_remap[link][vc_id] & 0x3) << 6;
 +
 +		struct reg_pair map_pipe_control[] = {
 +			// Update vc_id 1 formats (RGB)
-+			{MAX96712_MIPI_TX21_SRC_4_MAP_ADDR + map_pipe_offs, (vc_id << 6) | data_type1},
-+			{MAX96712_MIPI_TX22_DST_4_MAP_ADDR + map_pipe_offs, (vc_id << 6) | data_type1},
++			{MAX96712_MIPI_TX21_SRC_4_MAP_ADDR + map_pipe_offs, src_vc | data_type1},
++			{MAX96712_MIPI_TX22_DST_4_MAP_ADDR + map_pipe_offs, dst_vc | data_type1},
 +		};
 +		dev_dbg(dev, "%s: Updating vc_id %u on pipe %u to data type 0x%x\n",
 +				__func__, vc_id, pipe_id, data_type1);
 +		err |= max96712_set_registers(priv, map_pipe_control,
 +						ARRAY_SIZE(map_pipe_control));
-+	
++
 +		if (err) {
 +			return err;
 +		}
@@ -922,7 +1109,7 @@ index 329a10dfd..688f86fb8 100644
 +}
 +
 +int max96712_set_pipe(struct device *dev, int pipe_id,
-+		     u8 data_type1, u8 data_type2, u32 vc_id)
++		     u8 data_type1, u8 data_type2, u32 link, u32 vc_id)
 +{
 +	struct max96712 *priv = dev_get_drvdata(dev);
 +	int err = 0;
@@ -933,8 +1120,16 @@ index 329a10dfd..688f86fb8 100644
 +		return -EINVAL;
 +	}
 +
-+	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
-+		__func__, pipe_id, data_type1, data_type2, vc_id);
++	if (link >= MAX96712_MAX_LINKS || vc_id >= MAX96712_MAX_SER_VCS ||
++	    priv->vc_remap[link][vc_id] == MAX96712_VC_UNMAPPED) {
++		dev_err(dev, "%s: link %u serializer vc %u has no deserializer VC\n",
++			__func__, link, vc_id);
++		return -EINVAL;
++	}
++
++	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, link %u, vc_id %u -> dser vc %u\n",
++		__func__, pipe_id, data_type1, data_type2, link, vc_id,
++		priv->vc_remap[link][vc_id]);
 +
 +	mutex_lock(&priv->lock);
 +
@@ -945,14 +1140,14 @@ index 329a10dfd..688f86fb8 100644
 +		 * config-retry loop) reuse the existing mapping unchanged.
 +		 */
 +		if (!priv->multi_vc_configured[pipe_id]) {
-+			err = __max96712_set_multi_vc_pipe(dev, pipe_id, vc_id);
++			err = __max96712_set_multi_vc_pipe(dev, pipe_id, link);
 +			if (!err)
 +				priv->multi_vc_configured[pipe_id] = true;
 +		}
 +		if (!err)
-+			err = __max96712_update_multi_vc_pipe(dev, pipe_id, vc_id, data_type1);
++			err = __max96712_update_multi_vc_pipe(dev, pipe_id, link, vc_id, data_type1);
 +	} else {
-+		err = __max96712_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
++		err = __max96712_set_pipe(dev, pipe_id, data_type1, data_type2, link, vc_id);
 +	}
 +
 +	mutex_unlock(&priv->lock);
@@ -1098,7 +1293,7 @@ index 329a10dfd..688f86fb8 100644
  	{ },
  };
  
-@@ -301,6 +1176,7 @@ static struct i2c_driver max96712_i2c_driver = {
+@@ -301,6 +1371,7 @@ static struct i2c_driver max96712_i2c_driver = {
  	.driver = {
  		.name = "max96712",
  		.owner = THIS_MODULE,

--- a/kernel/nvidia/max96712.h
+++ b/kernel/nvidia/max96712.h
@@ -38,25 +38,38 @@
 
 int max96712_get_available_pipe_id(struct device *dev, int vc_id);
 /**
- * @brief  Returns the multi-VC pipe dedicated to the link that owns vc_id,
- * allocating one on first request. Used for MAX96717 serializers, which route
- * all of a camera's virtual channels through a single pipe. The pipe is sticky
- * for the driver's lifetime and is never freed by max96712_release_pipe().
+ * @brief  Returns the multi-VC pipe dedicated to a GMSL link, allocating one on
+ * first request. Used for MAX96717 serializers, which route all of a camera's
+ * virtual channels through a single pipe. The pipe is sticky for the driver's
+ * lifetime and is never freed by max96712_release_pipe().
  *
- * @param  [in]  dev    The deserializer device handle.
- * @param  [in]  vc_id  A virtual channel id of the requesting camera; the link
- *                      is derived as vc_id / 4.
+ * @param  [in]  dev   The deserializer device handle.
+ * @param  [in]  link  GMSL link index of the requesting camera.
  *
  * @return  pipe id (>= 0) on success, negative error code otherwise.
  */
-int max96712_get_multi_vc_pipe_id(struct device *dev, int vc_id);
+int max96712_get_multi_vc_pipe_id(struct device *dev, u32 link);
+/**
+ * @brief  Configure a deserializer pipe. vc_id is the serializer virtual
+ * channel; the outgoing CSI virtual channel comes from the link's
+ * "maxim,linkN-vc-remap" table. A link with no table gets a unity map (only
+ * usable as-is on a single-link deserializer); a link with one maps exactly
+ * the VCs it lists and rejects the rest.
+ */
 int max96712_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
-		     u8 data_type2, u32 vc_id);
+		     u8 data_type2, u32 link, u32 vc_id);
+/**
+ * @brief  Returns the serializer virtual channel that the link presents
+ * as deserializer VC dser_vc, per "maxim,linkN-vc-remap".
+ *
+ * @return  serializer VC (>= 0) on success, negative error code if unmapped.
+ */
+int max96712_get_ser_vc_id(struct device *dev, u32 link, u32 dser_vc);
 int max96712_release_pipe(struct device *dev, int pipe_id);
 void max96712_reset_oneshot(struct device *dev);
 /* RSDEV-12608: flush one GMSL link's pixel line buffer after a camera HW reset;
  * called per-link from d4xx's ds5_hw_reset_with_recovery(). */
-void max96712_reset_oneshot_link(struct device *dev, u32 vc_id);
+void max96712_reset_oneshot_link(struct device *dev, u32 link);
 int max96712_setup_link(struct device *dev, struct device *s_dev);
 int max96712_setup_control(struct device *dev, struct device *s_dev);
 int max96712_reset_control(struct device *dev, struct device *s_dev);
@@ -71,8 +84,9 @@ int max96712_init_settings(struct device *dev);
  * @param [in]  dev             The deserializer device handle.
  * @param [in]  dser_pipe_id    Deserializer pipe id.
  * @param [in]  ser_pipe_id     Serializer pipe id.
- * @param [in]  vc_id           vc_id associated with this pipe path.
+ * @param [in]  link            GMSL link the serializer pipe lives on.
  */
-int max96712_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id);
+int max96712_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id,
+								   u32 link);
 
 #endif  /* __MAX96712_H__ */

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -46,21 +46,26 @@
 
 /* Deserializer interface structure for abstraction */
 struct dser_interface {
-	/* Pipeline management */
+	/* Pipeline management. */
 	int (*get_available_pipe_id)(struct device *dev, int vc_id);
-	/* Allocate/return a sticky multi-VC pipe for the vc_id's link. Used for
-	 * MAX96717 serializers, which funnel all of a camera's VCs through one
-	 * pipe. Optional - NULL if the deserializer has no multi-VC support. */
-	int (*get_multi_vc_pipe_id)(struct device *dev, int vc_id);
-	int (*bind_ser_to_dser_pipe)(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id);
+	/* Reverse the link's VC map: Optional - NULL on
+	 * deserializers that do not remap */
+	int (*get_ser_vc_id)(struct device *dev, u32 link, u32 dser_vc);
+	/* Allocate/return a sticky multi-VC pipe for a link. Used for MAX96717
+	 * serializers, which funnel all of a camera's VCs through one pipe.
+	 * Optional - NULL if the deserializer has no multi-VC support. */
+	int (*get_multi_vc_pipe_id)(struct device *dev, u32 link);
+	int (*bind_ser_to_dser_pipe)(struct device *dev, int dser_pipe_id, int ser_pipe_id,
+				     u32 link);
 
-	int (*set_pipe)(struct device *dev, int pipe_id, u8 data_type1, u8 data_type2, u32 vc_id);
+	int (*set_pipe)(struct device *dev, int pipe_id, u8 data_type1, u8 data_type2,
+			u32 link, u32 vc_id);
 	int (*release_pipe)(struct device *dev, int pipe_id);
 	void (*reset_oneshot)(struct device *dev);
 	/* Flush one link's pixel line buffer, after a camera HW reset and on
 	 * link cold bring-up; NULL if the deser leaves no stale buffer
 	 * (max9296). Must not be called while the link has live streams. */
-	void (*reset_oneshot_link)(struct device *dev, u32 vc_id);
+	void (*reset_oneshot_link)(struct device *dev, u32 link);
 	void (*retrigger_datapath)(struct device *dev);
 
 	/* Setup and control */
@@ -281,6 +286,9 @@ enum ds5_mux_pad {
 #define DS5_N_CONTROLS			8
 
 #define DS5_MAX_STREAMS	4
+#define DS5_MAX_GMSL_LINKS	4
+/* No "maxim,gmsl-link-id" on the serializer node: derive it the old way. */
+#define DS5_GMSL_LINK_UNSET	0xFFFFFFFFu
 
 #define PIPE_NOT_CONFIGURED	-1
 
@@ -614,6 +622,10 @@ struct ds5 {
 	u16 control_status_reg;
 #ifdef CONFIG_VIDEO_D4XX_SERDES
 	struct gmsl_link_ctx g_ctx;
+	/* GMSL link this camera is wired to. From the serializer node's
+	 * "maxim,gmsl-link-id"; no longer derivable from dst_vc once a
+	 * deserializer remaps virtual channels. */
+	u32 gmsl_link;
 	struct device *ser_dev;
 	struct device *dser_dev;
 	struct i2c_client *ser_i2c;
@@ -734,6 +746,7 @@ static const struct dser_interface max9296_interface = {
 /* MAX96712 deserializer interface implementation */
 static const struct dser_interface max96712_interface = {
 	.get_available_pipe_id = max96712_get_available_pipe_id,
+	.get_ser_vc_id = max96712_get_ser_vc_id,
 	.get_multi_vc_pipe_id = max96712_get_multi_vc_pipe_id,
 	.bind_ser_to_dser_pipe = max96712_bind_ser_to_dser_pipe,
 	.set_pipe = max96712_set_pipe,
@@ -2122,27 +2135,23 @@ static int serdes_get_ser_pipe_id(struct ds5 *state, int dser_pipe_id,
 }
 
 static int ds5_setup_pipeline(struct ds5 *state, u8 data_type1, u8 data_type2,
-			      int pipe_id, u32 vc_id)
+			      int pipe_id, u32 vc_id, int ser_vc_id)
 {
 	int ret = 0;
-	/* While some deserializers can support up to 8 pipes, the serializer currently
-	 * only supports four vc_ids (0 - 3).
-	 * To use multiple cameras under this restriction, a second camera connected
-	 * to a deserializer will have its vc_id 0 - 3 mapped to outside vc_id 4 - 7 etc.
-	 * The ser_pipe_id mapping depends on both the serializer and the
-	 * deserializer (see serdes_get_ser_pipe_id()).
-	 */
-	int ser_vc_id = vc_id % DS5_MAX_STREAMS;
+	/* ser_pipe_id depends on both the serializer and the deserializer
+	 * (see serdes_get_ser_pipe_id()). */
 	int ser_pipe_id = serdes_get_ser_pipe_id(state, pipe_id, ser_vc_id);
 
-	ret |= state->dser_ops->bind_ser_to_dser_pipe(state->dser_dev, pipe_id, ser_pipe_id, vc_id);
+	ret |= state->dser_ops->bind_ser_to_dser_pipe(state->dser_dev, pipe_id, ser_pipe_id,
+				state->gmsl_link);
 	dev_dbg(&state->client->dev,
-			"set ser pipe %d, dser pipe %d, data_type1: 0x%x, data_type2: 0x%x, ser_vc_id: %u, vc_id: %u\n",
-			ser_pipe_id, pipe_id, data_type1, data_type2, ser_vc_id, vc_id);
+			"set ser pipe %d, dser pipe %d, data_type1: 0x%x, data_type2: 0x%x, link: %u, ser_vc_id: %u, vc_id: %u\n",
+			ser_pipe_id, pipe_id, data_type1, data_type2, state->gmsl_link,
+			ser_vc_id, vc_id);
 	ret |= state->ser_ops->set_pipe(state->ser_dev, ser_pipe_id,
 				data_type1, data_type2, ser_vc_id);
 	ret |= state->dser_ops->set_pipe(state->dser_dev, pipe_id,
-				data_type1, data_type2, vc_id);
+				data_type1, data_type2, state->gmsl_link, ser_vc_id);
 	if (ret)
 		dev_warn(&state->client->dev,
 			 "failed to set pipe %d, data_type1: 0x%x, data_type2: 0x%x, vc_id: %u\n",
@@ -2189,7 +2198,9 @@ static int ds5_configure(struct ds5 *state)
 #ifdef CONFIG_VIDEO_D4XX_SERDES
 	u16 data_type1, data_type2;
 	bool is_calib = 0;
+	int ser_vc_id;
 #endif
+	u16 md_vc = 0;
 	u16 dt_addr, md_addr, override_addr, fps_addr, width_addr, height_addr;
 	u16 dt_value = 0;
 	u16 md_value = 0;
@@ -2242,6 +2253,18 @@ static int ds5_configure(struct ds5 *state)
 	is_calib = (state->is_y8 && (data_type1 == GMSL_CSI_DT_RGB_888));
 
 	vc_id = state->g_ctx.dst_vc;
+	/* vc_id is the deserializer-side VC, from DT and used by the VI graph.
+	 * The serializer and the camera's own registers speak the serializer VC,
+	 * which only the deserializer's remap table can resolve. */
+	ser_vc_id = state->dser_ops->get_ser_vc_id ?
+		state->dser_ops->get_ser_vc_id(state->dser_dev, state->gmsl_link, vc_id) :
+		(int)vc_id;
+	if (ser_vc_id < 0) {
+		dev_err(&state->client->dev, "no serializer VC for link %u dser vc %u\n",
+			state->gmsl_link, vc_id);
+		return ser_vc_id;
+	}
+	md_vc = ser_vc_id;
     if (PIPE_NOT_CONFIGURED == sensor->pipe_id ||
 			sensor->pipe_data_type1 != data_type1 ||
 			sensor->pipe_data_type2 != data_type2 ||
@@ -2271,10 +2294,11 @@ static int ds5_configure(struct ds5 *state)
 		if (state->ser_ops == &max96717_interface &&
 		    state->dser_ops->get_multi_vc_pipe_id)
 			sensor->pipe_id =
-				state->dser_ops->get_multi_vc_pipe_id(state->dser_dev, (int)state->g_ctx.dst_vc);
+				state->dser_ops->get_multi_vc_pipe_id(state->dser_dev,
+								      state->gmsl_link);
 		else
 			sensor->pipe_id =
-				state->dser_ops->get_available_pipe_id(state->dser_dev, (int)state->g_ctx.dst_vc);
+				state->dser_ops->get_available_pipe_id(state->dser_dev, (int)vc_id);
 		mutex_unlock(&serdes_lock__);
 		if (sensor->pipe_id < 0) {
 			dev_err(&state->client->dev, "No free pipe in %s\n",state->dser_ops->name);
@@ -2282,7 +2306,7 @@ static int ds5_configure(struct ds5 *state)
 		}
 		mutex_lock(&serdes_lock__);
 		ret = ds5_setup_pipeline(state, data_type1, data_type2,
-					 sensor->pipe_id, vc_id);
+					 sensor->pipe_id, vc_id, ser_vc_id);
 		// reset data path when switching to Y12I
 		if (is_calib)
 			state->dser_ops->reset_oneshot(state->dser_dev);
@@ -2302,6 +2326,7 @@ static int ds5_configure(struct ds5 *state)
 	}
 #else /* Non-SERDES configuration */
 	vc_id = (state->is_depth) ? 0 : (state->is_rgb) ? 1 : (state->is_y8) ? 2 : 3;
+	md_vc = vc_id;
 #endif
 
 	/* Determine desired data-type (special cases for depth/IR), then write
@@ -2327,7 +2352,7 @@ static int ds5_configure(struct ds5 *state)
 		sensor->cached_dt_value = dt_value;
 	}
 
-	md_value = (vc_id << 8) | md_fmt;
+	md_value = (md_vc << 8) | md_fmt;
 	if (sensor->cached_md_value != md_value) {
 		ret = ds5_write(state, md_addr, md_value);
 		if (ret < 0)
@@ -3187,7 +3212,7 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	/* RSDEV-12608: drop the stale partial frame a mid-stream camera reset leaves
 	 * in this link's line buffer (NULL-safe; max9296 leaves none). */
 	if (state->dser_ops->reset_oneshot_link)
-		state->dser_ops->reset_oneshot_link(state->dser_dev, state->g_ctx.dst_vc);
+		state->dser_ops->reset_oneshot_link(state->dser_dev, state->gmsl_link);
 
 	/* Re-apply ESYNC tunneling to match cached sync_mode control */
 	if (state->ctrls.sync_mode) {
@@ -4737,6 +4762,7 @@ static int ds5_board_setup(struct ds5 *state)
 		ser_node = of_parse_phandle(node, "nvidia,gmsl-ser-device", 0);
 		if (ser_node == NULL) {
 			dev_err(dev, "missing %s handle\n", "[maxim|nvidia],gmsl-ser-device");
+			err = -EINVAL;
 			goto error;
 		}
 	}
@@ -4744,6 +4770,15 @@ static int ds5_board_setup(struct ds5 *state)
 	dev_dbg(dev,  "serializer reg: 0x%x\n", state->g_ctx.ser_reg);
 	if (err < 0) {
 		dev_err(dev, "serializer reg not found\n");
+		goto error;
+	}
+
+	/* The GMSL link is a static board fact stated on the serializer node. */
+	if (of_property_read_u32(ser_node, "maxim,gmsl-link-id", &state->gmsl_link))
+		state->gmsl_link = DS5_GMSL_LINK_UNSET;
+	else if (state->gmsl_link >= DS5_MAX_GMSL_LINKS) {
+		dev_err(dev, "illegal maxim,gmsl-link-id %u\n", state->gmsl_link);
+		err = -EINVAL;
 		goto error;
 	}
 
@@ -4756,6 +4791,7 @@ static int ds5_board_setup(struct ds5 *state)
 	}
 	if (ser_i2c->dev.driver == NULL) {
 		dev_err(dev, "missing serializer driver\n");
+		err = -EPROBE_DEFER;
 		goto error;
 	}
 
@@ -4778,6 +4814,7 @@ static int ds5_board_setup(struct ds5 *state)
 		dser_node = of_parse_phandle(node, "nvidia,gmsl-dser-device", 0);
 		if (dser_node == NULL) {
 			dev_err(dev, "missing %s handle\n", "[maxim|nvidia],gmsl-dser-device");
+			err = -EINVAL;
 			goto error;
 		}
 	}
@@ -4790,6 +4827,7 @@ static int ds5_board_setup(struct ds5 *state)
 	}
 	if (dser_i2c->dev.driver == NULL) {
 		dev_err(dev, "missing deserializer driver\n");
+		err = -EPROBE_DEFER;
 		goto error;
 	}
 
@@ -4807,6 +4845,7 @@ static int ds5_board_setup(struct ds5 *state)
 		dev_err(dev, "%s: Unsupported deserializer = %s\n", __func__, dser_node->name);
 		/* Should not be used, this is just to make sure we don't have NULL pointers */
 		state->dser_ops = &max9296_interface;
+		err = -ENODEV;
 		goto error;
 	}
 	dev_info(dev, "Using deserializer %s\n", state->dser_ops->name);
@@ -4852,6 +4891,7 @@ static int ds5_board_setup(struct ds5 *state)
 		state->g_ctx.csi_mode = GMSL_CSI_2X2_MODE;
 	} else {
 		dev_err(dev, "invalid csi mode\n");
+		err = -EINVAL;
 		goto error;
 	}
 
@@ -4877,6 +4917,13 @@ static int ds5_board_setup(struct ds5 *state)
 		goto error;
 	}
 	state->g_ctx.dst_vc = value;
+
+	/* Overlays predating maxim,gmsl-link-id encode the link in vc-id. */
+	if (state->gmsl_link == DS5_GMSL_LINK_UNSET) {
+		state->gmsl_link = state->g_ctx.dst_vc / DS5_MAX_STREAMS;
+		dev_warn(dev, "no maxim,gmsl-link-id, using link %u from vc-id %u\n",
+			 state->gmsl_link, state->g_ctx.dst_vc);
+	}
 
 	err = of_property_read_u32(gmsl, "num-lanes", &value);
 	if (err < 0) {
@@ -5029,6 +5076,7 @@ static int ds5_board_setup(struct ds5 *state)
 	}
 	state->g_ctx.st_vc = 0;
 	state->g_ctx.dst_vc = 0;
+	state->gmsl_link = 0;
 
 	state->g_ctx.num_csi_lanes = 2;
 	state->g_ctx.s_dev = dev;
@@ -6044,8 +6092,7 @@ static void ds5_flush_idle_link(struct ds5 *state)
 	mutex_unlock(&state->ds5_dev->lock);
 
 	if (flush)
-		state->dser_ops->reset_oneshot_link(state->dser_dev,
-						    state->g_ctx.dst_vc);
+		state->dser_ops->reset_oneshot_link(state->dser_dev, state->gmsl_link);
 }
 #endif
 
@@ -6333,11 +6380,16 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		mutex_unlock(&serdes_lock__);
 		/* Tell the serializer this stream stopped. On the last stream it
 		 * re-arms the MIPI RX PHY (idle) so the next stream re-locks
-		 * cleanly instead of wedging the shared pipe. vc_id % DS5_MAX_STREAMS
-		 * matches the ser_vc_id passed to set_pipe in ds5_setup_pipeline(). */
-		if (state->ser_ops->stream_stop)
-			state->ser_ops->stream_stop(state->ser_dev,
-						    vc_id % DS5_MAX_STREAMS);
+		 * cleanly instead of wedging the shared pipe. */
+		if (state->ser_ops->stream_stop) {
+			int ser_vc_id = state->dser_ops->get_ser_vc_id ?
+				state->dser_ops->get_ser_vc_id(state->dser_dev,
+							       state->gmsl_link, vc_id) :
+				(int)vc_id;
+
+			if (ser_vc_id >= 0)
+				state->ser_ops->stream_stop(state->ser_dev, ser_vc_id);
+		}
 		msleep_range(100);
 #endif
 	}

--- a/nvidia-oot/6.0/0002-max9295-max9296-SerDes-support-for-D4xx.patch
+++ b/nvidia-oot/6.0/0002-max9295-max9296-SerDes-support-for-D4xx.patch
@@ -369,7 +369,7 @@ index 1ceaf3cd..97559460 100644
 +EXPORT_SYMBOL(max9296_init_settings);
 +
 +int max9296_set_pipe(struct device *dev, int pipe_id,
-+		     u8 data_type1, u8 data_type2, u32 vc_id)
++		     u8 data_type1, u8 data_type2, u32 link, u32 vc_id)
 +{
 +	struct max9296 *priv = dev_get_drvdata(dev);
 +	int err = 0;
@@ -459,7 +459,7 @@ index 210dbc80..6b4c796e 100644
  
 +int max9296_get_available_pipe_id(struct device *dev, int vc_id);
 +int max9296_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
-+		     u8 data_type2, u32 vc_id);
++		     u8 data_type2, u32 link, u32 vc_id);
 +int max9296_release_pipe(struct device *dev, int pipe_id);
 +void max9296_reset_oneshot(struct device *dev);
 +
@@ -777,7 +777,7 @@ index d50bea51..92b483b6 100644
  }
  EXPORT_SYMBOL(max9296_init_settings);
  
-+int max9296_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id)
++int max9296_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 link)
 +{
 +	/* pipe id's are 1:1 in this deserializer */
 +	return 0;
@@ -785,7 +785,7 @@ index d50bea51..92b483b6 100644
 +EXPORT_SYMBOL(max9296_bind_ser_to_dser_pipe);
 +
  int max9296_set_pipe(struct device *dev, int pipe_id,
- 		     u8 data_type1, u8 data_type2, u32 vc_id)
+ 		     u8 data_type1, u8 data_type2, u32 link, u32 vc_id)
  {
 diff --git a/include/media/max9296.h b/include/media/max9296.h
 index 6b4c796e..db7365d7 100644
@@ -804,9 +804,9 @@ index 6b4c796e..db7365d7 100644
 + * @param [in]  dev             The deserializer device handle.
 + * @param [in]  dser_pipe_id    Deserializer pipe id.
 + * @param [in]  ser_pipe_id     Serializer pipe id.
-+ * @param [in]  vc_id           vc_id associated with this pipe path.
++ * @param [in]  link            GMSL link the serializer pipe lives on.
 + */
-+int max9296_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id);
++int max9296_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 link);
 +
  /** @} */
  

--- a/nvidia-oot/6.0/0003-Adding-max96712-support-for-D4xx.patch
+++ b/nvidia-oot/6.0/0003-Adding-max96712-support-for-D4xx.patch
@@ -1,20 +1,20 @@
-From ede2412e2c450275116a819838363a628c560f61 Mon Sep 17 00:00:00 2001
+From 9b1affb389a3679b6cfe4e9200bde75393a0ce4c Mon Sep 17 00:00:00 2001
 From: ejgoldik <ehud.joseph.goldik@realsenseai.com>
-Date: Wed, 5 Aug 2026 08:21:23 +0300
+Date: Mon, 24 Aug 2026 09:25:37 +0300
 Subject: [PATCH] Adding max96712 support for D4xx
 
 Add MAX96712 deserializer driver support for D4XX/D5XX cameras.
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- drivers/media/i2c/max96712.c | 940 +++++++++++++++++++++++++++++++++--
- 1 file changed, 905 insertions(+), 35 deletions(-)
+ drivers/media/i2c/max96712.c | 1135 ++++++++++++++++++++++++++++++++--
+ 1 file changed, 1100 insertions(+), 35 deletions(-)
 
 diff --git a/drivers/media/i2c/max96712.c b/drivers/media/i2c/max96712.c
-index 8e237eef..12729a1e 100644
+index 8e237eef..3b6a5103 100644
 --- a/drivers/media/i2c/max96712.c
 +++ b/drivers/media/i2c/max96712.c
-@@ -16,32 +16,162 @@
+@@ -16,32 +16,182 @@
  #include <linux/gpio.h>
  #include <linux/of.h>
  #include <linux/of_gpio.h>
@@ -65,6 +65,7 @@ index 8e237eef..12729a1e 100644
 +#define MAX96712_MIPI_TX_EXT12_ADDR 0x80c
 +#define MAX96712_MIPI_TX_EXT13_ADDR 0x80d
 +#define MAX96712_MIPI_TX_EXT14_ADDR 0x80e
++#define MAX96712_MIPI_TX_EXT15_ADDR 0x80f
 +
 +#define MAX96712_MIPI_PHY0_ADDR 0x8A0
 +#define MAX96712_MIPI_PHY2_ADDR 0x8A2
@@ -133,7 +134,22 @@ index 8e237eef..12729a1e 100644
 +/* data defines */
 +#define MAX96712_MAX_LINKS 4
 +#define MAX96712_MAX_PIPES 8
-+#define MAX9295_MAX_STREAMS 4
++/* Extended CSI VC: two low bits live in the SRC/DST map regs, three high bits
++ * in MIPI_TX_EXT<n> - DST at bits 4:2, SRC at bits 7:5. */
++#define MAX96712_MAX_VCS 32
++#define MAX96712_EXT_VC_DST_SHIFT 2
++#define MAX96712_EXT_VC_SRC_SHIFT 5
++/* Serializer VCs a link may present, i.e. the streams one camera can carry. */
++#define MAX96712_MAX_SER_VCS 8
++#define MAX96712_VC_UNMAPPED 0xFF
++#define MAX96712_VC_REMAP_CELLS 2
++
++/* MIPI_TX_EXT<n>: high bits of the source and destination virtual channels. */
++static inline u8 max96712_ext_vc(u32 src_vc, u32 dst_vc)
++{
++	return ((src_vc >> 2) << MAX96712_EXT_VC_SRC_SHIFT) |
++	       ((dst_vc >> 2) << MAX96712_EXT_VC_DST_SHIFT);
++}
  
  struct max96712 {
  	struct i2c_client *i2c_client;
@@ -155,6 +171,10 @@ index 8e237eef..12729a1e 100644
 +	 */
 +	int link_multi_vc_pipe[MAX96712_MAX_LINKS];
 +	bool multi_vc_configured[MAX96712_MAX_PIPES];
++	/* Serializer VC -> deserializer VC, or MAX96712_VC_UNMAPPED. A link with
++	 * no maxim,linkN-vc-remap gets a unity map; one with a table gets only
++	 * the VCs that table declares. */
++	u8 vc_remap[MAX96712_MAX_LINKS][MAX96712_MAX_SER_VCS];
 +	bool force_clk0;
 +	int lane_cnt;
 +	bool fangzhu_fg12_reverse_lane_polarity;
@@ -182,7 +202,7 @@ index 8e237eef..12729a1e 100644
  	i2c_client = global_priv[channel]->i2c_client;
  	bak = i2c_client->addr;
  
-@@ -53,7 +183,6 @@ int max96712_write_reg_Dser(int slaveAddr, int channel,
+@@ -53,7 +203,6 @@ int max96712_write_reg_Dser(int slaveAddr, int channel,
  		dev_err(&i2c_client->dev, "%s: addr = 0x%x, val = 0x%x\n",
  				__func__, addr, val);
  	}
@@ -190,7 +210,7 @@ index 8e237eef..12729a1e 100644
  	return err;
  }
  EXPORT_SYMBOL(max96712_write_reg_Dser);
-@@ -68,8 +197,6 @@ int max96712_read_reg_Dser(int slaveAddr, int channel,
+@@ -68,8 +217,6 @@ int max96712_read_reg_Dser(int slaveAddr, int channel,
  
  	if (channel > 3 || channel < 0 || global_priv[channel] == NULL)
  		return -1;
@@ -199,7 +219,7 @@ index 8e237eef..12729a1e 100644
  	i2c_client = global_priv[channel]->i2c_client;
  	bak = i2c_client->addr;
  	i2c_client->addr = slaveAddr / 2;
-@@ -80,11 +207,56 @@ int max96712_read_reg_Dser(int slaveAddr, int channel,
+@@ -80,11 +227,56 @@ int max96712_read_reg_Dser(int slaveAddr, int channel,
  		dev_err(&i2c_client->dev, "%s: addr = 0x%x, val = 0x%x\n",
  				__func__, addr, *val);
  	}
@@ -257,7 +277,7 @@ index 8e237eef..12729a1e 100644
  static int max96712_read_reg(struct max96712 *priv,
  			u16 addr, unsigned int *val)
  {
-@@ -99,6 +271,20 @@ static int max96712_read_reg(struct max96712 *priv,
+@@ -99,6 +291,20 @@ static int max96712_read_reg(struct max96712 *priv,
  	return err;
  }
  
@@ -278,7 +298,7 @@ index 8e237eef..12729a1e 100644
  
  static int max96712_stats_show(struct seq_file *s, void *data)
  {
-@@ -153,24 +339,6 @@ static const struct file_operations max96712_debugfs_fops = {
+@@ -153,24 +359,6 @@ static const struct file_operations max96712_debugfs_fops = {
  	.release = single_release,
  };
  
@@ -303,7 +323,7 @@ index 8e237eef..12729a1e 100644
  static int max96712_debugfs_init(const char *dir_name,
  				struct dentry **d_entry,
  				struct dentry **f_entry,
-@@ -225,7 +393,8 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -225,9 +413,106 @@ static int max96712_debugfs_init(const char *dir_name,
  static  struct regmap_config max96712_regmap_config = {
  	.reg_bits = 16,
  	.val_bits = 8,
@@ -312,8 +332,106 @@ index 8e237eef..12729a1e 100644
 +	.cache_type = REGCACHE_NONE,
  };
  
++/*
++ * Parse the optional per-link "maxim,linkN-vc-remap" tables, each a list of
++ * <serializer-vc deserializer-vc> pairs. A link with no table keeps the unity
++ * map; a link with one, maps exactly the VCs it lists and leaves the rest
++ * unmapped, so every link of a multi-link deserializer has to declare a table.
++ */
++static int max96712_parse_vc_remap(struct max96712 *priv, struct device_node *np)
++{
++	struct device *dev = &priv->i2c_client->dev;
++	unsigned int link;
++	u32 dser_vc_seen_mask = 0;
++	int map_elems, err, i;
++
++	/* Default unity mapping table */
++	for (link = 0; link < MAX96712_MAX_LINKS; link++) {
++		for (i = 0; i < MAX96712_MAX_SER_VCS; i++) {
++			priv->vc_remap[link][i] = i;
++		}
++	}
++
++	if (!np) {
++		return 0;
++	}
++
++	for (link = 0; link < MAX96712_MAX_LINKS; link++) {
++		char link_map_prop[32];
++		u32 src, dst;
++
++		snprintf(link_map_prop, sizeof(link_map_prop), "maxim,link%u-vc-remap", link);
++
++		map_elems = of_property_count_u32_elems(np, link_map_prop);
++		/* -EINVAL means absent; anything else negative is malformed. */
++		if (map_elems == -EINVAL)
++			continue;
++		if (map_elems < 0) {
++			dev_err(dev, "%s: unreadable (%d)\n", link_map_prop, map_elems);
++			return map_elems;
++		}
++		if (!(priv->link_mask & (1 << link))) {
++			dev_err(dev, "%s: link not enabled by link-mask 0x%x\n",
++				link_map_prop, priv->link_mask);
++			return -EINVAL;
++		}
++		if (map_elems % MAX96712_VC_REMAP_CELLS ||
++		    map_elems > MAX96712_MAX_SER_VCS * MAX96712_VC_REMAP_CELLS) {
++			dev_err(dev, "%s: %d cells, expected up to %d <ser dser> pairs\n",
++				link_map_prop, map_elems, MAX96712_MAX_SER_VCS);
++			return -EINVAL;
++		}
++
++		/* An explicit table replaces the unity default outright: VCs it
++		 * does not list stay unmapped. */
++		for (i = 0; i < MAX96712_MAX_SER_VCS; i++) {
++			priv->vc_remap[link][i] = MAX96712_VC_UNMAPPED;
++		}
++
++		/* Start filling the map */
++		for (i = 0; i < map_elems; i += MAX96712_VC_REMAP_CELLS) {
++			err = of_property_read_u32_index(np, link_map_prop, i, &src);
++			if (!err)
++				err = of_property_read_u32_index(np, link_map_prop, i + 1, &dst);
++			if (err) {
++				dev_err(dev, "%s: read failed (%d)\n", link_map_prop, err);
++				return err;
++			}
++			if (src >= MAX96712_MAX_SER_VCS || dst >= MAX96712_MAX_VCS) {
++				dev_err(dev, "%s: illegal pair <%u %u>\n", link_map_prop, src, dst);
++				return -EINVAL;
++			}
++			priv->vc_remap[link][src] = dst;
++		}
++	}
++
++	/* Validation loop - Making sure there are no dst vc collisions */
++	for (link = 0; link < MAX96712_MAX_LINKS; link++) {
++		if (!(priv->link_mask & (1 << link)))
++			continue;
++		for (i = 0; i < MAX96712_MAX_SER_VCS; i++) {
++			u8 vc = priv->vc_remap[link][i];
++
++			if (vc == MAX96712_VC_UNMAPPED)
++				continue;
++			if (dser_vc_seen_mask & (1u << vc)) {
++				dev_err(dev,
++					"dser VC %u mapped more than once, output VCs must be unique\n",
++					vc);
++				return -EINVAL;
++			}
++			dser_vc_seen_mask |= 1u << vc;
++			dev_dbg(dev, "link %u src_vc: %u dst_vc: %u\n", link, i, priv->vc_remap[link][i]);
++		}
++	}
++
++	return 0;
++}
++
  #if defined(NV_I2C_DRIVER_STRUCT_PROBE_WITHOUT_I2C_DEVICE_ID_ARG) /* Linux 6.3 */
-@@ -237,10 +406,16 @@ static int max96712_probe(struct i2c_client *client,
+ static int max96712_probe(struct i2c_client *client)
+ #else
+@@ -237,10 +522,16 @@ static int max96712_probe(struct i2c_client *client,
  {
  	struct max96712 *priv;
  	int err = 0;
@@ -330,7 +448,7 @@ index 8e237eef..12729a1e 100644
  	priv->i2c_client = client;
  	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
  				&max96712_regmap_config);
-@@ -249,15 +424,55 @@ static int max96712_probe(struct i2c_client *client,
+@@ -249,15 +540,59 @@ static int max96712_probe(struct i2c_client *client,
  			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
  		return -ENODEV;
  	}
@@ -386,12 +504,16 @@ index 8e237eef..12729a1e 100644
 +			of_property_read_bool(np, "fangzhu,fg12-poc-enable");
  	}
  
++	err = max96712_parse_vc_remap(priv, np);
++	if (err)
++		return err;
++
 +	dev_set_drvdata(&client->dev, priv);
 +
  	err = max96712_debugfs_init(NULL, NULL, NULL, priv);
  	if (err)
  		return err;
-@@ -274,8 +489,11 @@ static int max96712_remove(struct i2c_client *client)
+@@ -274,8 +609,11 @@ static int max96712_remove(struct i2c_client *client)
  static void max96712_remove(struct i2c_client *client)
  #endif
  {
@@ -404,7 +526,7 @@ index 8e237eef..12729a1e 100644
  		i2c_unregister_device(client);
  		client = NULL;
  	}
-@@ -284,13 +502,664 @@ static void max96712_remove(struct i2c_client *client)
+@@ -284,13 +622,739 @@ static void max96712_remove(struct i2c_client *client)
  #endif
  }
  
@@ -497,20 +619,19 @@ index 8e237eef..12729a1e 100644
 +}
 +
 +/*
-+ * Allocate (or return the already-allocated) multi-VC pipe for the link that
-+ * owns vc_id. Used for MAX96717 serializers, which route all of a camera's
++ * Allocate (or return the already-allocated) multi-VC pipe for a link. Used
++ * for MAX96717 serializers, which route all of a camera's
 + * virtual channels through a single serializer pipe. The pipe is dedicated to
 + * the link for the driver's lifetime: every stream of that camera reuses it and
 + * max96712_release_pipe() never frees it.
 + */
-+int max96712_get_multi_vc_pipe_id(struct device *dev, int vc_id)
++int max96712_get_multi_vc_pipe_id(struct device *dev, u32 link)
 +{
 +	struct max96712 *priv = dev_get_drvdata(dev);
-+	int link = vc_id / MAX9295_MAX_STREAMS;
 +	int pipe_id = -ENOSR;
 +	int i;
 +
-+	if (link < 0 || link >= MAX96712_MAX_LINKS)
++	if (link >= MAX96712_MAX_LINKS)
 +		return -EINVAL;
 +
 +	mutex_lock(&priv->lock);
@@ -537,11 +658,11 @@ index 8e237eef..12729a1e 100644
 +}
 +EXPORT_SYMBOL(max96712_get_multi_vc_pipe_id);
 +
-+static int __max96712_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id)
++static int __max96712_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
++					    int ser_pipe_id, u32 link_id)
 +{
 +	struct max96712 *priv = dev_get_drvdata(dev);
 +	unsigned int pipe_sel_val = 0;
-+	u32 link_id = vc_id / MAX9295_MAX_STREAMS;
 +	int err = 0;
 +
 +	/* dser_pipe_id will be connected to ser_pipe_id of link_id */
@@ -567,6 +688,28 @@ index 8e237eef..12729a1e 100644
 +
 +	return err;
 +}
++
++/*
++ * Reverse the link's VC map: which serializer VC arrives as dser_vc.
++ * vc_remap is written once at probe, so this needs no lock.
++ */
++int max96712_get_ser_vc_id(struct device *dev, u32 link, u32 dser_vc)
++{
++	struct max96712 *priv = dev_get_drvdata(dev);
++	int i;
++
++	if (link >= MAX96712_MAX_LINKS)
++		return -EINVAL;
++
++	for (i = 0; i < MAX96712_MAX_SER_VCS; i++)
++		if (priv->vc_remap[link][i] != MAX96712_VC_UNMAPPED &&
++		    priv->vc_remap[link][i] == dser_vc)
++			return i;
++
++	dev_err(dev, "link %u has no serializer VC mapped to dser VC %u\n", link, dser_vc);
++	return -EINVAL;
++}
++EXPORT_SYMBOL(max96712_get_ser_vc_id);
 +
 +int max96712_release_pipe(struct device *dev, int pipe_id)
 +{
@@ -622,12 +765,16 @@ index 8e237eef..12729a1e 100644
 +}
 +EXPORT_SYMBOL(max96712_reset_oneshot);
 +
-+/* RSDEV-12608: one-shot flush of the link carrying vc_id (link = vc_id / MAX9295_MAX_STREAMS).
-+ * Called from d4xx HW-reset recovery to drop the stale post-reset partial frame. */
-+void max96712_reset_oneshot_link(struct device *dev, u32 vc_id)
++/* RSDEV-12608: one-shot flush of a single link's pixel line buffer. Called from
++ * d4xx HW-reset recovery to drop the stale post-reset partial frame. */
++void max96712_reset_oneshot_link(struct device *dev, u32 link_id)
 +{
 +	struct max96712 *priv = dev_get_drvdata(dev);
-+	unsigned int link_id = vc_id / MAX9295_MAX_STREAMS;
++
++	if (link_id >= MAX96712_MAX_LINKS) {
++		dev_err(dev, "%s: illegal link %u\n", __func__, link_id);
++		return;
++	}
 +
 +	dev_info(dev, "RSDEV-12608: link %u line-buffer flush (post-HW-reset)\n", link_id);
 +	max96712_reset_oneshot_link_mask(priv, 1 << link_id);
@@ -635,37 +782,41 @@ index 8e237eef..12729a1e 100644
 +EXPORT_SYMBOL(max96712_reset_oneshot_link);
 +
 +static int __max96712_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
-+			      u8 data_type2, u32 vc_id)
++			      u8 data_type2, u32 link, u32 vc_id)
 +{
 +	int err = 0;
 +	struct max96712 *priv = dev_get_drvdata(dev);
-+	int vc_id_lsb = vc_id & 0x3;
-+	int vc_id_msb = vc_id >> 2;
++	u32 dser_vc = priv->vc_remap[link][vc_id];
++	/* SRC is the VC arriving from the serializer, DST the VC leaving on CSI;
++	 * they diverge whenever the link's remap table is not the identity. */
++	int src_vc_lsb = vc_id & 0x3;
++	int dst_vc_lsb = dser_vc & 0x3;
++	u8 ext_vc = max96712_ext_vc(vc_id, dser_vc);
 +	unsigned int pipe_en_val = 0;
 +
 +	struct reg_pair map_pipe_control[] = {
 +		// Enable 3/4 mappings for video pipe (4 if metadata enabled)
 +		{MAX96712_MIPI_TX11_ADDR + (0x40 * pipe_id), (data_type2 == 0) ? 0x07 : 0x0F},
 +		// Map data_type1 on vc_id
-+		{MAX96712_MIPI_TX13_SRC_0_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | data_type1},
-+		{MAX96712_MIPI_TX14_DST_0_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | data_type1},
++		{MAX96712_MIPI_TX13_SRC_0_MAP_ADDR + (0x40 * pipe_id), (src_vc_lsb << 6) | data_type1},
++		{MAX96712_MIPI_TX14_DST_0_MAP_ADDR + (0x40 * pipe_id), (dst_vc_lsb << 6) | data_type1},
 +		// Map frame_start on vc_id
-+		{MAX96712_MIPI_TX15_SRC_1_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | 0x00},
-+		{MAX96712_MIPI_TX16_DST_1_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | 0x00},
++		{MAX96712_MIPI_TX15_SRC_1_MAP_ADDR + (0x40 * pipe_id), (src_vc_lsb << 6) | 0x00},
++		{MAX96712_MIPI_TX16_DST_1_MAP_ADDR + (0x40 * pipe_id), (dst_vc_lsb << 6) | 0x00},
 +		// Map frame end on vc_id
-+		{MAX96712_MIPI_TX17_SRC_2_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | 0x01},
-+		{MAX96712_MIPI_TX18_DST_2_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | 0x01},
++		{MAX96712_MIPI_TX17_SRC_2_MAP_ADDR + (0x40 * pipe_id), (src_vc_lsb << 6) | 0x01},
++		{MAX96712_MIPI_TX18_DST_2_MAP_ADDR + (0x40 * pipe_id), (dst_vc_lsb << 6) | 0x01},
 +		// Map data_type2 on vc_id
-+		{MAX96712_MIPI_TX19_SRC_3_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | data_type2},
-+		{MAX96712_MIPI_TX20_DST_3_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | data_type2},
++		{MAX96712_MIPI_TX19_SRC_3_MAP_ADDR + (0x40 * pipe_id), (src_vc_lsb << 6) | data_type2},
++		{MAX96712_MIPI_TX20_DST_3_MAP_ADDR + (0x40 * pipe_id), (dst_vc_lsb << 6) | data_type2},
 +		// Extended dst vc_id mapping 0
-+		{MAX96712_MIPI_TX_EXT0_ADDR + (0x10 * pipe_id), vc_id_msb << 2},
++		{MAX96712_MIPI_TX_EXT0_ADDR + (0x10 * pipe_id), ext_vc},
 +		// Extended dst vc_id mapping 1
-+		{MAX96712_MIPI_TX_EXT1_ADDR + (0x10 * pipe_id), vc_id_msb << 2},
++		{MAX96712_MIPI_TX_EXT1_ADDR + (0x10 * pipe_id), ext_vc},
 +		// Extended dst vc_id mapping 2
-+		{MAX96712_MIPI_TX_EXT2_ADDR + (0x10 * pipe_id), vc_id_msb << 2},
++		{MAX96712_MIPI_TX_EXT2_ADDR + (0x10 * pipe_id), ext_vc},
 +		// Extended dst vc_id mapping 3
-+		{MAX96712_MIPI_TX_EXT3_ADDR + (0x10 * pipe_id), vc_id_msb << 2},
++		{MAX96712_MIPI_TX_EXT3_ADDR + (0x10 * pipe_id), ext_vc},
 +		// All mappings to PHY1 (master for port A)
 +		{MAX96712_MIPI_TX45_MAP_DPHY_DEST_ADDR + (0x40 * pipe_id), 0x55},
 +		// SEQ_MISS_EN: Disabled / DIS_PKT_DET: Disabled
@@ -691,63 +842,92 @@ index 8e237eef..12729a1e 100644
 +
 +/*
 + * Configure a multi-VC pipe (MAX96717) in one shot. Unlike __max96712_set_pipe(),
-+ * which dedicates a pipe to a single VC, this maps all four local virtual
++ * which dedicates a pipe to a single VC, this maps all four serializer virtual
 + * channels of the link (depth/RGB/IR/IMU) through one deserializer pipe, matching
 + * the way a MAX96717 funnels a camera's streams through a single serializer pipe.
 + * Called with priv->lock held.
 + */
-+static int __max96712_set_multi_vc_pipe(struct device *dev, int pipe_id, u32 vc_id)
++static int __max96712_set_multi_vc_pipe(struct device *dev, int pipe_id, u32 link)
 +{
 +	int err = 0;
-+	int iter;
++	int vc;
 +	struct max96712 *priv = dev_get_drvdata(dev);
-+	int link_id = vc_id / MAX9295_MAX_STREAMS;
 +	uint32_t map_pipe_offs = 0x40 * pipe_id;
 +	uint32_t ext_vc_offs = 0x10 * pipe_id;
++	/* SRC is the serializer VC arriving on the link, DST the remapped VC
++	 * leaving on CSI; EXT carries the high bits of both. */
++	u8 src_vc0 = 0 << 6;
++	u8 src_vc1 = 1 << 6;
++	u8 src_vc2 = 2 << 6;
++	u8 src_vc3 = 3 << 6;
++	u8 dst_vc0 = (priv->vc_remap[link][0] & 0x3) << 6;
++	u8 dst_vc1 = (priv->vc_remap[link][1] & 0x3) << 6;
++	u8 dst_vc2 = (priv->vc_remap[link][2] & 0x3) << 6;
++	u8 dst_vc3 = (priv->vc_remap[link][3] & 0x3) << 6;
++	u8 ext_vc0 = max96712_ext_vc(0, priv->vc_remap[link][0]);
++	u8 ext_vc1 = max96712_ext_vc(1, priv->vc_remap[link][1]);
++	u8 ext_vc2 = max96712_ext_vc(2, priv->vc_remap[link][2]);
++	u8 ext_vc3 = max96712_ext_vc(3, priv->vc_remap[link][3]);
 +
 +	struct reg_pair map_pipe_control[] = {
 +		// Enable all static mappings
 +		{MAX96712_MIPI_TX11_ADDR + map_pipe_offs, 0xFF},
 +		{MAX96712_MIPI_TX12_ADDR + map_pipe_offs, 0xFF},
 +		// Map vc_id 0 formats (depth)
-+		{MAX96712_MIPI_TX13_SRC_0_MAP_ADDR + map_pipe_offs, GMSL_CSI_DT_YUV422_8},
-+		{MAX96712_MIPI_TX14_DST_0_MAP_ADDR + map_pipe_offs, GMSL_CSI_DT_YUV422_8},
-+		{MAX96712_MIPI_TX15_SRC_1_MAP_ADDR + map_pipe_offs, 0x00},
-+		{MAX96712_MIPI_TX16_DST_1_MAP_ADDR + map_pipe_offs, 0x00},
-+		{MAX96712_MIPI_TX17_SRC_2_MAP_ADDR + map_pipe_offs, 0x01},
-+		{MAX96712_MIPI_TX18_DST_2_MAP_ADDR + map_pipe_offs, 0x01},
-+		{MAX96712_MIPI_TX19_SRC_3_MAP_ADDR + map_pipe_offs, GMSL_CSI_DT_EMBED},
-+		{MAX96712_MIPI_TX20_DST_3_MAP_ADDR + map_pipe_offs, GMSL_CSI_DT_EMBED},
++		{MAX96712_MIPI_TX13_SRC_0_MAP_ADDR + map_pipe_offs, src_vc0 | GMSL_CSI_DT_YUV422_8},
++		{MAX96712_MIPI_TX14_DST_0_MAP_ADDR + map_pipe_offs, dst_vc0 | GMSL_CSI_DT_YUV422_8},
++		{MAX96712_MIPI_TX_EXT0_ADDR + ext_vc_offs, ext_vc0},
++		{MAX96712_MIPI_TX15_SRC_1_MAP_ADDR + map_pipe_offs, src_vc0 | 0x00},
++		{MAX96712_MIPI_TX16_DST_1_MAP_ADDR + map_pipe_offs, dst_vc0 | 0x00},
++		{MAX96712_MIPI_TX_EXT1_ADDR + ext_vc_offs, ext_vc0},
++		{MAX96712_MIPI_TX17_SRC_2_MAP_ADDR + map_pipe_offs, src_vc0 | 0x01},
++		{MAX96712_MIPI_TX18_DST_2_MAP_ADDR + map_pipe_offs, dst_vc0 | 0x01},
++		{MAX96712_MIPI_TX_EXT2_ADDR + ext_vc_offs, ext_vc0},
++		{MAX96712_MIPI_TX19_SRC_3_MAP_ADDR + map_pipe_offs, src_vc0 | GMSL_CSI_DT_EMBED},
++		{MAX96712_MIPI_TX20_DST_3_MAP_ADDR + map_pipe_offs, dst_vc0 | GMSL_CSI_DT_EMBED},
++		{MAX96712_MIPI_TX_EXT3_ADDR + ext_vc_offs, ext_vc0},
 +
 +		// Map vc_id 1 formats (RGB)
-+		{MAX96712_MIPI_TX21_SRC_4_MAP_ADDR + map_pipe_offs, (1 << 6) | GMSL_CSI_DT_YUV422_8},
-+		{MAX96712_MIPI_TX22_DST_4_MAP_ADDR + map_pipe_offs, (1 << 6) | GMSL_CSI_DT_YUV422_8},
-+		{MAX96712_MIPI_TX23_SRC_5_MAP_ADDR + map_pipe_offs, (1 << 6) | 0x00},
-+		{MAX96712_MIPI_TX24_DST_5_MAP_ADDR + map_pipe_offs, (1 << 6) | 0x00},
-+		{MAX96712_MIPI_TX25_SRC_6_MAP_ADDR + map_pipe_offs, (1 << 6) | 0x01},
-+		{MAX96712_MIPI_TX26_DST_6_MAP_ADDR + map_pipe_offs, (1 << 6) | 0x01},
-+		{MAX96712_MIPI_TX27_SRC_7_MAP_ADDR + map_pipe_offs, (1 << 6) | GMSL_CSI_DT_EMBED},
-+		{MAX96712_MIPI_TX28_DST_7_MAP_ADDR + map_pipe_offs, (1 << 6) | GMSL_CSI_DT_EMBED},
++		{MAX96712_MIPI_TX21_SRC_4_MAP_ADDR + map_pipe_offs, src_vc1 | GMSL_CSI_DT_YUV422_8},
++		{MAX96712_MIPI_TX22_DST_4_MAP_ADDR + map_pipe_offs, dst_vc1 | GMSL_CSI_DT_YUV422_8},
++		{MAX96712_MIPI_TX_EXT4_ADDR + ext_vc_offs, ext_vc1},
++		{MAX96712_MIPI_TX23_SRC_5_MAP_ADDR + map_pipe_offs, src_vc1 | 0x00},
++		{MAX96712_MIPI_TX24_DST_5_MAP_ADDR + map_pipe_offs, dst_vc1 | 0x00},
++		{MAX96712_MIPI_TX_EXT5_ADDR + ext_vc_offs, ext_vc1},
++		{MAX96712_MIPI_TX25_SRC_6_MAP_ADDR + map_pipe_offs, src_vc1 | 0x01},
++		{MAX96712_MIPI_TX26_DST_6_MAP_ADDR + map_pipe_offs, dst_vc1 | 0x01},
++		{MAX96712_MIPI_TX_EXT6_ADDR + ext_vc_offs, ext_vc1},
++		{MAX96712_MIPI_TX27_SRC_7_MAP_ADDR + map_pipe_offs, src_vc1 | GMSL_CSI_DT_EMBED},
++		{MAX96712_MIPI_TX28_DST_7_MAP_ADDR + map_pipe_offs, dst_vc1 | GMSL_CSI_DT_EMBED},
++		{MAX96712_MIPI_TX_EXT7_ADDR + ext_vc_offs, ext_vc1},
 +
 +		// Map vc_id 2 formats (IR)
-+		{MAX96712_MIPI_TX29_SRC_8_MAP_ADDR + map_pipe_offs, (2 << 6) | GMSL_CSI_DT_YUV422_8},
-+		{MAX96712_MIPI_TX30_DST_8_MAP_ADDR + map_pipe_offs, (2 << 6) | GMSL_CSI_DT_YUV422_8},
-+		{MAX96712_MIPI_TX31_SRC_9_MAP_ADDR + map_pipe_offs, (2 << 6) | 0x00},
-+		{MAX96712_MIPI_TX32_DST_9_MAP_ADDR + map_pipe_offs, (2 << 6) | 0x00},
-+		{MAX96712_MIPI_TX33_SRC_10_MAP_ADDR + map_pipe_offs, (2 << 6) | 0x01},
-+		{MAX96712_MIPI_TX34_DST_10_MAP_ADDR + map_pipe_offs, (2 << 6) | 0x01},
-+		{MAX96712_MIPI_TX35_SRC_11_MAP_ADDR + map_pipe_offs, (2 << 6) | GMSL_CSI_DT_EMBED},
-+		{MAX96712_MIPI_TX36_DST_11_MAP_ADDR + map_pipe_offs, (2 << 6) | GMSL_CSI_DT_EMBED},
-+		{MAX96712_MIPI_TX37_SRC_12_MAP_ADDR + map_pipe_offs, (2 << 6) | GMSL_CSI_DT_RAW_16},
-+		{MAX96712_MIPI_TX38_DST_12_MAP_ADDR + map_pipe_offs, (2 << 6) | GMSL_CSI_DT_RAW_16},
++		{MAX96712_MIPI_TX29_SRC_8_MAP_ADDR + map_pipe_offs, src_vc2 | GMSL_CSI_DT_YUV422_8},
++		{MAX96712_MIPI_TX30_DST_8_MAP_ADDR + map_pipe_offs, dst_vc2 | GMSL_CSI_DT_YUV422_8},
++		{MAX96712_MIPI_TX_EXT8_ADDR + ext_vc_offs, ext_vc2},
++		{MAX96712_MIPI_TX31_SRC_9_MAP_ADDR + map_pipe_offs, src_vc2 | 0x00},
++		{MAX96712_MIPI_TX32_DST_9_MAP_ADDR + map_pipe_offs, dst_vc2 | 0x00},
++		{MAX96712_MIPI_TX_EXT9_ADDR + ext_vc_offs, ext_vc2},
++		{MAX96712_MIPI_TX33_SRC_10_MAP_ADDR + map_pipe_offs, src_vc2 | 0x01},
++		{MAX96712_MIPI_TX34_DST_10_MAP_ADDR + map_pipe_offs, dst_vc2 | 0x01},
++		{MAX96712_MIPI_TX_EXT10_ADDR + ext_vc_offs, ext_vc2},
++		{MAX96712_MIPI_TX35_SRC_11_MAP_ADDR + map_pipe_offs, src_vc2 | GMSL_CSI_DT_EMBED},
++		{MAX96712_MIPI_TX36_DST_11_MAP_ADDR + map_pipe_offs, dst_vc2 | GMSL_CSI_DT_EMBED},
++		{MAX96712_MIPI_TX_EXT11_ADDR + ext_vc_offs, ext_vc2},
++		{MAX96712_MIPI_TX37_SRC_12_MAP_ADDR + map_pipe_offs, src_vc2 | GMSL_CSI_DT_RAW_16},
++		{MAX96712_MIPI_TX38_DST_12_MAP_ADDR + map_pipe_offs, dst_vc2 | GMSL_CSI_DT_RAW_16},
++		{MAX96712_MIPI_TX_EXT12_ADDR + ext_vc_offs, ext_vc2},
 +
 +		// Map vc_id 3 formats (IMU)
-+		{MAX96712_MIPI_TX39_SRC_13_MAP_ADDR + map_pipe_offs, (3 << 6) | GMSL_CSI_DT_RAW_8},
-+		{MAX96712_MIPI_TX40_DST_13_MAP_ADDR + map_pipe_offs, (3 << 6) | GMSL_CSI_DT_RAW_8},
-+		{MAX96712_MIPI_TX41_SRC_14_MAP_ADDR + map_pipe_offs, (3 << 6) | 0x00},
-+		{MAX96712_MIPI_TX42_DST_14_MAP_ADDR + map_pipe_offs, (3 << 6) | 0x00},
-+		{MAX96712_MIPI_TX43_SRC_15_MAP_ADDR + map_pipe_offs, (3 << 6) | 0x01},
-+		{MAX96712_MIPI_TX44_DST_15_MAP_ADDR + map_pipe_offs, (3 << 6) | 0x01},
++		{MAX96712_MIPI_TX39_SRC_13_MAP_ADDR + map_pipe_offs, src_vc3 | GMSL_CSI_DT_RAW_8},
++		{MAX96712_MIPI_TX40_DST_13_MAP_ADDR + map_pipe_offs, dst_vc3 | GMSL_CSI_DT_RAW_8},
++		{MAX96712_MIPI_TX_EXT13_ADDR + ext_vc_offs, ext_vc3},
++		{MAX96712_MIPI_TX41_SRC_14_MAP_ADDR + map_pipe_offs, src_vc3 | 0x00},
++		{MAX96712_MIPI_TX42_DST_14_MAP_ADDR + map_pipe_offs, dst_vc3 | 0x00},
++		{MAX96712_MIPI_TX_EXT14_ADDR + ext_vc_offs, ext_vc3},
++		{MAX96712_MIPI_TX43_SRC_15_MAP_ADDR + map_pipe_offs, src_vc3 | 0x01},
++		{MAX96712_MIPI_TX44_DST_15_MAP_ADDR + map_pipe_offs, dst_vc3 | 0x01},
++		{MAX96712_MIPI_TX_EXT15_ADDR + ext_vc_offs, ext_vc3},
 +
 +		// All mappings to PHY1 (master for port A)
 +		{MAX96712_MIPI_TX45_MAP_DPHY_DEST_ADDR + map_pipe_offs, 0x55},
@@ -760,13 +940,18 @@ index 8e237eef..12729a1e 100644
 +		{MAX96712_VIDEO_RX0_ADDR + (0x12 * pipe_id) + ((pipe_id >= 5) ? 6 : 0), 0x23},
 +	};
 +
++	/* This table maps all four of the camera's VCs in one shot, so the link
++	 * must declare a deserializer VC for every one of them. */
++	for (vc = 0; vc < 4; vc++) {
++		if (priv->vc_remap[link][vc] == MAX96712_VC_UNMAPPED) {
++			dev_err(dev, "%s: link %u serializer vc %d unmapped\n",
++				__func__, link, vc);
++			return -EINVAL;
++		}
++	}
++
 +	err |= max96712_set_registers(priv, map_pipe_control,
 +					ARRAY_SIZE(map_pipe_control));
-+
-+	/* Configuring the mapping's extended VC */
-+	for (iter = 0; iter < 16; iter++) {
-+		err |= max96712_write_reg(priv, MAX96712_MIPI_TX_EXT0_ADDR + iter + ext_vc_offs, link_id << 2);
-+	}
 +
 +	if (err) {
 +		return err;
@@ -778,7 +963,8 @@ index 8e237eef..12729a1e 100644
 +}
 +
 +/* Update mapping table entries that can change in runtime */
-+static int __max96712_update_multi_vc_pipe(struct device *dev, int pipe_id, u32 vc_id, u8 data_type1)
++static int __max96712_update_multi_vc_pipe(struct device *dev, int pipe_id,
++					  u32 link, u32 vc_id, u8 data_type1)
 +{
 +	int err = 0;
 +
@@ -786,17 +972,19 @@ index 8e237eef..12729a1e 100644
 +	if (vc_id == 1) {
 +		struct max96712 *priv = dev_get_drvdata(dev);
 +		uint32_t map_pipe_offs = 0x40 * pipe_id;
++		u8 src_vc = vc_id << 6;
++		u8 dst_vc = (priv->vc_remap[link][vc_id] & 0x3) << 6;
 +
 +		struct reg_pair map_pipe_control[] = {
 +			// Update vc_id 1 formats (RGB)
-+			{MAX96712_MIPI_TX21_SRC_4_MAP_ADDR + map_pipe_offs, (vc_id << 6) | data_type1},
-+			{MAX96712_MIPI_TX22_DST_4_MAP_ADDR + map_pipe_offs, (vc_id << 6) | data_type1},
++			{MAX96712_MIPI_TX21_SRC_4_MAP_ADDR + map_pipe_offs, src_vc | data_type1},
++			{MAX96712_MIPI_TX22_DST_4_MAP_ADDR + map_pipe_offs, dst_vc | data_type1},
 +		};
 +		dev_dbg(dev, "%s: Updating vc_id %u on pipe %u to data type 0x%x\n",
 +				__func__, vc_id, pipe_id, data_type1);
 +		err |= max96712_set_registers(priv, map_pipe_control,
 +						ARRAY_SIZE(map_pipe_control));
-+	
++
 +		if (err) {
 +			return err;
 +		}
@@ -871,14 +1059,15 @@ index 8e237eef..12729a1e 100644
 +}
 +EXPORT_SYMBOL(max96712_init_settings);
 +
-+int max96712_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id)
++int max96712_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
++				   int ser_pipe_id, u32 link)
 +{
 +	struct max96712 *priv = dev_get_drvdata(dev);
 +	int err = 0;
 +
 +	mutex_lock(&priv->lock);
 +
-+	err = __max96712_bind_ser_to_dser_pipe(dev, dser_pipe_id, ser_pipe_id, vc_id);
++	err = __max96712_bind_ser_to_dser_pipe(dev, dser_pipe_id, ser_pipe_id, link);
 +
 +	mutex_unlock(&priv->lock);
 +
@@ -887,7 +1076,7 @@ index 8e237eef..12729a1e 100644
 +EXPORT_SYMBOL(max96712_bind_ser_to_dser_pipe);
 +
 +int max96712_set_pipe(struct device *dev, int pipe_id,
-+		     u8 data_type1, u8 data_type2, u32 vc_id)
++		     u8 data_type1, u8 data_type2, u32 link, u32 vc_id)
 +{
 +	struct max96712 *priv = dev_get_drvdata(dev);
 +	int err = 0;
@@ -898,8 +1087,16 @@ index 8e237eef..12729a1e 100644
 +		return -EINVAL;
 +	}
 +
-+	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
-+		__func__, pipe_id, data_type1, data_type2, vc_id);
++	if (link >= MAX96712_MAX_LINKS || vc_id >= MAX96712_MAX_SER_VCS ||
++	    priv->vc_remap[link][vc_id] == MAX96712_VC_UNMAPPED) {
++		dev_err(dev, "%s: link %u serializer vc %u has no deserializer VC\n",
++			__func__, link, vc_id);
++		return -EINVAL;
++	}
++
++	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, link %u, vc_id %u -> dser vc %u\n",
++		__func__, pipe_id, data_type1, data_type2, link, vc_id,
++		priv->vc_remap[link][vc_id]);
 +
 +	mutex_lock(&priv->lock);
 +
@@ -910,14 +1107,14 @@ index 8e237eef..12729a1e 100644
 +		 * config-retry loop) reuse the existing mapping unchanged.
 +		 */
 +		if (!priv->multi_vc_configured[pipe_id]) {
-+			err = __max96712_set_multi_vc_pipe(dev, pipe_id, vc_id);
++			err = __max96712_set_multi_vc_pipe(dev, pipe_id, link);
 +			if (!err)
 +				priv->multi_vc_configured[pipe_id] = true;
 +		}
 +		if (!err)
-+			err = __max96712_update_multi_vc_pipe(dev, pipe_id, vc_id, data_type1);
++			err = __max96712_update_multi_vc_pipe(dev, pipe_id, link, vc_id, data_type1);
 +	} else {
-+		err = __max96712_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
++		err = __max96712_set_pipe(dev, pipe_id, data_type1, data_type2, link, vc_id);
 +	}
 +
 +	mutex_unlock(&priv->lock);
@@ -1070,7 +1267,7 @@ index 8e237eef..12729a1e 100644
  	{ },
  };
  
-@@ -300,6 +1169,7 @@ static struct i2c_driver max96712_i2c_driver = {
+@@ -300,6 +1364,7 @@ static struct i2c_driver max96712_i2c_driver = {
  	.driver = {
  		.name = "max96712",
  		.owner = THIS_MODULE,

--- a/nvidia-oot/7.0/0008-Align-max9296-api-to-max96712.patch
+++ b/nvidia-oot/7.0/0008-Align-max9296-api-to-max96712.patch
@@ -5,9 +5,9 @@ Subject: [PATCH] Align max9296 api to max96712
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- drivers/media/i2c/max9296.c | 14 ++++++++++++++
- include/media/max9296.h     | 14 ++++++++++++++
- 2 files changed, 28 insertions(+)
+ drivers/media/i2c/max9296.c | 16 +++++++++++++++-
+ include/media/max9296.h     | 16 +++++++++++++++-
+ 2 files changed, 30 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/media/i2c/max9296.c b/drivers/media/i2c/max9296.c
 index d50bea51..92b483b6 100644
@@ -27,11 +27,11 @@ index d50bea51..92b483b6 100644
  void max9296_reset_oneshot(struct device *dev)
  {
  	struct max9296 *priv = dev_get_drvdata(dev);
-@@ -945,6 +952,13 @@ int max9296_init_settings(struct device *dev)
+@@ -945,8 +952,15 @@ int max9296_init_settings(struct device *dev)
  }
  EXPORT_SYMBOL(max9296_init_settings);
  
-+int max9296_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id)
++int max9296_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 link)
 +{
 +	/* pipe id's are 1:1 in this deserializer */
 +	return 0;
@@ -39,20 +39,26 @@ index d50bea51..92b483b6 100644
 +EXPORT_SYMBOL(max9296_bind_ser_to_dser_pipe);
 +
  int max9296_set_pipe(struct device *dev, int pipe_id,
- 		     u8 data_type1, u8 data_type2, u32 vc_id)
+-		     u8 data_type1, u8 data_type2, u32 vc_id)
++		     u8 data_type1, u8 data_type2, u32 link, u32 vc_id)
  {
+ 	struct max9296 *priv = dev_get_drvdata(dev);
+ 	int err = 0;
 diff --git a/include/media/max9296.h b/include/media/max9296.h
 index 6b4c796e..db7365d7 100644
 --- a/include/media/max9296.h
 +++ b/include/media/max9296.h
-@@ -24,6 +24,7 @@
+@@ -24,8 +24,9 @@
   */
  
  int max9296_get_available_pipe_id(struct device *dev, int vc_id);
 +int max9296_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id);
  int max9296_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
- 		     u8 data_type2, u32 vc_id);
+-		     u8 data_type2, u32 vc_id);
++		     u8 data_type2, u32 link, u32 vc_id);
  int max9296_release_pipe(struct device *dev, int pipe_id);
+ void max9296_reset_oneshot(struct device *dev);
+ 
 @@ -154,6 +155,19 @@ int max9296_power_on(struct device *dev);
  void max9296_power_off(struct device *dev);
  
@@ -66,9 +72,9 @@ index 6b4c796e..db7365d7 100644
 + * @param [in]  dev             The deserializer device handle.
 + * @param [in]  dser_pipe_id    Deserializer pipe id.
 + * @param [in]  ser_pipe_id     Serializer pipe id.
-+ * @param [in]  vc_id           vc_id associated with this pipe path.
++ * @param [in]  link            GMSL link the serializer pipe lives on.
 + */
-+int max9296_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id);
++int max9296_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 link);
 +
  /** @} */
  

--- a/nvidia-oot/max96712.h
+++ b/nvidia-oot/max96712.h
@@ -25,25 +25,38 @@
 
 int max96712_get_available_pipe_id(struct device *dev, int vc_id);
 /**
- * @brief  Returns the multi-VC pipe dedicated to the link that owns vc_id,
- * allocating one on first request. Used for MAX96717 serializers, which route
- * all of a camera's virtual channels through a single pipe. The pipe is sticky
- * for the driver's lifetime and is never freed by max96712_release_pipe().
+ * @brief  Returns the multi-VC pipe dedicated to a GMSL link, allocating one on
+ * first request. Used for MAX96717 serializers, which route all of a camera's
+ * virtual channels through a single pipe. The pipe is sticky for the driver's
+ * lifetime and is never freed by max96712_release_pipe().
  *
- * @param  [in]  dev    The deserializer device handle.
- * @param  [in]  vc_id  A virtual channel id of the requesting camera; the link
- *                      is derived as vc_id / 4.
+ * @param  [in]  dev   The deserializer device handle.
+ * @param  [in]  link  GMSL link index of the requesting camera.
  *
  * @return  pipe id (>= 0) on success, negative error code otherwise.
  */
-int max96712_get_multi_vc_pipe_id(struct device *dev, int vc_id);
+int max96712_get_multi_vc_pipe_id(struct device *dev, u32 link);
+/**
+ * @brief  Configure a deserializer pipe. vc_id is the serializer virtual
+ * channel; the outgoing CSI virtual channel comes from the link's
+ * "maxim,linkN-vc-remap" table. A link with no table gets a unity map (only
+ * usable as-is on a single-link deserializer); a link with one maps exactly
+ * the VCs it lists and rejects the rest.
+ */
 int max96712_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
-		     u8 data_type2, u32 vc_id);
+		     u8 data_type2, u32 link, u32 vc_id);
+/**
+ * @brief  Returns the serializer virtual channel that the link presents
+ * as deserializer VC dser_vc, per "maxim,linkN-vc-remap".
+ *
+ * @return  serializer VC (>= 0) on success, negative error code if unmapped.
+ */
+int max96712_get_ser_vc_id(struct device *dev, u32 link, u32 dser_vc);
 int max96712_release_pipe(struct device *dev, int pipe_id);
 void max96712_reset_oneshot(struct device *dev);
 /* RSDEV-12608: flush one GMSL link's pixel line buffer after a camera HW reset;
  * called per-link from d4xx's ds5_hw_reset_with_recovery(). */
-void max96712_reset_oneshot_link(struct device *dev, u32 vc_id);
+void max96712_reset_oneshot_link(struct device *dev, u32 link);
 int max96712_setup_link(struct device *dev, struct device *s_dev);
 int max96712_setup_control(struct device *dev, struct device *s_dev);
 int max96712_reset_control(struct device *dev, struct device *s_dev);
@@ -58,8 +71,9 @@ int max96712_init_settings(struct device *dev);
  * @param [in]  dev             The deserializer device handle.
  * @param [in]  dser_pipe_id    Deserializer pipe id.
  * @param [in]  ser_pipe_id     Serializer pipe id.
- * @param [in]  vc_id           vc_id associated with this pipe path.
+ * @param [in]  link            GMSL link the serializer pipe lives on.
  */
-int max96712_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id);
+int max96712_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id,
+								   u32 link);
 
 #endif  /* __MAX96712_H__ */

--- a/nvidia-oot/max96724.c
+++ b/nvidia-oot/max96724.c
@@ -1204,7 +1204,7 @@ int max96724_init_settings(struct device *dev)
 EXPORT_SYMBOL(max96724_init_settings);
 
 int max96724_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
-				   int ser_pipe_id, u32 vc_id)
+				   int ser_pipe_id, u32 link)
 {
 	/* In Tunnel Mode, pipe mapping is 1:1 (each camera → one pipe) */
 	return 0;
@@ -1212,7 +1212,7 @@ int max96724_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
 EXPORT_SYMBOL(max96724_bind_ser_to_dser_pipe);
 
 int max96724_set_pipe(struct device *dev, int pipe_id,
-		      u8 data_type1, u8 data_type2, u32 vc_id)
+		      u8 data_type1, u8 data_type2, u32 link, u32 vc_id)
 {
 	struct max96724 *priv = dev_get_drvdata(dev);
 	int err = 0;

--- a/nvidia-oot/max96724.h
+++ b/nvidia-oot/max96724.h
@@ -42,7 +42,7 @@
 
 int max96724_get_available_pipe_id(struct device *dev, int vc_id);
 int max96724_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
-		      u8 data_type2, u32 vc_id);
+		      u8 data_type2, u32 link, u32 vc_id);
 int max96724_release_pipe(struct device *dev, int pipe_id);
 void max96724_reset_oneshot(struct device *dev);
 void max96724_retrigger_datapath(struct device *dev);
@@ -161,12 +161,12 @@ int max96724_disable_fsync(struct device *dev);
  * @param  [in]  dev             The deserializer device handle.
  * @param  [in]  dser_pipe_id    Deserializer pipe ID.
  * @param  [in]  ser_pipe_id     Serializer pipe ID.
- * @param  [in]  vc_id           VC ID associated with this pipe.
+ * @param  [in]  link            GMSL link the serializer pipe lives on.
  *
  * @return  0 for success, or negative error code.
  */
 int max96724_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
-				   int ser_pipe_id, u32 vc_id);
+				   int ser_pipe_id, u32 link);
 
 /** @} */
 


### PR DESCRIPTION
- Serializer vc to deserializer vc mapping is now explicitly provided in the device tree
- If no remap table is given, then the default is unity (0 to 0, 1 to 1 etc)
- For multi link device trees, vc mapping table must be provided, otherwise there will be collisions on output VCs