### PR TITLE
[DISPROVEN — see comments] d4xx: scope deserializer power_off() to the last camera on the link (dev)

### DIFF
--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -4584,13 +4584,20 @@ static void ds5_init_ds5_dev(struct ds5 *state, struct ds5_dev *ds5_dev)
 	ds5_reset_streaming_flags(ds5_dev);
 }
 
-/* Caller must hold serdes_lock__. */
-static bool ds5_release_slot(struct ds5 *state)
+/* Caller must hold serdes_lock__. *dser_last_user, if non-NULL, is set to true
+ * iff this call released the last camera sharing state's deserializer -- the
+ * only time a deserializer-level teardown (e.g. power_off()) is correct, since
+ * power_on()/setup_link()/init_settings() run exactly once per deserializer
+ * (gated on dser_primary) rather than once per camera. */
+static bool ds5_release_slot(struct ds5 *state, bool *dser_last_user)
 {
 	struct dser_control *dser_control;
 	bool has_other_users = false;
 	bool released = false;
 	int i;
+
+	if (dser_last_user)
+		*dser_last_user = false;
 
 	if (!state->ds5_dev)
 		return false;
@@ -4635,6 +4642,8 @@ static bool ds5_release_slot(struct ds5 *state)
 	}
 
 	mutex_unlock(&serdes_lock__);
+	if (dser_last_user)
+		*dser_last_user = !has_other_users;
 	return released;
 }
 
@@ -5225,7 +5234,7 @@ serdes_setup_end:
 		state->ser_ops->sdev_unpair(state->ser_dev, state->g_ctx.s_dev);
 		state->dser_ops->sdev_unregister(state->dser_dev, state->g_ctx.s_dev);
 		if (state->ser_primary)
-			ds5_release_slot(state);
+			ds5_release_slot(state, NULL);
 	} else if (state->ser_primary) {
 		mutex_lock(&state->ds5_dev->lock);
 		if (state->ds5_dev->ds5_primary == state)
@@ -7871,8 +7880,9 @@ static void ds5_remove(struct i2c_client *c)
 	if (state->ser_primary) {
 		int ret;
 		bool do_cleanup = false;
+		bool dser_last_user = false;
 
-		do_cleanup = ds5_release_slot(state);
+		do_cleanup = ds5_release_slot(state, &dser_last_user);
 
 		if (do_cleanup) {
 			ret = state->ser_ops->reset_control(state->ser_dev);
@@ -7893,7 +7903,14 @@ static void ds5_remove(struct i2c_client *c)
 			if (ret)
 				dev_warn(&c->dev,
 					"failed to %s unregister sdev\n", state->dser_ops->name);
-			state->dser_ops->power_off(state->dser_dev);
+			/* power_off() is deserializer-scoped, not per-camera: on an
+			 * aggregated link it must fire once, matching the single
+			 * power_on() gated on dser_primary during probe -- not once
+			 * per camera, which powers down a shared deserializer while
+			 * siblings are still tearing down and leaves it net-imbalanced.
+			 */
+			if (dser_last_user)
+				state->dser_ops->power_off(state->dser_dev);
 		}
 	}
 #ifndef CONFIG_OF


### PR DESCRIPTION
## ⚠️ Same fix disproven on hardware via #616 — see that PR's comments for evidence

**This PR itself was never built or tested** — still blocked by the `dev`-specific vendor gap below (`get_ser_vc_id`), separate from what unblocked #616. But the code change here is identical to #616's (same `dser_last_user` gating), and #616's build of it was deployed to fw-orin-1 and directly disproven: `max96712` still corrupts to refcnt -1 on `modprobe -r d4xx`. No reason to expect this branch would behave differently — same mechanism, different base — but that's an inference from #616, not an independent result for `dev`.

Keeping open as the `dev`-targeted counterpart to #616's narrow, honest contract fix (the `power_off()` asymmetry is real and worth keeping regardless of the refcount bug) — not as a fix for the reinsert bug.

---

## Summary
Same fix as #616, retargeted to `dev` (the correct PR base per this repo's CLAUDE.md — #616 was mistakenly opened against `master`, which I only discovered while trying to build it: `master`'s d4xx.c doesn't compile against this repo's own JP6.2 vendor patches at all, `dev`'s no longer references `get_ser_pipe_id` there and has moved on).

See #616 for the full root-cause writeup and disproof evidence.

## Blocked on a separate, pre-existing issue (still unresolved for this branch)
Could not get a working JP6.2 build from `dev` to validate on hardware directly:
- `master`'s equivalent gap (`get_ser_pipe_id` missing from vendored `nvidia-oot/6.2/` patches) was resolved for #616 via a proper `apply_patches.sh reset && apply_patches.sh` cycle — the patches were present in the repo, just not applied to the live build tree.
- `dev` needs more than that: `set_pipe` takes an extra `u32` parameter and calls `max96712_get_ser_vc_id`, and **neither exists in any vendored patch in this repo, for any JetPack version** (checked all of them). This is a genuine gap between `dev`'s serdes abstraction and the vendored source, not a stale-build-tree issue — needs vendor source/docs to close, not something to guess at.

## Status
- ❌ Never built — blocked by the above.
- ❌ The identical fix, built via #616, was disproven on hardware (see that PR).
- Root cause of the refcount bug is still open; see #616 for where to look next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
