### PR TITLE
[DISPROVEN — see comments] d4xx: scope deserializer power_off() to the last camera on the link

### DIFF
--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -3734,13 +3734,20 @@ static void ds5_init_ds5_dev(struct ds5 *state, struct ds5_dev *ds5_dev)
 	ds5_reset_streaming_flags(ds5_dev);
 }
 
-/* Caller must hold serdes_lock__. */
-static bool ds5_release_slot(struct ds5 *state)
+/* Caller must hold serdes_lock__. *dser_last_user, if non-NULL, is set to true
+ * iff this call released the last camera sharing state's deserializer -- the
+ * only time a deserializer-level teardown (e.g. power_off()) is correct, since
+ * power_on()/setup_link()/init_settings() run exactly once per deserializer
+ * (gated on dser_primary) rather than once per camera. */
+static bool ds5_release_slot(struct ds5 *state, bool *dser_last_user)
 {
 	struct dser_control *dser_control;
 	bool has_other_users = false;
 	bool released = false;
 	int i;
+
+	if (dser_last_user)
+		*dser_last_user = false;
 
 	if (!state->ds5_dev)
 		return false;
@@ -3785,6 +3792,8 @@ static bool ds5_release_slot(struct ds5 *state)
 	}
 
 	mutex_unlock(&serdes_lock__);
+	if (dser_last_user)
+		*dser_last_user = !has_other_users;
 	return released;
 }
 
@@ -4331,7 +4340,7 @@ serdes_setup_end:
 		max9295_sdev_unpair(state->ser_dev, state->g_ctx.s_dev);
 		state->dser_ops->sdev_unregister(state->dser_dev, state->g_ctx.s_dev);
 		if (state->ser_primary)
-			ds5_release_slot(state);
+			ds5_release_slot(state, NULL);
 	} else if (state->ser_primary) {
 		mutex_lock(&state->ds5_dev->lock);
 		if (state->ds5_dev->ds5_primary == state)
@@ -6749,8 +6758,9 @@ static void ds5_remove(struct i2c_client *c)
 	if (state->ser_primary) {
 		int ret;
 		bool do_cleanup = false;
+		bool dser_last_user = false;
 
-		do_cleanup = ds5_release_slot(state);
+		do_cleanup = ds5_release_slot(state, &dser_last_user);
 
 		if (do_cleanup) {
 			ret = max9295_reset_control(state->ser_dev);
@@ -6771,7 +6781,14 @@ static void ds5_remove(struct i2c_client *c)
 			if (ret)
 				dev_warn(&c->dev,
 					"failed to %s unregister sdev\n", state->dser_ops->name);
-			state->dser_ops->power_off(state->dser_dev);
+			/* power_off() is deserializer-scoped, not per-camera: on an
+			 * aggregated link it must fire once, matching the single
+			 * power_on() gated on dser_primary during probe -- not once
+			 * per camera, which powers down a shared deserializer while
+			 * siblings are still tearing down and leaves it net-imbalanced.
+			 */
+			if (dser_last_user)
+				state->dser_ops->power_off(state->dser_dev);
 		}
 	}
 #ifndef CONFIG_OF


### PR DESCRIPTION
## ⚠️ DISPROVEN ON HARDWARE — see comments below for full evidence

Deployed and tested on fw-orin-1: this fix does **not** resolve the `max96712` refcount corruption. The `power_off()` asymmetry it fixes is real and independently defensible on its own merits, but it is not the cause of the refcount bug. Root cause is still open. See the pinned comment for the full CONFIRMED/inferred evidence trail, corroborated independently by a second session (`/sys/module/max96712/holders/` empty yet refcnt -1, `d4xx` absent from both `/proc/modules` and `/sys/module`, `modprobe d4xx` EBUSY with empty dmesg — all pointing at the kernel's module-dependency accounting or `i2c_del_driver()`'s post-loop teardown, not anything `ds5_remove()`'s per-camera block touches).

Keeping this open as a narrow, honest contract fix — not a fix for the reinsert bug.

---

## Summary
Found while investigating `modprobe d4xx` failing to reinsert with EBUSY after `modprobe -r d4xx` on an aggregated dual/tri-RGB rig (fw-orin-1, 3 cameras on one max96712 — later found to be 4 cameras after a reboot; camera count doesn't change the fix).

- `power_on()`/`setup_link()`/`init_settings()` (probe) are gated on `dser_primary` — fire once per shared deserializer.
- `power_off()` (`ds5_remove()`) was gated on `ser_primary` instead — fires once per camera. That's genuinely wrong regardless of the refcount bug: it powers down a shared deserializer while sibling cameras may still be mid-teardown, and is asymmetric with the single `power_on()`.
- Live evidence for the asymmetry itself: after a full `modprobe -r d4xx`, `lsmod` showed `max96712` at refcount **-1** while sibling deserializer modules sat at 0. That observation is real and reproducible — what turned out to be wrong was concluding this fix's `power_off()` gating explains it (see DISPROVEN note above).

Fix: `ds5_release_slot()` already computes whether a camera was the last user of its shared deserializer (used internally to clear `dser_control->dser_dev`). Threaded that out as a `dser_last_user` out-param and gated `power_off()` on it, matching `power_on()`'s scope.

## Status
- ✅ Builds clean against a properly-patched JP6.2 tree (`srcversion 4BD4C86BED1D957B568A877`).
- ✅ Deployed and boots clean on fw-orin-1 (56 `/dev/video*` nodes, no dmesg errors).
- ❌ Does **not** fix the `max96712` refcnt=-1 / EBUSY-on-reinsert bug — disproven on hardware, see comments.
- Root cause of the refcount bug is still open; next step is instrumenting `i2c_del_driver()`'s post-loop path or the kernel's module-dependency refcounting directly, not further static reading of `d4xx.c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
