### PR TITLE
Build D5xx device-tree overlays on JetPack 7

### DIFF
--- a/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-16ch-d5xx.dtso
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-16ch-d5xx.dtso
@@ -1,0 +1,485 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: Copyright (c) 2018-2023, INTEL CORPORATION.  All rights reserved.
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/clock/tegra234-clock.h>
+#include <dt-bindings/gpio/tegra234-gpio.h>
+#include <dt-bindings/pinctrl/pinctrl-tegra.h>
+
+#define MAX1_CSI_SYNC	TEGRA234_AON_GPIO(BB, 2)  //MAX96712_1 MFP2
+#define CAM0_PWDN	TEGRA234_MAIN_GPIO(H, 6)  //MAX96712_1 PWDN
+#define CAM12V_POC	TEGRA234_MAIN_GPIO(AC, 7)
+
+#define CAMERA_I2C_MUX_BUS(x) (0x1E + x)
+
+
+
+/* camera control gpio definitions */
+/ {
+	overlay-name = "Jetson RealSense Camera D5xx with max96712 and tca9546 (fg12-16ch)";
+	jetson-header-name = "Jetson AGX CSI Connector";
+	compatible = "nvidia,p3737-0000+p3701-0000",
+		     "nvidia,p3737-0000+p3701-0004",
+		     "nvidia,p3737-0000+p3701-0005",
+		     "nvidia,p3737-0000+p3701-0008";
+
+	/* TSC signal generators for MAX96712 MFP2 sync. */
+	fragment@3 {
+		target-path = "/";
+		__overlay__ {
+			tsc_sig_gen@c6a0000 {
+				status = "okay";
+				generator@380 {
+					status = "okay";
+					freq_hz = <30>;
+					duty_cycle = <25>;
+					gpio_pinmux = <&gpio_aon MAX1_CSI_SYNC GPIO_ACTIVE_LOW>;
+				};
+			};
+		};
+	};
+
+	/* Muxing MAX1_CSI_SYNC to TSC function
+	 * MAX_ALL_CAM_SYNC (PCC.00) does not have This routing on Orin
+	 * so we define it as high-Z input with pull-down for external wiring
+	 * Use MAX1_CSI_SYNC for Orin TSC as sync signal or use
+	 * MAX_ALL_CAM_SYNC connected to an external signal generator
+	 */
+	fragment@2 {
+		target-path = "/bus@0/pinmux@c300000";
+		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&tsc_sync_pinmux>;
+			tsc_sync_pinmux: tsc-sync-pins {
+				max1-csi-sync {
+					nvidia,pins = "soc_gpio50_pbb2";
+					nvidia,function = "tsc";
+					nvidia,tristate = <TEGRA_PIN_DISABLE>;
+					nvidia,enable-input = <TEGRA_PIN_DISABLE>;
+				};
+				sync-all-input {
+					nvidia,pins = "spi2_sck_pcc0";
+					nvidia,function = "rsvd1";
+					nvidia,tristate = <TEGRA_PIN_ENABLE>;
+					nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+					nvidia,pull = <TEGRA_PIN_PULL_DOWN>;
+				};
+			};
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			vdd_cam12v_poc: regulator-vdd-cam12v-poc {
+					compatible = "regulator-fixed";
+					regulator-name = "vdd-cam12v-poc";
+					regulator-min-microvolt = <12000000>;
+					regulator-max-microvolt = <12000000>;
+					gpio = <&gpio CAM12V_POC GPIO_ACTIVE_HIGH>;
+					enable-active-high;
+			};
+		};
+	};
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			tegra-capture-vi {
+				num-channels = <4>;
+				ports {
+					status = "okay";
+					port@0 {
+						status = "okay";
+						reg = <0>;
+						d4xx_vi_in0: endpoint {
+							status = "okay";
+							vc-id = <0>;
+							port-index = <0>;
+							bus-width = <4>;
+							remote-endpoint = <&d4xx_csi_out0>;
+						};
+					};
+					port@1 {
+						status = "okay";
+						reg = <1>;
+						d4xx_vi_in1: endpoint {
+							status = "okay";
+							vc-id = <1>;
+							port-index = <0>;
+							bus-width = <4>;
+							remote-endpoint = <&d4xx_csi_out1>;
+						};
+					};
+					port@2 {
+						status = "okay";
+						reg = <2>;
+						d4xx_vi_in2: endpoint {
+							status = "okay";
+							vc-id = <2>;
+							port-index = <0>;
+							bus-width = <4>;
+							remote-endpoint = <&d4xx_csi_out2>;
+						};
+					};
+					port@3 {
+						status = "okay";
+						reg = <3>;
+						d4xx_vi_in3: endpoint {
+							status = "okay";
+							vc-id = <3>;
+							port-index = <0>;
+							bus-width = <4>;
+							remote-endpoint = <&d4xx_csi_out3>;
+						};
+					};
+				};
+			};
+
+			bus@0 {
+				host1x@13e00000 {
+					nvcsi@15a00000 {
+						num-channels = <4>;
+						channel@0 {
+							status = "okay";
+							reg = <0>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in0: endpoint@0 {
+										status = "okay";
+										port-index = <0>;
+										bus-width = <4>;
+										remote-endpoint = <&ds5_0_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out0: endpoint@1 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in0>;
+									};
+								};
+							};
+						};
+						channel@1 {
+							status = "okay";
+							reg = <1>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in1: endpoint@2 {
+										status = "okay";
+										port-index = <0>;
+										bus-width = <4>;
+										remote-endpoint = <&ds5_1_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out1: endpoint@3 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in1>;
+									};
+								};
+							};
+						};
+						channel@2 {
+							status = "okay";
+							reg = <2>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in2: endpoint@4 {
+										status = "okay";
+										port-index = <0>;
+										bus-width = <4>;
+										remote-endpoint = <&ds5_2_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out2: endpoint@5 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in2>;
+									};
+								};
+							};
+						};
+						channel@3 {
+							status = "okay";
+							reg = <3>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in3: endpoint@6 {
+										status = "okay";
+										port-index = <0>;
+										bus-width = <4>;
+										remote-endpoint = <&ds5_3_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out3: endpoint@7 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in3>;
+									};
+								};
+							};
+						};
+					};
+				};
+
+				i2c@3180000 {
+					clock-frequency = <100000>;
+					tca9546@70 {
+						status = "okay";
+						reg = <0x70>;
+						compatible = "nxp,pca9546";
+						#address-cells = <1>;
+						#size-cells = <0>;
+						skip_mux_detect = "yes";
+						/*vcc-pullup-supply = <&battery_reg>;*/
+						force_bus_start = <CAMERA_I2C_MUX_BUS(0)>;
+						vcc_lp = "vcc";
+						i2c@0 {
+							status = "okay";
+							reg = <0>;
+							i2c-mux,deselect-on-exit;
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							dser: max96712@29 {
+								status = "okay";
+								reg = <0x29>;
+								compatible = "maxim,max96712";
+								csi-mode = "2x4";
+								lane_cnt = <4>;
+								channel = "a";
+								pwdn-gpios = <&gpio CAM0_PWDN GPIO_ACTIVE_HIGH>;
+							};
+
+							ser_a: max96717@40 {
+								status = "okay";
+								compatible = "maxim,max96717";
+								reg = <0x40>;
+								maxim,gmsl-dser-device = <&dser>;
+							};
+
+							ds5_3: ds5@1d {
+								status = "okay";
+								def-addr = <0x10>;
+								reg = <0x1d>;
+								override_reg = <0x1a>;
+								compatible = "realsense,d5xx";
+								use_sensor_mode_id = "true";
+								vcc-supply = <&vdd_cam12v_poc>;
+								cam-type = "IMU";
+								nvidia,gmsl-ser-device = <&ser_a>;
+								nvidia,gmsl-dser-device = <&dser>;
+								ports {
+									#address-cells = <1>;
+									#size-cells = <0>;
+
+									port@0 {
+										reg = <0>;
+										ds5_3_out: endpoint {
+											vc-id = <3>;
+											port-index = <3>;
+											bus-width = <4>;
+											remote-endpoint = <&d4xx_csi_in3>;
+										};
+									};
+								};
+								mode0 {
+									pixel_t = "grey_y16";
+									num_lanes = "4";
+									csi_pixel_bit_depth = "16";
+									active_w = "640";
+									active_h = "480";
+									tegra_sinterface = "serial_b";
+									mclk_khz = "24000";
+									pix_clk_hz = "74250000";
+									serdes_pix_clk_hz = "325000000";
+									line_length = "1280"; /* 2200 */
+									embedded_metadata_height = "0";
+								};
+								gmsl-link {
+									src-csi-port = "b";
+									dst-csi-port = "a";
+									serdes-csi-link = "a";
+									csi-mode = "1x4";
+									st-vc = <0>;
+									vc-id = <3>;
+									num-lanes = <4>;
+								};
+							};
+
+							ds5_2: ds5@1c {
+								status = "okay";
+								def-addr = <0x10>;
+								reg = <0x1c>;
+								override_reg = <0x1a>;
+								compatible = "realsense,d5xx";
+								use_sensor_mode_id = "true";
+								vcc-supply = <&vdd_cam12v_poc>;
+								cam-type = "Y8";
+								nvidia,gmsl-ser-device = <&ser_a>;
+								nvidia,gmsl-dser-device = <&dser>;
+								ports {
+									#address-cells = <1>;
+									#size-cells = <0>;
+
+									port@0 {
+										reg = <0>;
+										ds5_2_out: endpoint {
+											vc-id = <2>;
+											port-index = <2>;
+											bus-width = <4>;
+											remote-endpoint = <&d4xx_csi_in2>;
+										};
+									};
+								};
+								/* mode0: Y8, mode1: depth D16 */
+								mode0 {
+									pixel_t = "grey_y16";
+									num_lanes = "4";
+									csi_pixel_bit_depth = "16";
+									active_w = "1280";
+									active_h = "720";
+									tegra_sinterface = "serial_b";
+									mclk_khz = "24000";
+									pix_clk_hz = "74250000";
+									serdes_pix_clk_hz = "325000000";
+									line_length = "1280"; /* 2200 */
+									embedded_metadata_height = "1";
+								};
+								gmsl-link {
+									src-csi-port = "b";
+									dst-csi-port = "a";
+									serdes-csi-link = "a";
+									csi-mode = "1x4";
+									st-vc = <0>;
+									vc-id = <2>;
+									num-lanes = <4>;
+								};
+							};
+
+							ds5_1: ds5@1b {
+								status = "okay";
+								def-addr = <0x10>;
+								reg = <0x1b>;
+								override_reg = <0x1a>;
+								compatible = "realsense,d5xx";
+								use_sensor_mode_id = "true";
+								vcc-supply = <&vdd_cam12v_poc>;
+								cam-type = "RGB";
+								nvidia,gmsl-ser-device = <&ser_a>;
+								nvidia,gmsl-dser-device = <&dser>;
+								ports {
+									#address-cells = <1>;
+									#size-cells = <0>;
+
+									port@0 {
+										reg = <0>;
+										ds5_1_out: endpoint {
+											vc-id = <1>;
+											port-index = <1>;
+											bus-width = <4>;
+											remote-endpoint = <&d4xx_csi_in1>;
+										};
+									};
+								};
+								mode0 {
+									pixel_t = "grey_y16";
+									num_lanes = "4";
+									csi_pixel_bit_depth = "16";
+									active_w = "1920";
+									active_h = "1080";
+									tegra_sinterface = "serial_e";
+									mclk_khz = "24000";
+									pix_clk_hz = "74250000";
+									serdes_pix_clk_hz = "325000000";
+									line_length = "1280"; /* 2200 */
+									embedded_metadata_height = "1";
+								};
+								gmsl-link {
+									src-csi-port = "b";
+									dst-csi-port = "a";
+									serdes-csi-link = "a";
+									csi-mode = "1x4";
+									st-vc = <0>;
+									vc-id = <1>;
+									num-lanes = <4>;
+								};
+							};
+
+							ds5_0: ds5@1a {
+								status = "okay";
+								def-addr = <0x10>;
+								reg = <0x1a>;
+								compatible = "realsense,d5xx";
+								use_sensor_mode_id = "true";
+								vcc-supply = <&vdd_cam12v_poc>;
+								cam-type = "Depth";
+								nvidia,gmsl-ser-device = <&ser_a>;
+								nvidia,gmsl-dser-device = <&dser>;
+								ports {
+									#address-cells = <1>;
+									#size-cells = <0>;
+
+									port@0 {
+										reg = <0>;
+										ds5_0_out: endpoint {
+											vc-id = <0>;
+											port-index = <0>;
+											bus-width = <4>;
+											remote-endpoint = <&d4xx_csi_in0>;
+										};
+									};
+								};
+								mode0 {
+									pixel_t = "grey_y16";
+									num_lanes = "4";
+									csi_pixel_bit_depth = "16";
+									active_w = "1280";
+									active_h = "720";
+									tegra_sinterface = "serial_a";
+									mclk_khz = "24000";
+									pix_clk_hz = "74250000";
+									serdes_pix_clk_hz = "325000000";
+									line_length = "1280"; /* 2200 */
+									embedded_metadata_height = "1";
+								};
+								gmsl-link {
+									src-csi-port = "b";
+									dst-csi-port = "a";
+									serdes-csi-link = "a";
+									csi-mode = "1x4";
+									st-vc = <0>;
+									vc-id = <0>;
+									num-lanes = <4>;
+								};
+							};
+						};
+					};
+				};
+			};
+		};
+	};
+};

--- a/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-4ch-d5xx.dtso
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-4ch-d5xx.dtso
@@ -1,0 +1,501 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: Copyright (c) 2018-2023, INTEL CORPORATION.  All rights reserved.
+
+/*
+ * RealSense D5xx overlay for the FangZhu FG12-4CH carrier board on
+ * NVIDIA Jetson Orin Nano (p3768-0000 + p3767-xxxx).
+ *
+ * Board topology (single D5xx on deserializer link A):
+ *   D5xx --CSI-2 4-lane--> MAX96717 serializer (0x40)
+ *        --GMSL2--> MAX96712 deserializer (0x29)
+ *        --CSI-2 4-lane--> Orin Nano CSI port C/D
+ *                         (port-index = 2 / serial_c).
+ *
+ * The board-specific I2C GPIO mux, PoC control and reversed CSI lane polarity
+ * are inherited from the verified FG12-4CH D457 configuration.  The MAX96717
+ * and 4-lane camera settings are derived from the FG12-16CH D5xx overlay.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/clock/tegra234-clock.h>
+#include <dt-bindings/gpio/tegra234-gpio.h>
+
+/* Camera control GPIO definitions from the official FG12-4CH device tree. */
+#define CAM0_SYNC	TEGRA234_MAIN_GPIO(H, 6)
+#define CAM1_SYNC	TEGRA234_MAIN_GPIO(AC, 0)
+#define CAM_I2C_MUX	TEGRA234_AON_GPIO(CC, 3)
+
+/ {
+	overlay-name = "Jetson RealSense Camera D5xx with max96712 for FangZhu FG12-4CH on Orin Nano (link A)";
+	jetson-header-name = "Jetson 22pin CSI Connector";
+	compatible = "nvidia,p3768-0000+p3767-0000",
+		     "nvidia,p3768-0000+p3767-0001",
+		     "nvidia,p3768-0000+p3767-0003",
+		     "nvidia,p3768-0000+p3767-0004",
+		     "nvidia,p3768-0000+p3767-0005",
+		     "nvidia,p3768-0000+p3767-0000-super",
+		     "nvidia,p3768-0000+p3767-0001-super",
+		     "nvidia,p3768-0000+p3767-0003-super",
+		     "nvidia,p3768-0000+p3767-0004-super",
+		     "nvidia,p3768-0000+p3767-0005-super";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			tegra-capture-vi {
+				num-channels = <4>;
+				ports {
+					status = "okay";
+					port@0 {
+						status = "okay";
+						reg = <0>;
+						d4xx_vi_in0: endpoint {
+							status = "okay";
+							vc-id = <0>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d4xx_csi_out0>;
+						};
+					};
+					port@1 {
+						status = "okay";
+						reg = <1>;
+						d4xx_vi_in1: endpoint {
+							status = "okay";
+							vc-id = <1>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d4xx_csi_out1>;
+						};
+					};
+					port@2 {
+						status = "okay";
+						reg = <2>;
+						d4xx_vi_in2: endpoint {
+							status = "okay";
+							vc-id = <2>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d4xx_csi_out2>;
+						};
+					};
+					port@3 {
+						status = "okay";
+						reg = <3>;
+						d4xx_vi_in3: endpoint {
+							status = "okay";
+							vc-id = <3>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d4xx_csi_out3>;
+						};
+					};
+				};
+			};
+
+			tegra-camera-platform {
+				compatible = "nvidia, tegra-camera-platform";
+				status = "okay";
+				num_csi_lanes = <4>;
+				max_lane_speed = <1500000>;
+				min_bits_per_pixel = <8>;
+				vi_peak_byte_per_pixel = <2>;
+				vi_bw_margin_pct = <25>;
+				max_pixel_rate = <160000>;
+				isp_peak_byte_per_pixel = <5>;
+				isp_bw_margin_pct = <25>;
+				modules {
+					status = "okay";
+					module0 {
+						status = "okay";
+						badge = "d5xx_depth";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-001a";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ds5@1a";
+						};
+					};
+					module1 {
+						status = "okay";
+						badge = "d5xx_rgb";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-001b";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ds5@1b";
+						};
+					};
+					module2 {
+						status = "okay";
+						badge = "d5xx_Y8";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-001c";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ds5@1c";
+						};
+					};
+					module3 {
+						status = "okay";
+						badge = "d5xx_imu";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-001d";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ds5@1d";
+						};
+					};
+				};
+			};
+
+			bus@0 {
+				host1x@13e00000 {
+					nvcsi@15a00000 {
+						num-channels = <4>;
+						channel@0 {
+							status = "okay";
+							reg = <0>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in0: endpoint@0 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&ds5_0_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out0: endpoint@1 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in0>;
+									};
+								};
+							};
+						};
+						channel@1 {
+							status = "okay";
+							reg = <1>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in1: endpoint@2 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&ds5_1_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out1: endpoint@3 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in1>;
+									};
+								};
+							};
+						};
+						channel@2 {
+							status = "okay";
+							reg = <2>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in2: endpoint@4 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&ds5_2_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out2: endpoint@5 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in2>;
+									};
+								};
+							};
+						};
+						channel@3 {
+							status = "okay";
+							reg = <3>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in3: endpoint@6 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&ds5_3_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out3: endpoint@7 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in3>;
+									};
+								};
+							};
+						};
+					};
+				};
+
+				/*
+				 * FG12-4CH routes camera I2C through a GPIO-selected mux.
+				 * The deserializer is on i2c@1 (GPIO high); video is routed
+				 * independently to CSI C/D (port-index 2 / serial_c).
+				 */
+				cam_i2cmux {
+					compatible = "i2c-mux-gpio";
+					#address-cells = <1>;
+					#size-cells = <0>;
+					i2c-parent = <&cam_i2c>;
+					mux-gpios = <&gpio_aon CAM_I2C_MUX GPIO_ACTIVE_HIGH>;
+
+					i2c@1 {
+						reg = <1>;
+						#address-cells = <1>;
+						#size-cells = <0>;
+
+						dser: max96712@29 {
+							status = "okay";
+							reg = <0x29>;
+							compatible = "maxim,max96712";
+							csi-mode = "2x4";
+							lane_cnt = <4>;
+							link-mask = <0x1>;
+							channel = "a";
+							fangzhu,fg12-reverse-lane-polarity;
+							fangzhu,fg12-poc-enable;
+						};
+
+						ser_a: max96717@40 {
+							status = "okay";
+							compatible = "maxim,max96717";
+							reg = <0x40>;
+							maxim,gmsl-dser-device = <&dser>;
+						};
+
+						ds5_3: ds5@1d {
+							status = "okay";
+							def-addr = <0x10>;
+							reg = <0x1d>;
+							override_reg = <0x1a>;
+							compatible = "realsense,d5xx";
+							use_sensor_mode_id = "true";
+							cam-type = "IMU";
+							nvidia,gmsl-ser-device = <&ser_a>;
+							nvidia,gmsl-dser-device = <&dser>;
+							ports {
+								#address-cells = <1>;
+								#size-cells = <0>;
+
+								port@0 {
+									reg = <0>;
+									ds5_3_out: endpoint {
+										vc-id = <3>;
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&d4xx_csi_in3>;
+									};
+								};
+							};
+							mode0 {
+								pixel_t = "grey_y16";
+								num_lanes = "4";
+								csi_pixel_bit_depth = "16";
+								active_w = "640";
+								active_h = "480";
+								tegra_sinterface = "serial_c";
+								mclk_khz = "24000";
+								pix_clk_hz = "74250000";
+								serdes_pix_clk_hz = "325000000";
+								line_length = "1280"; /* 2200 */
+								embedded_metadata_height = "0";
+							};
+							gmsl-link {
+								src-csi-port = "b";
+								dst-csi-port = "a";
+								serdes-csi-link = "a";
+								csi-mode = "1x4";
+								st-vc = <0>;
+								vc-id = <3>;
+								num-lanes = <4>;
+							};
+						};
+
+						ds5_2: ds5@1c {
+							status = "okay";
+							def-addr = <0x10>;
+							reg = <0x1c>;
+							override_reg = <0x1a>;
+							compatible = "realsense,d5xx";
+							use_sensor_mode_id = "true";
+							cam-type = "Y8";
+							nvidia,gmsl-ser-device = <&ser_a>;
+							nvidia,gmsl-dser-device = <&dser>;
+							ports {
+								#address-cells = <1>;
+								#size-cells = <0>;
+
+								port@0 {
+									reg = <0>;
+									ds5_2_out: endpoint {
+										vc-id = <2>;
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&d4xx_csi_in2>;
+									};
+								};
+							};
+							/* mode0: Y8, mode1: depth D16 */
+							mode0 {
+								pixel_t = "grey_y16";
+								num_lanes = "4";
+								csi_pixel_bit_depth = "16";
+								active_w = "1280";
+								active_h = "720";
+								tegra_sinterface = "serial_c";
+								mclk_khz = "24000";
+								pix_clk_hz = "74250000";
+								serdes_pix_clk_hz = "325000000";
+								line_length = "1280"; /* 2200 */
+								embedded_metadata_height = "1";
+							};
+							gmsl-link {
+								src-csi-port = "b";
+								dst-csi-port = "a";
+								serdes-csi-link = "a";
+								csi-mode = "1x4";
+								st-vc = <0>;
+								vc-id = <2>;
+								num-lanes = <4>;
+							};
+						};
+
+						ds5_1: ds5@1b {
+							status = "okay";
+							def-addr = <0x10>;
+							reg = <0x1b>;
+							override_reg = <0x1a>;
+							compatible = "realsense,d5xx";
+							use_sensor_mode_id = "true";
+							cam-type = "RGB";
+							nvidia,gmsl-ser-device = <&ser_a>;
+							nvidia,gmsl-dser-device = <&dser>;
+							ports {
+								#address-cells = <1>;
+								#size-cells = <0>;
+
+								port@0 {
+									reg = <0>;
+									ds5_1_out: endpoint {
+										vc-id = <1>;
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&d4xx_csi_in1>;
+									};
+								};
+							};
+							mode0 {
+								pixel_t = "grey_y16";
+								num_lanes = "4";
+								csi_pixel_bit_depth = "16";
+								active_w = "1920";
+								active_h = "1080";
+								tegra_sinterface = "serial_c";
+								mclk_khz = "24000";
+								pix_clk_hz = "74250000";
+								serdes_pix_clk_hz = "325000000";
+								line_length = "1280"; /* 2200 */
+								embedded_metadata_height = "1";
+							};
+							gmsl-link {
+								src-csi-port = "b";
+								dst-csi-port = "a";
+								serdes-csi-link = "a";
+								csi-mode = "1x4";
+								st-vc = <0>;
+								vc-id = <1>;
+								num-lanes = <4>;
+							};
+						};
+
+						ds5_0: ds5@1a {
+							status = "okay";
+							def-addr = <0x10>;
+							reg = <0x1a>;
+							compatible = "realsense,d5xx";
+							use_sensor_mode_id = "true";
+							cam-type = "Depth";
+							nvidia,gmsl-ser-device = <&ser_a>;
+							nvidia,gmsl-dser-device = <&dser>;
+							ports {
+								#address-cells = <1>;
+								#size-cells = <0>;
+
+								port@0 {
+									reg = <0>;
+									ds5_0_out: endpoint {
+										vc-id = <0>;
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&d4xx_csi_in0>;
+									};
+								};
+							};
+							mode0 {
+								pixel_t = "grey_y16";
+								num_lanes = "4";
+								csi_pixel_bit_depth = "16";
+								active_w = "1280";
+								active_h = "720";
+								tegra_sinterface = "serial_c";
+								mclk_khz = "24000";
+								pix_clk_hz = "74250000";
+								serdes_pix_clk_hz = "325000000";
+								line_length = "1280"; /* 2200 */
+								embedded_metadata_height = "1";
+							};
+							gmsl-link {
+								src-csi-port = "b";
+								dst-csi-port = "a";
+								serdes-csi-link = "a";
+								csi-mode = "1x4";
+								st-vc = <0>;
+								vc-id = <0>;
+								num-lanes = <4>;
+							};
+						};
+					};
+				};
+			};
+		};
+	};
+};

--- a/hardware/realsense/tegra234-camera-d4xx-overlay-fg24-4ch-d5xx.dtso
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-fg24-4ch-d5xx.dtso
@@ -1,0 +1,649 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: Copyright (c) 2026, RealSense CORPORATION.  All rights reserved.
+
+/*
+ * Device tree overlay for RealSense D585 depth camera on FangZhu FG24-4CH board:
+ *   Serializer:   MAX96717
+ *   Deserializer: MAX96724
+ *   Camera SoC:   HKR
+ *   I2C Mux:      GPIO-based (i2c-mux-gpio)
+ *   Board:        FangZhu FG24-4CH (Orin Nano/NX P3767+P3768)
+ *
+ * VC assignment:
+ *   VC0 = Depth  (Z16,  1280x720  @60fps)
+ *   VC1 = RGB    (YUY2, 1920x1080 @30fps)
+ *   VC2 = IR     (Y8/Y8I/Y12I, 1280x720 @60fps)
+ *   VC3 = IMU    (RAW8)
+ *
+ * GMSL link:
+ *   GMSL2 Tunnel Mode, 6 Gbps
+ *   HKR MIPI Tx → MAX96717: 4-lane CSI-2
+ *   MAX96724 Port A → Orin NVCSI: 4-lane CSI-2 over the Orin Nano CAM1
+ *   22-pin connector.
+ *
+ * CSI port / control I2C:
+ *   The physical CAM1 connector is not auto-bound to I2C by Linux. This
+ *   overlay explicitly binds the video path to Orin NVCSI CSI-C via
+ *   port-index 2 / tegra_sinterface "serial_c", and binds control I2C to
+ *   cam_i2c (i2c@3180000) through the GPIO mux channel 1 node i2c@1
+ *   (mux-gpio AON_GPIO(CC,3) driven HIGH). Linux runtime i2c-10 is HDMI DDC
+ *   on this platform and is not the camera control bus.
+ *
+ * I2C address map (7-bit):
+ *   GPIO mux:     AON_GPIO(CC, 3)
+ *   MAX96724 deser:  0x27
+ *   MAX96717 ser:    0x40 (default), 0x60 (aliased)
+ *   HKR camera SoC:  0x10 (def-addr)
+ *   Sensor aliases:   0x1a (Depth), 0x1b (RGB), 0x1c (IR), 0x1d (IMU)
+ *
+ * CSI lane properties:
+ *   mipi-lane-rate-mbps = HKR-to-MAX96717 input rate per lane
+ *   csi-lane-rate-mbps  = MAX96724-to-Orin output rate per lane
+ *   csi-lane-count      = MAX96724 output width; only 4 lanes are supported
+ *
+ * ADI specifies a fixed 6 Gbps GMSL2 forward rate and up to 2.5 Gbps per
+ * D-PHY lane. This single-link topology uses 4 x 1500 Mbps on the CSI output,
+ * matching the 6 Gbps input-link ceiling; 4 x 2000 Mbps adds D-PHY headroom
+ * but cannot increase sustained input-limited throughput. The generic driver
+ * keeps its legacy 2000 Mbps default for other, potentially 2-lane, boards.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/clock/tegra234-clock.h>
+#include <dt-bindings/gpio/tegra234-gpio.h>
+
+#define CAM_I2C_MUX	TEGRA234_AON_GPIO(CC, 3)
+
+/ {
+	overlay-name = "Jetson RealSense Camera D5xx with max96724 on FG24-4CH";
+	jetson-header-name = "Jetson 22pin CSI Connector";
+	compatible = "nvidia,p3768-0000+p3767-0000",
+		     "nvidia,p3768-0000+p3767-0001",
+		     "nvidia,p3768-0000+p3767-0003",
+		     "nvidia,p3768-0000+p3767-0004",
+		     "nvidia,p3768-0000+p3767-0005",
+		     "nvidia,p3768-0000+p3767-0000-super",
+		     "nvidia,p3768-0000+p3767-0001-super",
+		     "nvidia,p3768-0000+p3767-0003-super",
+		     "nvidia,p3768-0000+p3767-0004-super",
+		     "nvidia,p3768-0000+p3767-0005-super";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			tegra-capture-vi {
+				num-channels = <4>;
+				ports {
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					/* VC0: Depth — Z16 1280x720 @60fps */
+					port@0 {
+						status = "okay";
+						reg = <0>;
+						d5xx_vi_in0: endpoint {
+							status = "okay";
+							vc-id = <0>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d5xx_csi_out0>;
+						};
+					};
+
+					/* VC1: RGB — YUY2 1920x1080 @30fps */
+					port@1 {
+						status = "okay";
+						reg = <1>;
+						d5xx_vi_in1: endpoint {
+							status = "okay";
+							vc-id = <1>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d5xx_csi_out1>;
+						};
+					};
+
+					/* VC2: IR — Y8/Y8I/Y12I 1280x720 @60fps */
+					port@2 {
+						status = "okay";
+						reg = <2>;
+						d5xx_vi_in2: endpoint {
+							status = "okay";
+							vc-id = <2>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d5xx_csi_out2>;
+						};
+					};
+
+					/* VC3: IMU — RAW8 */
+					port@3 {
+						status = "okay";
+						reg = <3>;
+						d5xx_vi_in3: endpoint {
+							status = "okay";
+							vc-id = <3>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d5xx_csi_out3>;
+						};
+					};
+				};
+			};
+
+			/*
+			 * tegra-camera-platform is REQUIRED. Without it the
+			 * tegra_camera_platform driver never probes, leaving
+			 * tegra_camera_misc.parent == NULL. At STREAMON,
+			 * vi5_power_on() -> tegra_camera_emc_clk_enable() calls
+			 * dev_get_drvdata(NULL) -> NULL deref at offset 0x78 ->
+			 * kernel panic / instant reboot. The 4 modules below map
+			 * the 4 D5xx streams (Depth/RGB/IR/IMU) for bandwidth calc.
+			 */
+			tegra-camera-platform {
+				status = "okay";
+				compatible = "nvidia, tegra-camera-platform";
+				num_csi_lanes = <4>;
+				max_lane_speed = <1500000>;
+				min_bits_per_pixel = <10>;
+				vi_peak_byte_per_pixel = <2>;
+				vi_bw_margin_pct = <25>;
+				max_pixel_rate = <7500000>;
+				isp_peak_byte_per_pixel = <5>;
+				isp_bw_margin_pct = <25>;
+
+				modules {
+					cam_module0: module0 {
+						badge = "d5xx_depth";
+						position = "bottomleft";
+						orientation = "1";
+						cam_module0_drivernode0: drivernode0 {
+							pcl_id = "v4l2_sensor";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/d5xx@1a";
+						};
+					};
+					cam_module1: module1 {
+						badge = "d5xx_rgb";
+						position = "centerleft";
+						orientation = "1";
+						cam_module1_drivernode0: drivernode0 {
+							pcl_id = "v4l2_sensor";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/d5xx@1b";
+						};
+					};
+					cam_module2: module2 {
+						badge = "d5xx_ir";
+						position = "topleft";
+						orientation = "1";
+						cam_module2_drivernode0: drivernode0 {
+							pcl_id = "v4l2_sensor";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/d5xx@1c";
+						};
+					};
+					cam_module3: module3 {
+						badge = "d5xx_imu";
+						position = "frontcenter";
+						orientation = "1";
+						cam_module3_drivernode0: drivernode0 {
+							pcl_id = "v4l2_sensor";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/d5xx@1d";
+						};
+					};
+				};
+			};
+
+			bus@0 {
+				host1x@13e00000 {
+					nvcsi@15a00000 {
+						num-channels = <4>;
+						#address-cells = <1>;
+						#size-cells = <0>;
+
+						/* NVCSI channel 0: Depth (VC0) */
+						channel@0 {
+							status = "okay";
+							reg = <0>;
+							ports {
+                                status = "okay";
+								#address-cells = <1>;
+								#size-cells = <0>;
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d5xx_csi_in0: endpoint@0 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+                                        vc-id = <0>;
+										remote-endpoint = <&d5xx_depth_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d5xx_csi_out0: endpoint@1 {
+										status = "okay";
+										remote-endpoint = <&d5xx_vi_in0>;
+									};
+								};
+							};
+						};
+
+						/* NVCSI channel 1: RGB (VC1) */
+						channel@1 {
+							status = "okay";
+							reg = <1>;
+							ports {
+                                status = "okay";
+								#address-cells = <1>;
+								#size-cells = <0>;
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d5xx_csi_in1: endpoint@2 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+                                        vc-id = <1>;
+										remote-endpoint = <&d5xx_rgb_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d5xx_csi_out1: endpoint@3 {
+										status = "okay";
+										remote-endpoint = <&d5xx_vi_in1>;
+									};
+								};
+							};
+						};
+
+						/* NVCSI channel 2: IR (VC2) */
+						channel@2 {
+							status = "okay";
+							reg = <2>;
+							ports {
+                                status = "okay";
+								#address-cells = <1>;
+								#size-cells = <0>;
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d5xx_csi_in2: endpoint@4 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+                                        vc-id = <2>;
+										remote-endpoint = <&d5xx_ir_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d5xx_csi_out2: endpoint@5 {
+										status = "okay";
+										remote-endpoint = <&d5xx_vi_in2>;
+									};
+								};
+							};
+						};
+
+						/* NVCSI channel 3: IMU (VC3) */
+						channel@3 {
+							status = "okay";
+							reg = <3>;
+							ports {
+                                status = "okay";
+								#address-cells = <1>;
+								#size-cells = <0>;
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d5xx_csi_in3: endpoint@6 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+                                        vc-id = <3>;
+										remote-endpoint = <&d5xx_imu_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d5xx_csi_out3: endpoint@7 {
+										status = "okay";
+										remote-endpoint = <&d5xx_vi_in3>;
+									};
+								};
+							};
+						};
+					};
+				};
+
+				cam_i2cmux {
+					compatible = "i2c-mux-gpio";
+					#address-cells = <1>;
+					#size-cells = <0>;
+					i2c-parent = <&cam_i2c>;
+					mux-gpios = <&gpio_aon CAM_I2C_MUX GPIO_ACTIVE_HIGH>;
+
+					/*
+					 * Camera control path for this CAM1-wired design:
+					 * cam_i2c -> GPIO mux channel 1 (i2c@1, mux-gpio HIGH).
+					 * The video path is selected separately by serial_c /
+					 * port-index 2 on all NVCSI and sensor endpoints.
+					 */
+					i2c@1 {
+						reg = <1>;
+						#address-cells = <1>;
+						#size-cells = <0>;
+
+						/*
+						 * MAX96724 Deserializer
+						 * I2C addr: 0x27 (7-bit)
+						 * csi-mode: "2x4" — Controller1→PortA, 4-lane output
+						 * max-src: 1 — single D585 camera on link
+						 * gmsl-link-speed: 6 — 6Gbps GMSL2
+						 */
+						dser: max96724@27 {
+							status = "okay";
+							reg = <0x27>;
+							compatible = "adi,max96724";
+							csi-mode = "2x4";
+							csi-lane-count = <4>;
+							max-src = <1>;
+							csi-lane-rate-mbps = <1500>;
+							link-mask = <0x1>;
+							gmsl-link-speed = <6>;
+						};
+
+						/*
+						 * MAX96717 serializer address is assigned by MAX96724
+						 * as 0x40 + link index (link A is 0x40).
+						 * Single 4-lane CSI-2 D-PHY input.
+						 */
+						ser_a: max96717_a@40 {
+							status = "okay";
+							compatible = "adi,max96717";
+							reg = <0x40>;
+							adi,tunnel-mode;
+							maxim,gmsl-dser-device = <&dser>;
+						};
+
+						/*
+						 * D585 IMU stream — VC3
+						 * RAW8 logical stream
+						 */
+						d5xx_imu: d5xx@1d {
+							status = "okay";
+							def-addr = <0x10>;
+							reg = <0x1d>;
+							override_reg = <0x1a>;
+							compatible = "realsense,d5xx";
+							use_sensor_mode_id = "true";
+							cam-type = "IMU";
+							mipi-lane-rate-mbps = <1300>;
+							nvidia,gmsl-ser-device = <&ser_a>;
+							nvidia,gmsl-dser-device = <&dser>;
+
+							ports {
+								#address-cells = <1>;
+								#size-cells = <0>;
+
+								port@0 {
+									reg = <0>;
+									d5xx_imu_out: endpoint {
+										vc-id = <3>;
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&d5xx_csi_in3>;
+									};
+								};
+							};
+
+							mode0 {
+								pixel_t = "grey_y8";
+								num_lanes = "4";
+								csi_pixel_bit_depth = "8";
+								active_w = "640";
+								active_h = "480";
+								tegra_sinterface = "serial_c";
+								phy_mode = "DPHY";
+								discontinuous_clk = "no";
+								cil_settletime = "0";
+								deskew_initial_enable = "false";
+								deskew_periodic_enable = "false";
+								mclk_khz = "24000";
+								pix_clk_hz = "650000000";
+								serdes_pix_clk_hz = "750000000";
+								line_length = "640";
+								embedded_metadata_height = "0";
+							};
+
+							gmsl-link {
+								src-csi-port = "a";
+								dst-csi-port = "a";
+								serdes-csi-link = "a";
+								csi-mode = "1x4";
+								st-vc = <3>;
+								vc-id = <3>;
+								num-lanes = <4>;
+							};
+						};
+
+						/*
+						 * D585 IR stream — VC2
+						 * Y8/Y8I/Y12I, 1280x720, 60fps
+						 */
+						d5xx_ir: d5xx@1c {
+							status = "okay";
+							def-addr = <0x10>;
+							reg = <0x1c>;
+							override_reg = <0x1a>;
+							compatible = "realsense,d5xx";
+							use_sensor_mode_id = "true";
+							cam-type = "Y8";
+							mipi-lane-rate-mbps = <1300>;
+							nvidia,gmsl-ser-device = <&ser_a>;
+							nvidia,gmsl-dser-device = <&dser>;
+
+							ports {
+								#address-cells = <1>;
+								#size-cells = <0>;
+
+								port@0 {
+									reg = <0>;
+									d5xx_ir_out: endpoint {
+										vc-id = <2>;
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&d5xx_csi_in2>;
+									};
+								};
+							};
+
+							mode0 {
+								/* Y8: 8-bit raw IR */
+								pixel_t = "grey_y8";
+								num_lanes = "4";
+								csi_pixel_bit_depth = "8";
+								active_w = "1280";
+								active_h = "720";
+								tegra_sinterface = "serial_c";
+								phy_mode = "DPHY";
+								discontinuous_clk = "no";
+								cil_settletime = "0";
+								deskew_initial_enable = "false";
+								deskew_periodic_enable = "false";
+								mclk_khz = "24000";
+								pix_clk_hz = "650000000";
+								serdes_pix_clk_hz = "750000000";
+								line_length = "1280";
+								embedded_metadata_height = "1";
+							};
+
+							mode1 {
+								/* Y8I: 16-bit Raw IR interleaved */
+								pixel_t = "grey_y16";
+								num_lanes = "4";
+								csi_pixel_bit_depth = "16";
+								active_w = "1280";
+								active_h = "720";
+								tegra_sinterface = "serial_c";
+								phy_mode = "DPHY";
+								discontinuous_clk = "no";
+								cil_settletime = "0";
+								deskew_initial_enable = "false";
+								deskew_periodic_enable = "false";
+								mclk_khz = "24000";
+								pix_clk_hz = "325000000";
+								serdes_pix_clk_hz = "375000000";
+								line_length = "1280";
+								embedded_metadata_height = "1";
+							};
+
+							gmsl-link {
+								src-csi-port = "a";
+								dst-csi-port = "a";
+								serdes-csi-link = "a";
+								csi-mode = "1x4";
+								st-vc = <2>;
+								vc-id = <2>;
+								num-lanes = <4>;
+							};
+						};
+
+						/*
+						 * D585 RGB stream — VC1
+						 * YUY2, 1920x1080, 30fps
+						 */
+						d5xx_rgb: d5xx@1b {
+							status = "okay";
+							def-addr = <0x10>;
+							reg = <0x1b>;
+							override_reg = <0x1a>;
+							compatible = "realsense,d5xx";
+							use_sensor_mode_id = "true";
+							cam-type = "RGB";
+							mipi-lane-rate-mbps = <1300>;
+							nvidia,gmsl-ser-device = <&ser_a>;
+							nvidia,gmsl-dser-device = <&dser>;
+
+							ports {
+								#address-cells = <1>;
+								#size-cells = <0>;
+
+								port@0 {
+									reg = <0>;
+									d5xx_rgb_out: endpoint {
+										vc-id = <1>;
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&d5xx_csi_in1>;
+									};
+								};
+							};
+
+							mode0 {
+								pixel_t = "yuv_yuyv16";
+								num_lanes = "4";
+								csi_pixel_bit_depth = "16";
+								active_w = "1920";
+								active_h = "1080";
+								tegra_sinterface = "serial_c";
+								phy_mode = "DPHY";
+								discontinuous_clk = "no";
+								cil_settletime = "0";
+								deskew_initial_enable = "false";
+								deskew_periodic_enable = "false";
+								mclk_khz = "24000";
+								pix_clk_hz = "325000000";
+								serdes_pix_clk_hz = "375000000";
+								line_length = "1920";
+								embedded_metadata_height = "1";
+							};
+
+							gmsl-link {
+								src-csi-port = "a";
+								dst-csi-port = "a";
+								serdes-csi-link = "a";
+								csi-mode = "1x4";
+								st-vc = <1>;
+								vc-id = <1>;
+								num-lanes = <4>;
+							};
+						};
+
+						/*
+						 * D585 Depth stream — VC0
+						 * Z16, 1280x720, 60fps
+						 */
+						d5xx_depth: d5xx@1a {
+							status = "okay";
+							def-addr = <0x10>;
+							reg = <0x1a>;
+							compatible = "realsense,d5xx";
+							use_sensor_mode_id = "true";
+							cam-type = "Depth";
+							mipi-lane-rate-mbps = <1300>;
+							nvidia,gmsl-ser-device = <&ser_a>;
+							nvidia,gmsl-dser-device = <&dser>;
+
+							ports {
+								#address-cells = <1>;
+								#size-cells = <0>;
+
+								port@0 {
+									reg = <0>;
+									d5xx_depth_out: endpoint {
+										vc-id = <0>;
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&d5xx_csi_in0>;
+									};
+								};
+							};
+
+							/*
+							 * At 1.5Gbps/lane, SerDes pixel clock is
+							 * 375MHz at 16bpp and 750MHz at 8bpp in
+							 * mixed-VC tunnel mode.
+							 */
+							mode0 {
+								pixel_t = "yuv_uyvy16";
+								num_lanes = "4";
+								csi_pixel_bit_depth = "16";
+								active_w = "1280";
+								active_h = "720";
+								tegra_sinterface = "serial_c";
+								phy_mode = "DPHY";
+								discontinuous_clk = "no";
+								cil_settletime = "0";
+								deskew_initial_enable = "false";
+								deskew_periodic_enable = "false";
+								mclk_khz = "24000";
+								pix_clk_hz = "325000000";
+								serdes_pix_clk_hz = "375000000";
+								line_length = "1280";
+								embedded_metadata_height = "1";
+							};
+
+							gmsl-link {
+								src-csi-port = "a";
+								dst-csi-port = "a";
+								serdes-csi-link = "a";
+								csi-mode = "1x4";
+								st-vc = <0>;
+								vc-id = <0>;
+								num-lanes = <4>;
+							};
+						};
+					};
+				};
+			};
+		};
+	};
+};

--- a/kernel/kernel-noble-src/7.0/0004-add-d4xx-camera-overlays.patch
+++ b/kernel/kernel-noble-src/7.0/0004-add-d4xx-camera-overlays.patch
@@ -2,7 +2,7 @@ Index: kernel-noble-src/arch/arm64/boot/dts/nvidia/Makefile
 ===================================================================
 --- kernel-noble-src.orig/arch/arm64/boot/dts/nvidia/Makefile
 +++ kernel-noble-src/arch/arm64/boot/dts/nvidia/Makefile
-@@ -30,3 +30,16 @@ dtb-$(CONFIG_ARCH_TEGRA_234_SOC) += tegr
+@@ -30,3 +30,19 @@ dtb-$(CONFIG_ARCH_TEGRA_234_SOC) += tegr
  dtb-$(CONFIG_ARCH_TEGRA_234_SOC) += tegra234-p3740-0002+p3701-0008.dtb
  dtb-$(CONFIG_ARCH_TEGRA_234_SOC) += tegra234-p3768-0000+p3767-0000.dtb
  dtb-$(CONFIG_ARCH_TEGRA_234_SOC) += tegra234-p3768-0000+p3767-0005.dtb
@@ -10,6 +10,9 @@ Index: kernel-noble-src/arch/arm64/boot/dts/nvidia/Makefile
 +# Fangzhu (FG12-16CH, max96712) overlays for JP7.2 on AGX Orin (tegra234)
 +dtb-$(CONFIG_ARCH_TEGRA_234_SOC) += tegra234-camera-d4xx-overlay-fg12-16ch.dtbo
 +dtb-$(CONFIG_ARCH_TEGRA_234_SOC) += tegra234-camera-d4xx-overlay-fg12-16ch-cams-0-1-2-3.dtbo
++dtb-$(CONFIG_ARCH_TEGRA_234_SOC) += tegra234-camera-d4xx-overlay-fg24-4ch-d5xx.dtbo
++dtb-$(CONFIG_ARCH_TEGRA_234_SOC) += tegra234-camera-d4xx-overlay-fg12-16ch-d5xx.dtbo
++dtb-$(CONFIG_ARCH_TEGRA_234_SOC) += tegra234-camera-d4xx-overlay-fg12-4ch-d5xx.dtbo
 +
 +dtb-$(CONFIG_ARCH_TEGRA_264_SOC) += tegra264-camera-d4xx-overlay-advantech.dtbo
 +dtb-$(CONFIG_ARCH_TEGRA_264_SOC) += tegra264-camera-d4xx-overlay-advantech-cams-0-1-2-3.dtbo


### PR DESCRIPTION
## Summary
- add the three requested D5xx JP7 DTSo sources, following the existing JP7 overlay layout
- register their DTBO targets in the existing JP7 NVIDIA kernel DTS Makefile patch, alongside the other Realsense overlays
- keep the common kernel build command as ordinary `make dtbs`; no special target arguments or extra include directories are needed
- reuse the existing `apply_patches.sh` source-link wildcard and `build_all.sh` rootfs copy wildcard unchanged

## Included DTBOs
- `tegra234-camera-d4xx-overlay-fg24-4ch-d5xx.dtbo`
- `tegra234-camera-d4xx-overlay-fg12-16ch-d5xx.dtbo`
- `tegra234-camera-d4xx-overlay-fg12-4ch-d5xx.dtbo`

## Root cause confirmed from Jenkins job #20
The three DTSo files were linked into the JP7.2 kernel tree, but Jenkins invoked plain `make dtbs`. The previous wrapper-Makefile target arguments were therefore not used, and the files were absent from the kernel source DTS Makefile target list.

## Validation
- applied the updated patch cleanly to NVIDIA kernel tag `jetson_39.2.0` used by JP7.2
- ran the same plain `make dtbs` path and generated all three non-empty DTBO files
- exercised the existing `build_all.sh` wildcard copy and tar packaging path
- verified all three exact DTBO names are present under `boot/` in the resulting test `rootfs.tar`
- `git diff --check` passed for the PR changes