### PR TITLE
Skills: fix apply_patches.sh reset argument order + document 2 gotchas

### DIFF
--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -26,10 +26,14 @@ Ask the user whether they need to apply patches or just copy `d4xx.c` and build.
 
 Requires `git config user.name` and `git config user.email` to be set.
 
-Always reset patches before re-applying:
+Always reset patches before re-applying. **`reset` must come before `$VERSION`, not after** —
+`apply_patches.sh`'s own argument loop stops parsing at the first token it doesn't recognize as
+a flag, and `$VERSION` (e.g. `6.2`) isn't one, so `./apply_patches.sh $VERSION reset` never
+reaches `reset` at all and silently runs a plain `apply` instead. Also pipe `yes` so the
+"changes will be hard reset, continue?" prompt doesn't stall non-interactively:
 ```bash
-./apply_patches.sh $VERSION reset
-./apply_patches.sh $VERSION
+yes | ./apply_patches.sh reset $VERSION
+yes | ./apply_patches.sh $VERSION
 ```
 
 #### Option B: Copy d4xx.c only (skip patches)
@@ -58,6 +62,13 @@ Flags:
 - `--dev-dbg` — enable `CONFIG_DYNAMIC_DEBUG` and `CONFIG_DYNAMIC_DEBUG_CORE` in kernel
 
 Output directory: `images/$VERSION/` (normalized: `images/6.x/` for JP 6.x, `images/5.x/` for JP 5.x).
+
+**This build takes several minutes (kernel Image + OOT modules + DTBs) — run it with your
+tool's own backgrounding, plain, with no output redirection.** Do not wrap it in your own
+`nohup ... &`: if your tool call already backgrounds the command for you, adding your own `&`
+on top makes the wrapper return the moment the child is launched, so the tool thinks the
+command finished instantly while the real build keeps running as an untracked orphan — no
+completion signal will ever fire for it.
 
 ### Step 3 (optional): Overlay-only rebuild
 

--- a/.claude/skills/workspace-setup/SKILL.md
+++ b/.claude/skills/workspace-setup/SKILL.md
@@ -53,6 +53,13 @@ Ask the user for their name and email. Set these in the repo root — `apply_pat
 
 ## Step 4: Download NVIDIA Sources and Toolchain
 
+**Check first whether `sources_$VERSION`/`l4t-gcc` already exist — this step is expensive
+and skippable if they do.** Check each path individually (`[ -d sources_$VERSION ] && echo
+present`), not `ls -la sources_$VERSION l4t-gcc | head -N`: GNU `ls` prints multi-directory
+output sections in **alphabetical order of the names, not command-line order** — `l4t-gcc`
+sorts before `sources_*`, so a `head` truncation can cut off the `sources_$VERSION` section
+entirely and make a present, healthy directory look missing.
+
 ```bash
 ./setup_workspace.sh $VERSION
 ```


### PR DESCRIPTION
## Summary
- `build/SKILL.md`: fixed `apply_patches.sh $VERSION reset` — the script's own argument loop stops parsing at the first token it doesn't recognize as a flag, and `$VERSION` isn't one, so `reset` was never reached and it silently ran a plain `apply` instead. Corrected to `reset $VERSION`, matching the order `CLAUDE.md`'s own example already had.
- `build/SKILL.md`: warned against wrapping `build_all.sh` in your own `nohup ... &` inside a tool call that already backgrounds commands — the wrapper returns instantly while the real build becomes an untracked orphan with no completion signal.
- `workspace-setup/SKILL.md`: warned that `ls -la sources_$VERSION l4t-gcc | head -N` can hide a present `sources_$VERSION` entirely, since GNU `ls` sorts multi-directory output sections alphabetically regardless of argument order — check paths individually instead.

## Test plan
- [x] Reproduced the `apply_patches.sh` argument-order bug directly: `./apply_patches.sh 6.2 reset` ran `apply` (visible per-patch listing, `Patches applied successfully`) instead of resetting; `./apply_patches.sh reset 6.2` correctly reset all three sub-repos to their clean L4T tags.
- [x] Reproduced the `ls`/`head` truncation directly: confirmed a present `sources_6.2` got cut from `head -5` output purely due to alphabetical section ordering (`l4t-gcc` sorts first).
- [ ] Maintainer read-through to confirm nothing else in these two skills relies on the old (wrong) argument order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)