### PR TITLE
Add RealSense VID (0x38E5) UVC metadata wildcard to Jetson kernel patches

### DIFF
--- a/kernel/kernel-5.10/5.0.2/0004-realsense-metadata-jetpack-5.0.2.patch
+++ b/kernel/kernel-5.10/5.0.2/0004-realsense-metadata-jetpack-5.0.2.patch
@@ -109,7 +109,7 @@ diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driv
 +	{ .match_flags		= USB_DEVICE_ID_MATCH_VENDOR
 +				| USB_DEVICE_ID_MATCH_INT_CLASS
 +				| USB_DEVICE_ID_MATCH_INT_SUBCLASS,
-+	  .idVendor			= 0x38E5,
++	  .idVendor		= 0x38E5,
 +	  .bInterfaceClass	= USB_CLASS_VIDEO,
 +	  .bInterfaceSubClass	= 1,
 +	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },

--- a/kernel/kernel-5.10/5.0.2/0004-realsense-metadata-jetpack-5.0.2.patch
+++ b/kernel/kernel-5.10/5.0.2/0004-realsense-metadata-jetpack-5.0.2.patch
@@ -20,8 +20,8 @@ librealsense focal patch are already present upstream in L4T 35.1.
 
 Signed-off-by: Remi Bettan <remi.bettan@realsenseai.com>
 ---
- drivers/media/usb/uvc/uvc_driver.c | 54 ++++++++++++++++++++++++++++++
- 1 file changed, 54 insertions(+)
+ drivers/media/usb/uvc/uvc_driver.c | 62 ++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 62 insertions(+)
 
 diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
 --- a/drivers/media/usb/uvc/uvc_driver.c
@@ -74,7 +74,7 @@ diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driv
  	  /* Intel D405 */
  	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
  				| USB_DEVICE_ID_MATCH_INT_INFO,
-@@ -3293,6 +3320,33 @@ static const struct usb_device_id uvc_ids[] = {
+@@ -3293,6 +3320,41 @@ static const struct usb_device_id uvc_ids[] = {
  	  .bInterfaceSubClass	= 1,
  	  .bInterfaceProtocol	= 0,
  	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
@@ -104,6 +104,14 @@ diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driv
 +	  .bInterfaceClass	= USB_CLASS_VIDEO,
 +	  .bInterfaceSubClass	= 1,
 +	  .bInterfaceProtocol	= UVC_PC_PROTOCOL_15,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	/* All RealSense-VID cameras - UVC metadata (protocol-agnostic, covers all PIDs) */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_VENDOR
++				| USB_DEVICE_ID_MATCH_INT_CLASS
++				| USB_DEVICE_ID_MATCH_INT_SUBCLASS,
++	  .idVendor			= 0x38E5,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
 +	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
  	/* Generic USB Video Class */
  	{ USB_INTERFACE_INFO(USB_CLASS_VIDEO, 1, UVC_PC_PROTOCOL_UNDEFINED) },

--- a/kernel/kernel-jammy-src/6.0/0003-realsense-metadata-jammy-master.patch
+++ b/kernel/kernel-jammy-src/6.0/0003-realsense-metadata-jammy-master.patch
@@ -8,15 +8,15 @@ Co-developed-by: Yu MENG <yu1.meng@intel.com>
 Co-developed-by: Evgeni Raikhel <evgeni.raikhel@intel.com>
 Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
 ---
- drivers/media/usb/uvc/uvc_driver.c | 288 +++++++++++++++++++++++++++++
+ drivers/media/usb/uvc/uvc_driver.c | 296 +++++++++++++++++++++++++++++++++++++
  drivers/media/usb/uvc/uvcvideo.h   |   2 +-
- 2 files changed, 289 insertions(+), 1 deletion(-)
+ 2 files changed, 297 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
 index 2e7df1de0..848417912 100644
 --- a/drivers/media/usb/uvc/uvc_driver.c
 +++ b/drivers/media/usb/uvc/uvc_driver.c
-@@ -3152,6 +3152,294 @@ static const struct usb_device_id uvc_ids[] = {
+@@ -3152,6 +3152,302 @@ static const struct usb_device_id uvc_ids[] = {
  	  .bInterfaceSubClass	= 1,
  	  .bInterfaceProtocol	= 0,
  	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
@@ -307,6 +307,14 @@ index 2e7df1de0..848417912 100644
 +	  .bInterfaceClass	= USB_CLASS_VIDEO,
 +	  .bInterfaceSubClass	= 1,
 +	  .bInterfaceProtocol	= UVC_PC_PROTOCOL_15,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	/* All RealSense-VID cameras - UVC metadata (protocol-agnostic, covers all PIDs) */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_VENDOR
++				| USB_DEVICE_ID_MATCH_INT_CLASS
++				| USB_DEVICE_ID_MATCH_INT_SUBCLASS,
++	  .idVendor			= 0x38E5,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
 +	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
  	/* Generic USB Video Class */
  	{ USB_INTERFACE_INFO(USB_CLASS_VIDEO, 1, UVC_PC_PROTOCOL_UNDEFINED) },

--- a/kernel/kernel-jammy-src/6.2.1/0003-realsense-metadata-jammy-master.patch
+++ b/kernel/kernel-jammy-src/6.2.1/0003-realsense-metadata-jammy-master.patch
@@ -8,15 +8,15 @@ Co-developed-by: Yu MENG <yu1.meng@intel.com>
 Co-developed-by: Evgeni Raikhel <evgeni.raikhel@intel.com>
 Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
 ---
- drivers/media/usb/uvc/uvc_driver.c | 288 +++++++++++++++++++++++++++++
+ drivers/media/usb/uvc/uvc_driver.c | 296 +++++++++++++++++++++++++++++++++++++
  drivers/media/usb/uvc/uvcvideo.h   |   2 +-
- 2 files changed, 289 insertions(+), 1 deletion(-)
+ 2 files changed, 297 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
 index 2e7df1de0..848417912 100644
 --- a/drivers/media/usb/uvc/uvc_driver.c
 +++ b/drivers/media/usb/uvc/uvc_driver.c
-@@ -3152,6 +3152,294 @@ static const struct usb_device_id uvc_ids[] = {
+@@ -3152,6 +3152,302 @@ static const struct usb_device_id uvc_ids[] = {
  	  .bInterfaceSubClass	= 1,
  	  .bInterfaceProtocol	= 0,
  	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
@@ -307,6 +307,14 @@ index 2e7df1de0..848417912 100644
 +	  .bInterfaceClass	= USB_CLASS_VIDEO,
 +	  .bInterfaceSubClass	= 1,
 +	  .bInterfaceProtocol	= UVC_PC_PROTOCOL_15,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	/* All RealSense-VID cameras - UVC metadata (protocol-agnostic, covers all PIDs) */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_VENDOR
++				| USB_DEVICE_ID_MATCH_INT_CLASS
++				| USB_DEVICE_ID_MATCH_INT_SUBCLASS,
++	  .idVendor			= 0x38E5,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
 +	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
  	/* Generic USB Video Class */
  	{ USB_INTERFACE_INFO(USB_CLASS_VIDEO, 1, UVC_PC_PROTOCOL_UNDEFINED) },

--- a/kernel/kernel-jammy-src/6.2/0003-realsense-metadata-jammy-master.patch
+++ b/kernel/kernel-jammy-src/6.2/0003-realsense-metadata-jammy-master.patch
@@ -8,15 +8,15 @@ Co-developed-by: Yu MENG <yu1.meng@intel.com>
 Co-developed-by: Evgeni Raikhel <evgeni.raikhel@intel.com>
 Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
 ---
- drivers/media/usb/uvc/uvc_driver.c | 288 +++++++++++++++++++++++++++++
+ drivers/media/usb/uvc/uvc_driver.c | 296 +++++++++++++++++++++++++++++++++++++
  drivers/media/usb/uvc/uvcvideo.h   |   2 +-
- 2 files changed, 289 insertions(+), 1 deletion(-)
+ 2 files changed, 297 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
 index 2e7df1de0..848417912 100644
 --- a/drivers/media/usb/uvc/uvc_driver.c
 +++ b/drivers/media/usb/uvc/uvc_driver.c
-@@ -3152,6 +3152,294 @@ static const struct usb_device_id uvc_ids[] = {
+@@ -3152,6 +3152,302 @@ static const struct usb_device_id uvc_ids[] = {
  	  .bInterfaceSubClass	= 1,
  	  .bInterfaceProtocol	= 0,
  	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
@@ -307,6 +307,14 @@ index 2e7df1de0..848417912 100644
 +	  .bInterfaceClass	= USB_CLASS_VIDEO,
 +	  .bInterfaceSubClass	= 1,
 +	  .bInterfaceProtocol	= UVC_PC_PROTOCOL_15,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	/* All RealSense-VID cameras - UVC metadata (protocol-agnostic, covers all PIDs) */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_VENDOR
++				| USB_DEVICE_ID_MATCH_INT_CLASS
++				| USB_DEVICE_ID_MATCH_INT_SUBCLASS,
++	  .idVendor			= 0x38E5,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
 +	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
  	/* Generic USB Video Class */
  	{ USB_INTERFACE_INFO(USB_CLASS_VIDEO, 1, UVC_PC_PROTOCOL_UNDEFINED) },

--- a/kernel/kernel-noble-src/7.0/0003-realsense-metadata-jammy-master.patch
+++ b/kernel/kernel-noble-src/7.0/0003-realsense-metadata-jammy-master.patch
@@ -8,14 +8,14 @@ Co-developed-by: Yu MENG <yu1.meng@intel.com>
 Co-developed-by: Evgeni Raikhel <evgeni.raikhel@intel.com>
 Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
 ---
- drivers/media/usb/uvc/uvc_driver.c | 288 +++++++++++++++++++++++++++++
- 2 files changed, 289 insertions(+), 1 deletion(-)
+ drivers/media/usb/uvc/uvc_driver.c | 296 +++++++++++++++++++++++++++++++++++++
+ 2 files changed, 297 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
 index 2e7df1de0..848417912 100644
 --- a/drivers/media/usb/uvc/uvc_driver.c
 +++ b/drivers/media/usb/uvc/uvc_driver.c
-@@ -3152,6 +3152,294 @@ static const struct usb_device_id uvc_ids[] = {
+@@ -3152,6 +3152,302 @@ static const struct usb_device_id uvc_ids[] = {
  	  .bInterfaceSubClass	= 1,
  	  .bInterfaceProtocol	= 0,
  	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
@@ -306,6 +306,14 @@ index 2e7df1de0..848417912 100644
 +	  .bInterfaceClass	= USB_CLASS_VIDEO,
 +	  .bInterfaceSubClass	= 1,
 +	  .bInterfaceProtocol	= UVC_PC_PROTOCOL_15,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	/* All RealSense-VID cameras - UVC metadata (protocol-agnostic, covers all PIDs) */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_VENDOR
++				| USB_DEVICE_ID_MATCH_INT_CLASS
++				| USB_DEVICE_ID_MATCH_INT_SUBCLASS,
++	  .idVendor			= 0x38E5,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
 +	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
  	/* Generic USB Video Class */
  	{ USB_INTERFACE_INFO(USB_CLASS_VIDEO, 1, UVC_PC_PROTOCOL_UNDEFINED) },

--- a/kernel/kernel-noble-src/7.1/0003-realsense-metadata-jammy-master.patch
+++ b/kernel/kernel-noble-src/7.1/0003-realsense-metadata-jammy-master.patch
@@ -8,14 +8,14 @@ Co-developed-by: Yu MENG <yu1.meng@intel.com>
 Co-developed-by: Evgeni Raikhel <evgeni.raikhel@intel.com>
 Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
 ---
- drivers/media/usb/uvc/uvc_driver.c | 288 +++++++++++++++++++++++++++++
- 2 files changed, 289 insertions(+), 1 deletion(-)
+ drivers/media/usb/uvc/uvc_driver.c | 296 +++++++++++++++++++++++++++++++++++++
+ 2 files changed, 297 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
 index 2e7df1de0..848417912 100644
 --- a/drivers/media/usb/uvc/uvc_driver.c
 +++ b/drivers/media/usb/uvc/uvc_driver.c
-@@ -3152,6 +3152,294 @@ static const struct usb_device_id uvc_ids[] = {
+@@ -3152,6 +3152,302 @@ static const struct usb_device_id uvc_ids[] = {
  	  .bInterfaceSubClass	= 1,
  	  .bInterfaceProtocol	= 0,
  	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
@@ -306,6 +306,14 @@ index 2e7df1de0..848417912 100644
 +	  .bInterfaceClass	= USB_CLASS_VIDEO,
 +	  .bInterfaceSubClass	= 1,
 +	  .bInterfaceProtocol	= UVC_PC_PROTOCOL_15,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	/* All RealSense-VID cameras - UVC metadata (protocol-agnostic, covers all PIDs) */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_VENDOR
++				| USB_DEVICE_ID_MATCH_INT_CLASS
++				| USB_DEVICE_ID_MATCH_INT_SUBCLASS,
++	  .idVendor			= 0x38E5,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
 +	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
  	/* Generic USB Video Class */
  	{ USB_INTERFACE_INFO(USB_CLASS_VIDEO, 1, UVC_PC_PROTOCOL_UNDEFINED) },


### PR DESCRIPTION
**Overview:** RealSense cameras with the new USB VID `0x38E5` now get a D4XX metadata node on Jetson — the UVC metadata kernel patches matched Intel VID `0x8086` only.

Tracked on [RSDSO-21905]

## Why
New SKUs enumerate with VID `0x38E5`. Every metadata patch in this repo matches `0x8086` per-PID, so `V4L2_META_FMT_D4XX` is never attached for those devices and metadata is unavailable on Jetson.

## Summary
- Added one protocol-agnostic vendor+interface match (`idVendor=0x38E5`, `USB_CLASS_VIDEO`, subclass 1) to each metadata patch, so current and future RealSense-VID cameras are covered with no per-PID kernel patch.
- Existing `0x8086` per-PID entries untouched.
- Hunk headers and diffstat counts updated accordingly.

Files (6 real patches; `6.2.2` and `7.2` are symlinks into `6.2.1` / `7.0`):

| Patch | JetPack |
|---|---|
| `kernel/kernel-5.10/5.0.2/0004-realsense-metadata-jetpack-5.0.2.patch` | 5.0.2, 5.1.2 |
| `kernel/kernel-jammy-src/6.0/0003-realsense-metadata-jammy-master.patch` | 6.0 |
| `kernel/kernel-jammy-src/6.2/0003-realsense-metadata-jammy-master.patch` | 6.2 |
| `kernel/kernel-jammy-src/6.2.1/0003-realsense-metadata-jammy-master.patch` | 6.2.1, 6.2.2 |
| `kernel/kernel-noble-src/7.0/0003-realsense-metadata-jammy-master.patch` | 7.0, 7.2 |
| `kernel/kernel-noble-src/7.1/0003-realsense-metadata-jammy-master.patch` | 7.1 |

Mirrors the same wildcard already merged in `librealsense` (`realsense-metadata-*.patch`) and in `dkms4librealsense` (RSDSO-21412).

`nvidia-oot/*/0001-embedded-metadata-support-for-D4xx.patch` is unchanged — that is the MIPI/VI path and carries no USB device table.

Verified on Jetson nano
<img width="997" height="799" alt="image" src="https://github.com/user-attachments/assets/ac8fa4fd-1463-4b3c-a21c-dd3f09be6dd5" />


---
🤖 Generated by AI
