### PR TITLE
[TEST] D585 DFU driver bundle: PR #564 + PR #606 + PR #595

### DIFF
--- a/kernel/nvidia/5.0.2/0017-Adding-max96712-support-for-D4xx.patch
+++ b/kernel/nvidia/5.0.2/0017-Adding-max96712-support-for-D4xx.patch
@@ -1,17 +1,14 @@
-From d99126280f65cf1b8d11c434ad98014c1a124720 Mon Sep 17 00:00:00 2001
+From a1d00290130eb3e2472c6015b8139481ad267db2 Mon Sep 17 00:00:00 2001
 From: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 Date: Wed, 29 Apr 2026 08:14:22 +0300
 Subject: [PATCH] Adding max96712 support for D4xx
 
-Add MAX96712 deserializer driver support for D4XX cameras.
-
-Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- drivers/media/i2c/max96712.c | 911 ++++++++++++++++++++++++++++++++++++++++++-
- 1 file changed, 908 insertions(+), 3 deletions(-)
+ drivers/media/i2c/max96712.c | 1003 +++++++++++++++++++++++++++++++++-
+ 1 file changed, 1000 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/media/i2c/max96712.c b/drivers/media/i2c/max96712.c
-index 8081385f0..aaa115696 100644
+index 8081385f0..f0eb2e8d6 100644
 --- a/drivers/media/i2c/max96712.c
 +++ b/drivers/media/i2c/max96712.c
 @@ -21,18 +21,148 @@
@@ -164,10 +161,11 @@ index 8081385f0..aaa115696 100644
  {
  	struct i2c_client *i2c_client = NULL;
  	int bak = 0;
-@@ -85,6 +215,52 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
+@@ -85,6 +215,49 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
  
  EXPORT_SYMBOL(max96712_read_reg_Dser);
  
++/* Caller holds priv->lock while the shared I2C client address is redirected. */
 +static int max96712_read_slave_reg(struct max96712 *priv,
 +			int ShortSlaveAddr, u16 addr, unsigned int *val)
 +{
@@ -176,7 +174,6 @@ index 8081385f0..aaa115696 100644
 +	int bak = i2c_client->addr;
 +	unsigned int value = 0;
 +
-+	mutex_lock(&priv->lock);
 +	i2c_client->addr = ShortSlaveAddr;
 +	err = regmap_read(priv->regmap, addr, &value);
 +	i2c_client->addr = bak;
@@ -186,7 +183,6 @@ index 8081385f0..aaa115696 100644
 +			__func__, ShortSlaveAddr, addr);
 +	usleep_range(100, 110);
 +	*val = value;
-+	mutex_unlock(&priv->lock);
 +
 +	return err;
 +}
@@ -198,7 +194,6 @@ index 8081385f0..aaa115696 100644
 +	int err;
 +	int bak = i2c_client->addr;
 +
-+	mutex_lock(&priv->lock);
 +	i2c_client->addr = ShortSlaveAddr;
 +	err = regmap_write(priv->regmap, addr, val);
 +	i2c_client->addr = bak;
@@ -209,7 +204,6 @@ index 8081385f0..aaa115696 100644
 +
 +	/* delay before next i2c command as required for SERDES link */
 +	usleep_range(100, 110);
-+	mutex_unlock(&priv->lock);
 +
 +	return err;
 +}
@@ -217,7 +211,7 @@ index 8081385f0..aaa115696 100644
  static int max96712_read_reg(struct max96712 *priv,
  			u16 addr, unsigned int *val)
  {
-@@ -99,6 +275,20 @@ static int max96712_read_reg(struct max96712 *priv,
+@@ -99,6 +272,20 @@ static int max96712_read_reg(struct max96712 *priv,
  	return err;
  }
  
@@ -238,7 +232,7 @@ index 8081385f0..aaa115696 100644
  
  static int max96712_stats_show(struct seq_file *s, void *data)
  {
-@@ -169,7 +359,10 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -169,7 +356,10 @@ static int max96712_debugfs_init(const char *dir_name,
  	if (np) {
  		err = of_property_read_string(np, "channel", &priv->channel);
  		if (err)
@@ -249,7 +243,7 @@ index 8081385f0..aaa115696 100644
  
  		err = snprintf(dev_name, sizeof(dev_name), "max96712_%s", priv->channel);
  		if (err < 0)
-@@ -208,7 +401,8 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -208,7 +398,8 @@ static int max96712_debugfs_init(const char *dir_name,
  static  struct regmap_config max96712_regmap_config = {
  	.reg_bits = 16,
  	.val_bits = 8,
@@ -259,7 +253,7 @@ index 8081385f0..aaa115696 100644
  };
  
  static int max96712_probe(struct i2c_client *client,
-@@ -216,10 +410,16 @@ static int max96712_probe(struct i2c_client *client,
+@@ -216,10 +407,16 @@ static int max96712_probe(struct i2c_client *client,
  {
  	struct max96712 *priv;
  	int err = 0;
@@ -276,7 +270,7 @@ index 8081385f0..aaa115696 100644
  	priv->i2c_client = client;
  	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
  				&max96712_regmap_config);
-@@ -228,10 +428,60 @@ static int max96712_probe(struct i2c_client *client,
+@@ -228,10 +425,60 @@ static int max96712_probe(struct i2c_client *client,
  			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
  		return -ENODEV;
  	}
@@ -337,7 +331,7 @@ index 8081385f0..aaa115696 100644
  
  	/*set daymode by fault*/
  	dev_info(&client->dev, "%s:  success\n", __func__);
-@@ -243,8 +493,12 @@ static int max96712_probe(struct i2c_client *client,
+@@ -243,8 +490,12 @@ static int max96712_probe(struct i2c_client *client,
  static int
  max96712_remove(struct i2c_client *client)
  {
@@ -350,7 +344,7 @@ index 8081385f0..aaa115696 100644
  		i2c_unregister_device(client);
  		client = NULL;
  	}
-@@ -252,13 +506,663 @@ max96712_remove(struct i2c_client *client)
+@@ -252,13 +503,758 @@ max96712_remove(struct i2c_client *client)
  	return 0;
  }
  
@@ -561,10 +555,14 @@ index 8081385f0..aaa115696 100644
 +}
 +EXPORT_SYMBOL(max96712_get_ser_pipe_id);
 +
-+static void max96712_reset_oneshot_link_mask(struct max96712 *priv, uint8_t link_mask)
++static int max96712_reset_oneshot_link_mask(struct max96712 *priv, uint8_t link_mask)
 +{
-+	max96712_write_reg(priv, MAX96712_CTRL1_ADDR, link_mask);
++	int err = max96712_write_reg(priv, MAX96712_CTRL1_ADDR, link_mask);
++
++	if (err)
++		return err;
 +	msleep(100);
++	return 0;
 +}
 +
 +void max96712_reset_oneshot(struct device *dev)
@@ -737,6 +735,7 @@ index 8081385f0..aaa115696 100644
 +	int link_id = vc_id / MAX9295_MAX_STREAMS;
 +	uint32_t map_pipe_offs = 0x40 * pipe_id;
 +	uint32_t ext_vc_offs = 0x10 * pipe_id;
++	unsigned int pipe_en_val = 0;
 +
 +	struct reg_pair map_pipe_control[] = {
 +		// Enable all static mappings
@@ -805,7 +804,13 @@ index 8081385f0..aaa115696 100644
 +		return err;
 +	}
 +
-+	max96712_write_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, 1 << pipe_id);
++	err |= max96712_read_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR,
++				       &pipe_en_val);
++	if (!err) {
++		pipe_en_val |= BIT(pipe_id);
++		err = max96712_write_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR,
++					 pipe_en_val);
++	}
 +
 +	return err;
 +}
@@ -888,6 +893,8 @@ index 8081385f0..aaa115696 100644
 +	unsigned default_ser_addr = MAX9295_DEFAULT_ADDR;
 +	int err = 0;
 +
++	mutex_lock(&priv->lock);
++
 +	/* Iterating over the links and assigning unique serializer i2c addresses */
 +	for (link_id_iter = 0; link_id_iter < MAX96712_MAX_LINKS ; link_id_iter++)
 +	{
@@ -914,9 +921,91 @@ index 8081385f0..aaa115696 100644
 +		}
 +	}
 +	max96712_write_reg(priv, MAX96712_REG6_ADDR, dser_empty_link_mask_reg | link_mask);
++	mutex_unlock(&priv->lock);
 +	return 0;
 +}
 +EXPORT_SYMBOL(max96712_setup_link);
++
++#define MAX96712_RECOVER_MAX_RETRIES	20
++#define MAX96712_RECOVER_RETRY_DELAY_MS	100
++
++int max96712_recover_link(struct device *dev, struct device *ser_dev)
++{
++	struct max96712 *priv = dev_get_drvdata(dev);
++	struct i2c_client *ser_client = to_i2c_client(ser_dev);
++	unsigned int link_id;
++	unsigned int reg_val = 0;
++	u8 target_addr;
++	int restore_err;
++	int err;
++	int retry;
++
++	target_addr = ser_client->addr;
++	if (target_addr < MAX9295_DEFAULT_ADDR ||
++	    target_addr >= MAX9295_DEFAULT_ADDR + MAX96712_MAX_LINKS)
++		return -EINVAL;
++	link_id = target_addr - MAX9295_DEFAULT_ADDR;
++	if (!(priv->link_mask & BIT(link_id)))
++		return -EINVAL;
++
++	mutex_lock(&priv->lock);
++
++	/* Isolate the requested link so a serializer at the default address
++	 * cannot collide with a serializer on another camera module.
++	 */
++	err = max96712_write_reg(priv, MAX96712_REG6_ADDR,
++				   0xF0 | BIT(link_id));
++	if (!err) {
++		msleep(20);
++		err = max96712_reset_oneshot_link_mask(priv, BIT(link_id));
++	}
++
++	if (!err) {
++		/* HKR powers the serializer only after its reboot and GMSL startup.
++		 * Poll the isolated link instead of assuming the fixed host-side delay
++		 * was long enough. Non-zero links may also need address reassignment.
++		 */
++		for (retry = 0; retry < MAX96712_RECOVER_MAX_RETRIES; retry++) {
++			reg_val = 0;
++			err = max96712_read_slave_reg(priv, target_addr, 0, &reg_val);
++			if (!err && reg_val == target_addr << 1)
++				break;
++
++			if (target_addr != MAX9295_DEFAULT_ADDR) {
++				reg_val = 0;
++				err = max96712_read_slave_reg(priv,
++					MAX9295_DEFAULT_ADDR, 0, &reg_val);
++				if (!err && reg_val == MAX9295_DEFAULT_ADDR << 1) {
++					err = max96712_write_slave_reg(priv,
++						MAX9295_DEFAULT_ADDR, 0,
++						target_addr << 1);
++					if (!err)
++						msleep(20);
++				}
++			}
++
++			if (retry < MAX96712_RECOVER_MAX_RETRIES - 1)
++				msleep(MAX96712_RECOVER_RETRY_DELAY_MS);
++		}
++		if (retry == MAX96712_RECOVER_MAX_RETRIES)
++			err = -ETIMEDOUT;
++	}
++
++	restore_err = max96712_write_reg(priv, MAX96712_REG6_ADDR,
++					     0xF0 | priv->link_mask);
++	if (!err)
++		err = restore_err;
++	if (!err && priv->link_multi_vc_pipe[link_id] >= 0) {
++		/* The serializer video path was reset. Reapply this link's complete
++		 * multi-VC mapping on the first post-recovery stream start. */
++		priv->multi_vc_configured[
++			priv->link_multi_vc_pipe[link_id]] = false;
++	}
++
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96712_recover_link);
 +
 +int max96712_setup_control(struct device *dev, struct device *s_dev)
 +{
@@ -1015,7 +1104,7 @@ index 8081385f0..aaa115696 100644
  	{ },
  };
  
-@@ -268,6 +1172,7 @@ static struct i2c_driver max96712_i2c_driver = {
+@@ -268,6 +1264,7 @@ static struct i2c_driver max96712_i2c_driver = {
  	.driver = {
  		.name = "max96712",
  		.owner = THIS_MODULE,
@@ -1023,5 +1112,3 @@ index 8081385f0..aaa115696 100644
  	},
  	.probe = max96712_probe,
  	.remove = max96712_remove,
--- 
-2.43.0

--- a/kernel/nvidia/5.1.2/0007-Adding-max96712-support-for-D4xx.patch
+++ b/kernel/nvidia/5.1.2/0007-Adding-max96712-support-for-D4xx.patch
@@ -1,17 +1,14 @@
-From 34d61f8eee4645bbfbcf6e9ef087637015b7b3f2 Mon Sep 17 00:00:00 2001
+From aa0d58da52ac76b45dc7ff67d8167cfa08e0d0fb Mon Sep 17 00:00:00 2001
 From: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 Date: Wed, 29 Apr 2026 08:25:56 +0300
 Subject: [PATCH] Adding max96712 support for D4xx
 
-Add MAX96712 deserializer driver support for D4XX cameras.
-
-Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- drivers/media/i2c/max96712.c | 956 +++++++++++++++++++++++++++++++++++++++++--
- 1 file changed, 916 insertions(+), 40 deletions(-)
+ drivers/media/i2c/max96712.c | 1048 ++++++++++++++++++++++++++++++++--
+ 1 file changed, 1008 insertions(+), 40 deletions(-)
 
 diff --git a/drivers/media/i2c/max96712.c b/drivers/media/i2c/max96712.c
-index 329a10dfd..688f86fb8 100644
+index 329a10dfd..0f86d83a6 100644
 --- a/drivers/media/i2c/max96712.c
 +++ b/drivers/media/i2c/max96712.c
 @@ -21,32 +21,156 @@
@@ -203,7 +200,7 @@ index 329a10dfd..688f86fb8 100644
  	i2c_client = global_priv[channel]->i2c_client;
  	bak = i2c_client->addr;
  	i2c_client->addr = slaveAddr / 2;
-@@ -85,13 +207,60 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
+@@ -85,13 +207,57 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
  	{
  		dev_err(&i2c_client->dev, "%s: addr = 0x%x, val = 0x%x\n",
  				__func__, addr, *val);
@@ -217,6 +214,7 @@ index 329a10dfd..688f86fb8 100644
  
  EXPORT_SYMBOL(max96712_read_reg_Dser);
  
++/* Caller holds priv->lock while the shared I2C client address is redirected. */
 +static int max96712_read_slave_reg(struct max96712 *priv,
 +			int ShortSlaveAddr, u16 addr, unsigned int *val)
 +{
@@ -225,7 +223,6 @@ index 329a10dfd..688f86fb8 100644
 +	int bak = i2c_client->addr;
 +	unsigned int value = 0;
 +
-+	mutex_lock(&priv->lock);
 +	i2c_client->addr = ShortSlaveAddr;
 +	err = regmap_read(priv->regmap, addr, &value);
 +	i2c_client->addr = bak;
@@ -235,7 +232,6 @@ index 329a10dfd..688f86fb8 100644
 +			__func__, ShortSlaveAddr, addr);
 +	usleep_range(100, 110);
 +	*val = value;
-+	mutex_unlock(&priv->lock);
 +
 +	return err;
 +}
@@ -247,7 +243,6 @@ index 329a10dfd..688f86fb8 100644
 +	int err;
 +	int bak = i2c_client->addr;
 +
-+	mutex_lock(&priv->lock);
 +	i2c_client->addr = ShortSlaveAddr;
 +	err = regmap_write(priv->regmap, addr, val);
 +	i2c_client->addr = bak;
@@ -258,7 +253,6 @@ index 329a10dfd..688f86fb8 100644
 +
 +	/* delay before next i2c command as required for SERDES link */
 +	usleep_range(100, 110);
-+	mutex_unlock(&priv->lock);
 +
 +	return err;
 +}
@@ -266,7 +260,7 @@ index 329a10dfd..688f86fb8 100644
  static int max96712_read_reg(struct max96712 *priv,
  			u16 addr, unsigned int *val)
  {
-@@ -106,6 +275,20 @@ static int max96712_read_reg(struct max96712 *priv,
+@@ -106,6 +272,20 @@ static int max96712_read_reg(struct max96712 *priv,
  	return err;
  }
  
@@ -287,7 +281,7 @@ index 329a10dfd..688f86fb8 100644
  
  static int max96712_stats_show(struct seq_file *s, void *data)
  {
-@@ -161,24 +344,6 @@ static const struct file_operations max96712_debugfs_fops = {
+@@ -161,24 +341,6 @@ static const struct file_operations max96712_debugfs_fops = {
  	.release = single_release,
  };
  
@@ -312,7 +306,7 @@ index 329a10dfd..688f86fb8 100644
  static int max96712_debugfs_init(const char *dir_name,
  				struct dentry **d_entry,
  				struct dentry **f_entry,
-@@ -194,7 +359,10 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -194,7 +356,10 @@ static int max96712_debugfs_init(const char *dir_name,
  	if (np) {
  		err = of_property_read_string(np, "channel", &priv->channel);
  		if (err)
@@ -323,7 +317,7 @@ index 329a10dfd..688f86fb8 100644
  
  		err = snprintf(dev_name, sizeof(dev_name), "max96712_%s", priv->channel);
  		if (err < 0)
-@@ -233,7 +401,8 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -233,7 +398,8 @@ static int max96712_debugfs_init(const char *dir_name,
  static  struct regmap_config max96712_regmap_config = {
  	.reg_bits = 16,
  	.val_bits = 8,
@@ -333,7 +327,7 @@ index 329a10dfd..688f86fb8 100644
  };
  
  static int max96712_probe(struct i2c_client *client,
-@@ -241,9 +410,11 @@ static int max96712_probe(struct i2c_client *client,
+@@ -241,9 +407,11 @@ static int max96712_probe(struct i2c_client *client,
  {
  	struct max96712 *priv;
  	int err = 0;
@@ -346,7 +340,7 @@ index 329a10dfd..688f86fb8 100644
  	priv = devm_kzalloc(&client->dev, sizeof(*priv), GFP_KERNEL);
  	priv->i2c_client = client;
  	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
-@@ -253,18 +424,68 @@ static int max96712_probe(struct i2c_client *client,
+@@ -253,18 +421,68 @@ static int max96712_probe(struct i2c_client *client,
  			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
  		return -ENODEV;
  	}
@@ -420,7 +414,7 @@ index 329a10dfd..688f86fb8 100644
  
  	/*set daymode by fault*/
  	dev_info(&client->dev, "%s:  success\n", __func__);
-@@ -276,8 +497,12 @@ static int max96712_probe(struct i2c_client *client,
+@@ -276,8 +494,12 @@ static int max96712_probe(struct i2c_client *client,
  static int
  max96712_remove(struct i2c_client *client)
  {
@@ -433,7 +427,7 @@ index 329a10dfd..688f86fb8 100644
  		i2c_unregister_device(client);
  		client = NULL;
  	}
-@@ -285,13 +510,663 @@ max96712_remove(struct i2c_client *client)
+@@ -285,13 +507,758 @@ max96712_remove(struct i2c_client *client)
  	return 0;
  }
  
@@ -644,10 +638,14 @@ index 329a10dfd..688f86fb8 100644
 +}
 +EXPORT_SYMBOL(max96712_get_ser_pipe_id);
 +
-+static void max96712_reset_oneshot_link_mask(struct max96712 *priv, uint8_t link_mask)
++static int max96712_reset_oneshot_link_mask(struct max96712 *priv, uint8_t link_mask)
 +{
-+	max96712_write_reg(priv, MAX96712_CTRL1_ADDR, link_mask);
++	int err = max96712_write_reg(priv, MAX96712_CTRL1_ADDR, link_mask);
++
++	if (err)
++		return err;
 +	msleep(100);
++	return 0;
 +}
 +
 +void max96712_reset_oneshot(struct device *dev)
@@ -820,6 +818,7 @@ index 329a10dfd..688f86fb8 100644
 +	int link_id = vc_id / MAX9295_MAX_STREAMS;
 +	uint32_t map_pipe_offs = 0x40 * pipe_id;
 +	uint32_t ext_vc_offs = 0x10 * pipe_id;
++	unsigned int pipe_en_val = 0;
 +
 +	struct reg_pair map_pipe_control[] = {
 +		// Enable all static mappings
@@ -888,7 +887,13 @@ index 329a10dfd..688f86fb8 100644
 +		return err;
 +	}
 +
-+	max96712_write_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, 1 << pipe_id);
++	err |= max96712_read_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR,
++				       &pipe_en_val);
++	if (!err) {
++		pipe_en_val |= BIT(pipe_id);
++		err = max96712_write_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR,
++					 pipe_en_val);
++	}
 +
 +	return err;
 +}
@@ -971,6 +976,8 @@ index 329a10dfd..688f86fb8 100644
 +	unsigned default_ser_addr = MAX9295_DEFAULT_ADDR;
 +	int err = 0;
 +
++	mutex_lock(&priv->lock);
++
 +	/* Iterating over the links and assigning unique serializer i2c addresses */
 +	for (link_id_iter = 0; link_id_iter < MAX96712_MAX_LINKS ; link_id_iter++)
 +	{
@@ -997,9 +1004,91 @@ index 329a10dfd..688f86fb8 100644
 +		}
 +	}
 +	max96712_write_reg(priv, MAX96712_REG6_ADDR, dser_empty_link_mask_reg | link_mask);
++	mutex_unlock(&priv->lock);
 +	return 0;
 +}
 +EXPORT_SYMBOL(max96712_setup_link);
++
++#define MAX96712_RECOVER_MAX_RETRIES	20
++#define MAX96712_RECOVER_RETRY_DELAY_MS	100
++
++int max96712_recover_link(struct device *dev, struct device *ser_dev)
++{
++	struct max96712 *priv = dev_get_drvdata(dev);
++	struct i2c_client *ser_client = to_i2c_client(ser_dev);
++	unsigned int link_id;
++	unsigned int reg_val = 0;
++	u8 target_addr;
++	int restore_err;
++	int err;
++	int retry;
++
++	target_addr = ser_client->addr;
++	if (target_addr < MAX9295_DEFAULT_ADDR ||
++	    target_addr >= MAX9295_DEFAULT_ADDR + MAX96712_MAX_LINKS)
++		return -EINVAL;
++	link_id = target_addr - MAX9295_DEFAULT_ADDR;
++	if (!(priv->link_mask & BIT(link_id)))
++		return -EINVAL;
++
++	mutex_lock(&priv->lock);
++
++	/* Isolate the requested link so a serializer at the default address
++	 * cannot collide with a serializer on another camera module.
++	 */
++	err = max96712_write_reg(priv, MAX96712_REG6_ADDR,
++				   0xF0 | BIT(link_id));
++	if (!err) {
++		msleep(20);
++		err = max96712_reset_oneshot_link_mask(priv, BIT(link_id));
++	}
++
++	if (!err) {
++		/* HKR powers the serializer only after its reboot and GMSL startup.
++		 * Poll the isolated link instead of assuming the fixed host-side delay
++		 * was long enough. Non-zero links may also need address reassignment.
++		 */
++		for (retry = 0; retry < MAX96712_RECOVER_MAX_RETRIES; retry++) {
++			reg_val = 0;
++			err = max96712_read_slave_reg(priv, target_addr, 0, &reg_val);
++			if (!err && reg_val == target_addr << 1)
++				break;
++
++			if (target_addr != MAX9295_DEFAULT_ADDR) {
++				reg_val = 0;
++				err = max96712_read_slave_reg(priv,
++					MAX9295_DEFAULT_ADDR, 0, &reg_val);
++				if (!err && reg_val == MAX9295_DEFAULT_ADDR << 1) {
++					err = max96712_write_slave_reg(priv,
++						MAX9295_DEFAULT_ADDR, 0,
++						target_addr << 1);
++					if (!err)
++						msleep(20);
++				}
++			}
++
++			if (retry < MAX96712_RECOVER_MAX_RETRIES - 1)
++				msleep(MAX96712_RECOVER_RETRY_DELAY_MS);
++		}
++		if (retry == MAX96712_RECOVER_MAX_RETRIES)
++			err = -ETIMEDOUT;
++	}
++
++	restore_err = max96712_write_reg(priv, MAX96712_REG6_ADDR,
++					     0xF0 | priv->link_mask);
++	if (!err)
++		err = restore_err;
++	if (!err && priv->link_multi_vc_pipe[link_id] >= 0) {
++		/* The serializer video path was reset. Reapply this link's complete
++		 * multi-VC mapping on the first post-recovery stream start. */
++		priv->multi_vc_configured[
++			priv->link_multi_vc_pipe[link_id]] = false;
++	}
++
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96712_recover_link);
 +
 +int max96712_setup_control(struct device *dev, struct device *s_dev)
 +{
@@ -1098,7 +1187,7 @@ index 329a10dfd..688f86fb8 100644
  	{ },
  };
  
-@@ -301,6 +1176,7 @@ static struct i2c_driver max96712_i2c_driver = {
+@@ -301,6 +1268,7 @@ static struct i2c_driver max96712_i2c_driver = {
  	.driver = {
  		.name = "max96712",
  		.owner = THIS_MODULE,
@@ -1106,5 +1195,3 @@ index 329a10dfd..688f86fb8 100644
  	},
  	.probe = max96712_probe,
  	.remove = max96712_remove,
--- 
-2.43.0

--- a/kernel/nvidia/max96712.h
+++ b/kernel/nvidia/max96712.h
@@ -58,6 +58,7 @@ void max96712_reset_oneshot(struct device *dev);
  * called per-link from d4xx's ds5_hw_reset_with_recovery(). */
 void max96712_reset_oneshot_link(struct device *dev, u32 vc_id);
 int max96712_setup_link(struct device *dev, struct device *s_dev);
+int max96712_recover_link(struct device *dev, struct device *ser_dev);
 int max96712_setup_control(struct device *dev, struct device *s_dev);
 int max96712_reset_control(struct device *dev, struct device *s_dev);
 int max96712_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx);

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -67,6 +67,7 @@ struct dser_interface {
 	int (*setup_link)(struct device *dev, struct device *s_dev);
 	int (*setup_control)(struct device *dev, struct device *s_dev);
 	int (*reset_control)(struct device *dev, struct device *s_dev);
+	int (*recover_link)(struct device *dev, struct device *ser_dev);
 	int (*setup_fsync)(struct device *dev, u32 fps);
 	int (*disable_fsync)(struct device *dev);
 	
@@ -149,6 +150,9 @@ struct ser_interface {
 /* GVD response payload size per product line */
 #define DS5_GVD_LEN_D4XX		276
 #define DS5_GVD_LEN_D5XX		606
+#define D585_GVD_PID_OFFSET		18
+#define D585_2C_PROTO_PID		0x0C07
+#define D585_3C_PROTO_PID		0x0C08
 
 #define DS5_MIPI_LANE_NUMS		0x0400
 #define DS5_MIPI_LANE_DATARATE		0x0402
@@ -661,6 +665,7 @@ struct ds5_dev {
 	* read still returns 0.
 	*/
 	u16 cached_device_type;
+	u16 d585_product_id;
 
 	/* Timestamp (jiffies) of last completed HW reset.
 	* Used to enforce DS5_HW_RESET_COOLDOWN_MS between consecutive resets
@@ -757,6 +762,7 @@ static const struct dser_interface max96712_interface = {
 	.setup_link = max96712_setup_link,
 	.setup_control = max96712_setup_control,
 	.reset_control = max96712_reset_control,
+	.recover_link = max96712_recover_link,
 	.sdev_register = max96712_sdev_register,
 	.sdev_unregister = max96712_sdev_unregister,
 	.power_on = max96712_power_on,
@@ -775,6 +781,7 @@ static const struct dser_interface max96724_interface = {
 	.setup_link = max96724_setup_link,
 	.setup_control = max96724_setup_control,
 	.reset_control = max96724_reset_control,
+	.recover_link = max96724_recover_link,
 	.setup_fsync = max96724_setup_fsync,
 	.disable_fsync = max96724_disable_fsync,
 	.sdev_register = max96724_sdev_register,
@@ -856,6 +863,8 @@ static inline bool ds5_is_d58x(struct ds5 *state)
 		READ_ONCE(state->ds5_dev->cached_device_type) ==
 			DS5_DEVICE_TYPE_D58X;
 }
+
+static int ds5_hw_init(struct i2c_client *c, struct ds5 *state);
 
 static inline u16 ds5_rgb_ctrl_offset(struct ds5 *state, u16 d4xx_offset,
 				      u16 d58x_offset)
@@ -3016,6 +3025,9 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	bool rgb_streaming;
 	bool ir_streaming;
 	bool imu_streaming;
+	u16 d585_product_id = READ_ONCE(state->ds5_dev->d585_product_id);
+	bool d585_proto_reset = d585_product_id == D585_2C_PROTO_PID ||
+				 d585_product_id == D585_3C_PROTO_PID;
 	unsigned long ds5_last_reset_jiffies = READ_ONCE(state->ds5_dev->last_reset_jiffies);
 	unsigned long ts, timeout;
 
@@ -3084,7 +3096,9 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	 *    has long finished its init (matching v1.0.1.33 behavior).
 	 */
 	atomic_inc(ds5_get_reset_gen(state));
-	WRITE_ONCE(state->ds5_dev->cached_device_type, DS5_DEVICE_TYPE_UNKNOWN);
+	if (!d585_proto_reset)
+		WRITE_ONCE(state->ds5_dev->cached_device_type,
+			   DS5_DEVICE_TYPE_UNKNOWN);
 	ds5_reset_streaming_flags(state->ds5_dev);
 
 	/* 3. Scratch one control-status register before reset.
@@ -3117,6 +3131,32 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	/* 5. Delay to allow reset to complete */
 	ts = jiffies;
 	msleep(DS5_HW_RESET_INITIAL_DELAY_MS);
+
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+	if (d585_proto_reset) {
+		struct ds5 *primary = state->ds5_dev->ds5_primary;
+
+		if (!primary || !primary->dser_ops->recover_link)
+			return -ENODEV;
+
+		mutex_lock(&serdes_lock__);
+		ret = primary->ser_ops->reset_control(primary->ser_dev);
+		if (!ret)
+			ret = primary->dser_ops->recover_link(primary->dser_dev,
+						      primary->ser_dev);
+		if (!ret)
+			ret = primary->ser_ops->setup_control(primary->ser_dev);
+		if (!ret)
+			ret = primary->ser_ops->init_settings(primary->ser_dev);
+		mutex_unlock(&serdes_lock__);
+		if (ret) {
+			dev_err(&state->client->dev,
+				"%s(): D585 prototype SerDes recovery failed (%d)\n",
+				__func__, ret);
+			return ret;
+		}
+	}
+#endif
 
 	/* 6. Poll for control-status defaults to confirm reset completion. */
 	for (retry = 0, timeout = ts + msecs_to_jiffies(DS5_HW_RESET_TIMEOUT_MS);
@@ -3189,6 +3229,13 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 		dev_err(&state->client->dev,
 			"%s(): Failed to read firmware build: %d\n", __func__, ret);
 		return ret;
+	}
+
+	/* HKR reboot drops its MIPI TX runtime configuration. */
+	if (d585_proto_reset) {
+		ret = ds5_hw_init(state->client, state);
+		if (ret)
+			return ret;
 	}
 
 	dev_info(&state->client->dev,
@@ -3570,6 +3617,16 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 		if (ctrl->p_new.p_u8) {
 			u16 size = 0;
 			struct hwm_cmd *cmd = (struct hwm_cmd *)ctrl->p_new.p_u8;
+
+			u16 pid = READ_ONCE(state->ds5_dev->d585_product_id);
+
+			if (cmd->opcode == 0x20 &&
+			    (pid == D585_2C_PROTO_PID ||
+			     pid == D585_3C_PROTO_PID)) {
+				ret = ds5_hw_reset_with_recovery(state);
+				break;
+			}
+
 			size = *((u8 *)ctrl->p_new.p_u8 + 1) << 8;
 			size |= *((u8 *)ctrl->p_new.p_u8 + 0);
 			ret = ds5_hwmc_send(state, size + 4, cmd);
@@ -4566,6 +4623,7 @@ static void ds5_init_ds5_dev(struct ds5 *state, struct ds5_dev *ds5_dev)
 	ds5_dev->ds5_primary = state;
 	ds5_dev->serdes_setup_complete = false;
 	ds5_dev->cached_device_type = DS5_DEVICE_TYPE_UNKNOWN;
+	ds5_dev->d585_product_id = 0;
 	ds5_dev->configured_device_mode = D500_DEVICE_MODE_3C;
 	ds5_dev->active_device_mode = D500_DEVICE_MODE_3C;
 	ds5_dev->device_mode_valid = false;
@@ -7843,6 +7901,28 @@ static int ds5_probe(struct i2c_client *c
 			"%s(): device type is not valid: %d (last val 0x%x)\n",
 			__func__, ret, rec_state);
 		goto e_chardev;
+	}
+
+	if (rec_state == DS5_DEVICE_TYPE_D58X &&
+	    !READ_ONCE(state->ds5_dev->d585_product_id)) {
+		unsigned char *gvd_data = kzalloc(DS5_GVD_LEN_D5XX, GFP_KERNEL);
+
+		if (gvd_data) {
+			ret = ds5_gvd(state, gvd_data, DS5_GVD_LEN_D5XX);
+			if (ret) {
+				dev_warn(&c->dev,
+					 "%s(): cannot cache D585 PID from GVD (%d)\n",
+					 __func__, ret);
+			} else {
+				u16 pid = gvd_data[D585_GVD_PID_OFFSET] |
+					  (gvd_data[D585_GVD_PID_OFFSET + 1] << 8);
+
+				WRITE_ONCE(state->ds5_dev->d585_product_id, pid);
+				dev_info(&c->dev, "%s(): D585 PID 0x%04x\n",
+					 __func__, pid);
+			}
+			kfree(gvd_data);
+		}
 	}
 
 	ds5_read_with_check(state, DS5_FW_VERSION, &state->fw_version);

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -303,6 +303,12 @@ enum ds5_mux_pad {
  */
 #define DFU_MANIFEST_TIMEOUT_MS 180000
 
+/* Length/status reads (0x5004, 0x4e00) can briefly return 0xFFFF/0xFF while D58x
+ * is between manifest sub-states or under I2C contention; retry a bounded number
+ * of times before declaring the poll a failure. */
+#define DFU_STATUS_RETRY_MAX	5
+#define DFU_STATUS_RETRY_MS	20
+
 #define DS5_START_POLL_TIME	10
 #define DS5_START_MAX_TIME	2000
 #define DS5_START_MAX_COUNT	(DS5_START_MAX_TIME / DS5_START_POLL_TIME)
@@ -7002,13 +7008,31 @@ static int ds5_dfu_wait_for_get_dfu_status(struct ds5 *state,
 
 		} while (status);
 
-		ds5_read_with_check(state, 0x5004, &dfu_state_len);
+		/* Retry on transient garbage: length 0xFFFF or status 0xFF happens
+		 * when the read hits the D58x manifest-reset window or an I2C glitch;
+		 * a healthy poll returns on the first read. */
+		{
+			int retries;
+
+			for (retries = 0; retries < DFU_STATUS_RETRY_MAX; retries++) {
+				if (retries)
+					msleep_range(DFU_STATUS_RETRY_MS);
+				if (ds5_read_poll(state, 0x5004, &dfu_state_len))
+					continue;
+				if (dfu_state_len != DFU_WAIT_RET_LEN)
+					continue;
+				if (regmap_raw_read(state->regmap, 0x4e00,
+						dfu_asw_buf, DFU_WAIT_RET_LEN))
+					continue;
+				if (dfu_asw_buf[0] == 0)
+					break;
+			}
+		}
 		if (dfu_state_len != DFU_WAIT_RET_LEN) {
 			dev_err(&state->client->dev,
 					"%s(): Wrong answer len (%d)\n", __func__, dfu_state_len);
 			return -EINVAL;
 		}
-		ds5_raw_read_with_check(state, 0x4e00, &dfu_asw_buf, DFU_WAIT_RET_LEN);
 		if (dfu_asw_buf[0]) {
 			dev_err(&state->client->dev,
 					"%s(): Wrong dfu_status (%d)\n", __func__, dfu_asw_buf[0]);

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -139,6 +139,12 @@ struct ser_interface {
 #define DS5_DEVICE_TYPE_D45X		6
 #define DS5_DEVICE_TYPE_D43X		5
 #define DS5_DEVICE_TYPE_UNKNOWN		0
+/*
+ * FW version major byte identifies the family in recovery, where DEVICE_TYPE
+ * (0x0310) is not served: D58x reports 7 or 8, D4xx reports 5.
+ */
+#define DS5_D58X_FW_MAJOR_MIN		7
+#define DS5_D58X_FW_MAJOR_MAX		8
 
 /* GVD response payload size per product line */
 #define DS5_GVD_LEN_D4XX		276
@@ -285,6 +291,13 @@ enum ds5_mux_pad {
 #define PIPE_NOT_CONFIGURED	-1
 
 #define DFU_WAIT_RET_LEN 6
+
+/*
+ * Deadline for the D58x manifest wait; the manifest can legitimately take
+ * up to ~90 s, so the bound is generous and only guards against a device
+ * stuck in an intermediate manifest state.
+ */
+#define DFU_MANIFEST_TIMEOUT_MS 180000
 
 #define DS5_START_POLL_TIME	10
 #define DS5_START_MAX_TIME	2000
@@ -570,6 +583,7 @@ struct ds5_dfu_dev {
 	struct class *ds5_class;
 	int device_open_count;
 	enum dfu_state dfu_state_flag;
+	enum dfu_fw_state manifest_state;
 	unsigned char *dfu_msg;
 	u16 msg_write_once;
 	// unsigned char init_v4l_f; // need refactoring
@@ -6912,6 +6926,8 @@ static int ds5_dfu_wait_for_get_dfu_status(struct ds5 *state,
 	u16 status, dfu_state_len = 0x0000;
 	unsigned char dfu_asw_buf[DFU_WAIT_RET_LEN];
 	unsigned int dfu_wr_wait_msec = 0;
+	unsigned long manifest_deadline = jiffies +
+			msecs_to_jiffies(DFU_MANIFEST_TIMEOUT_MS);
 
 	do {
 		ds5_write_with_check(state, 0x5008, 0x0003); // Get Write state
@@ -6943,7 +6959,18 @@ static int ds5_dfu_wait_for_get_dfu_status(struct ds5 *state,
 		dfu_wr_wait_msec = (((unsigned int)dfu_asw_buf[3]) << 16)
 						| (((unsigned int)dfu_asw_buf[2]) << 8)
 						| dfu_asw_buf[1];
-	} while (dfu_asw_buf[4] == dfuDNBUSY && exp_state == dfuDNLOAD_IDLE);
+	/*
+	 * D58x manifestation runs dfuMANIFEST_SYNC -> dfuMANIFEST ->
+	 * dfuMANIFEST_WAIT_RESET; keep polling through the intermediate
+	 * states until the terminal wait-reset state is reached, bounded by
+	 * manifest_deadline so a stuck device errors out instead of hanging.
+	 */
+	} while ((dfu_asw_buf[4] == dfuDNBUSY &&
+		  exp_state == dfuDNLOAD_IDLE) ||
+		 ((dfu_asw_buf[4] == dfuMANIFEST_SYNC ||
+		   dfu_asw_buf[4] == dfuMANIFEST) &&
+		  exp_state == dfuMANIFEST_WAIT_RESET &&
+		  time_before(jiffies, manifest_deadline)));
 
 	if (dfu_asw_buf[4] != exp_state) {
 		dev_notice(&state->client->dev,
@@ -6979,6 +7006,7 @@ static int ds5_dfu_get_dev_info(struct ds5 *state, struct __fw_status *buf)
 static int ds5_dfu_detach(struct ds5 *state)
 {
 	int ret;
+	u8 fw_major;
 	struct __fw_status buf = {0};
 
 	ds5_write_with_check(state, 0x500c, 0x00);
@@ -6991,6 +7019,15 @@ static int ds5_dfu_detach(struct ds5 *state)
 			__func__, buf.FW_lastVersion);
 	dev_notice(&state->client->dev, "%s():FW status (%s)\n",
 			__func__, buf.DFU_isLocked ? "locked" : "unlocked");
+	/* Recovery never ran ds5_wait_device_type(), so use the known D58x FW
+	 * major range only as a DFU-session hint. Do not write cached_device_type:
+	 * that cache is reserved for a value read from DS5_DEVICE_TYPE and is also
+	 * used outside DFU for readiness and register routing.
+	 */
+	fw_major = (buf.FW_lastVersion >> 24) & 0xff;
+	if (!ret && fw_major >= DS5_D58X_FW_MAJOR_MIN &&
+	    fw_major <= DS5_D58X_FW_MAJOR_MAX)
+		state->dfu_dev.manifest_state = dfuMANIFEST_WAIT_RESET;
 	return ret;
 };
 
@@ -7039,6 +7076,21 @@ e_dfu_read_failed:
 	mutex_unlock(&state->lock);
 	return ret;
 };
+
+/* The caller must hold state->lock. */
+static int ds5_dfu_finalize_download(struct ds5 *state)
+{
+	enum dfu_fw_state manifest_state = state->dfu_dev.manifest_state;
+	int ret;
+
+	ret = ds5_write(state, 0x4a04, 0x00); /* Download complete */
+	if (!ret)
+		ret = ds5_dfu_wait_for_get_dfu_status(state, manifest_state);
+	if (!ret)
+		state->dfu_dev.dfu_state_flag = DS5_DFU_DONE;
+
+	return ret;
+}
 
 static ssize_t ds5_dfu_device_write(struct file *flip,
 		const char __user *buffer, size_t len, loff_t *offset)
@@ -7100,12 +7152,9 @@ static ssize_t ds5_dfu_device_write(struct file *flip,
 			if (!ret)
 				ret = ds5_dfu_wait_for_get_dfu_status(state, dfuDNLOAD_IDLE);
 			if (!ret)
-				ret = ds5_write(state, 0x4a04, 0x00); /*Download complete */
-			if (!ret)
-				ret = ds5_dfu_wait_for_get_dfu_status(state, dfuMANIFEST);
+				ret = ds5_dfu_finalize_download(state);
 			if (ret < 0)
 				goto dfu_write_error;
-			state->dfu_dev.dfu_state_flag = DS5_DFU_DONE;
 		}
 		if (len)
 			dev_notice(&state->client->dev, "%s(): DFU block (%d) bytes written\n",
@@ -7147,6 +7196,12 @@ static int ds5_dfu_device_open(struct inode *inode, struct file *file)
 	state->dfu_dev.device_open_count++;
 	if (state->dfu_dev.dfu_state_flag != DS5_DFU_RECOVERY)
 		state->dfu_dev.dfu_state_flag = DS5_DFU_OPEN;
+	/*
+	 * Operational probe has an authoritative type; recovery defaults to the
+	 * D4xx terminal state until ds5_dfu_detach() obtains a D58x-only hint.
+	 */
+	state->dfu_dev.manifest_state = ds5_is_d58x(state) ?
+		dfuMANIFEST_WAIT_RESET : dfuMANIFEST;
 	state->dfu_dev.dfu_msg = devm_kzalloc(&state->client->dev,
 			DFU_BLOCK_SIZE, GFP_KERNEL);
 	if (!state->dfu_dev.dfu_msg) {
@@ -7175,6 +7230,30 @@ static int ds5_dfu_device_open(struct inode *inode, struct file *file)
 	mutex_unlock(&state->lock);
 	return 0;
 };
+
+static int ds5_dfu_device_flush(struct file *file, fl_owner_t id)
+{
+	struct ds5 *state = file->private_data;
+	int ret = 0;
+
+	(void)id;
+	mutex_lock(&state->lock);
+	/* A partial block finalizes in write(). Use close as the end signal for an
+	 * aligned image because userspace may split it across multiple writes.
+	 */
+	if (state->dfu_dev.dfu_state_flag == DS5_DFU_IN_PROGRESS) {
+		ret = ds5_dfu_finalize_download(state);
+		if (ret < 0) {
+			state->dfu_dev.dfu_state_flag = DS5_DFU_ERROR;
+			/* Reset the DFU device to IDLE, matching the write error path. */
+			if (!ds5_write(state, 0x5010, 0x0))
+				state->dfu_dev.dfu_state_flag = DS5_DFU_IDLE;
+		}
+	}
+	mutex_unlock(&state->lock);
+
+	return ret;
+}
 
 /* Adjust sync_mode control range based on device type.
  * Must be called after ds5_mux_init() which creates the control.
@@ -7381,6 +7460,7 @@ static const struct file_operations ds5_device_file_ops = {
 	.read = &ds5_dfu_device_read,
 	.write = &ds5_dfu_device_write,
 	.open = &ds5_dfu_device_open,
+	.flush = &ds5_dfu_device_flush,
 	.release = &ds5_dfu_device_release
 };
 

--- a/nvidia-oot/6.0/0003-Adding-max96712-support-for-D4xx.patch
+++ b/nvidia-oot/6.0/0003-Adding-max96712-support-for-D4xx.patch
@@ -1,17 +1,14 @@
-From ede2412e2c450275116a819838363a628c560f61 Mon Sep 17 00:00:00 2001
+From 47fc47cb15083c01599e6a043cf65eedcf36513e Mon Sep 17 00:00:00 2001
 From: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 Date: Wed, 5 Aug 2026 08:21:23 +0300
 Subject: [PATCH] Adding max96712 support for D4xx
 
-Add MAX96712 deserializer driver support for D4XX/D5XX cameras.
-
-Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- drivers/media/i2c/max96712.c | 940 +++++++++++++++++++++++++++++++++--
- 1 file changed, 905 insertions(+), 35 deletions(-)
+ drivers/media/i2c/max96712.c | 1032 ++++++++++++++++++++++++++++++++--
+ 1 file changed, 997 insertions(+), 35 deletions(-)
 
 diff --git a/drivers/media/i2c/max96712.c b/drivers/media/i2c/max96712.c
-index 8e237eef..12729a1e 100644
+index 8e237eef..c3351352 100644
 --- a/drivers/media/i2c/max96712.c
 +++ b/drivers/media/i2c/max96712.c
 @@ -16,32 +16,162 @@
@@ -199,7 +196,7 @@ index 8e237eef..12729a1e 100644
  	i2c_client = global_priv[channel]->i2c_client;
  	bak = i2c_client->addr;
  	i2c_client->addr = slaveAddr / 2;
-@@ -80,11 +207,56 @@ int max96712_read_reg_Dser(int slaveAddr, int channel,
+@@ -80,11 +207,53 @@ int max96712_read_reg_Dser(int slaveAddr, int channel,
  		dev_err(&i2c_client->dev, "%s: addr = 0x%x, val = 0x%x\n",
  				__func__, addr, *val);
  	}
@@ -208,6 +205,7 @@ index 8e237eef..12729a1e 100644
  }
  EXPORT_SYMBOL(max96712_read_reg_Dser);
  
++/* Caller holds priv->lock while the shared I2C client address is redirected. */
 +static int max96712_read_slave_reg(struct max96712 *priv,
 +			int ShortSlaveAddr, u16 addr, unsigned int *val)
 +{
@@ -216,7 +214,6 @@ index 8e237eef..12729a1e 100644
 +	int bak = i2c_client->addr;
 +	unsigned int value = 0;
 +
-+	mutex_lock(&priv->lock);
 +	i2c_client->addr = ShortSlaveAddr;
 +	err = regmap_read(priv->regmap, addr, &value);
 +	i2c_client->addr = bak;
@@ -226,7 +223,6 @@ index 8e237eef..12729a1e 100644
 +			__func__, ShortSlaveAddr, addr);
 +	usleep_range(100, 110);
 +	*val = value;
-+	mutex_unlock(&priv->lock);
 +
 +	return err;
 +}
@@ -238,7 +234,6 @@ index 8e237eef..12729a1e 100644
 +	int err;
 +	int bak = i2c_client->addr;
 +
-+	mutex_lock(&priv->lock);
 +	i2c_client->addr = ShortSlaveAddr;
 +	err = regmap_write(priv->regmap, addr, val);
 +	i2c_client->addr = bak;
@@ -249,7 +244,6 @@ index 8e237eef..12729a1e 100644
 +
 +	/* delay before next i2c command as required for SERDES link */
 +	usleep_range(100, 110);
-+	mutex_unlock(&priv->lock);
 +
 +	return err;
 +}
@@ -257,7 +251,7 @@ index 8e237eef..12729a1e 100644
  static int max96712_read_reg(struct max96712 *priv,
  			u16 addr, unsigned int *val)
  {
-@@ -99,6 +271,20 @@ static int max96712_read_reg(struct max96712 *priv,
+@@ -99,6 +268,20 @@ static int max96712_read_reg(struct max96712 *priv,
  	return err;
  }
  
@@ -278,7 +272,7 @@ index 8e237eef..12729a1e 100644
  
  static int max96712_stats_show(struct seq_file *s, void *data)
  {
-@@ -153,24 +339,6 @@ static const struct file_operations max96712_debugfs_fops = {
+@@ -153,24 +336,6 @@ static const struct file_operations max96712_debugfs_fops = {
  	.release = single_release,
  };
  
@@ -303,7 +297,7 @@ index 8e237eef..12729a1e 100644
  static int max96712_debugfs_init(const char *dir_name,
  				struct dentry **d_entry,
  				struct dentry **f_entry,
-@@ -225,7 +393,8 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -225,7 +390,8 @@ static int max96712_debugfs_init(const char *dir_name,
  static  struct regmap_config max96712_regmap_config = {
  	.reg_bits = 16,
  	.val_bits = 8,
@@ -313,7 +307,7 @@ index 8e237eef..12729a1e 100644
  };
  
  #if defined(NV_I2C_DRIVER_STRUCT_PROBE_WITHOUT_I2C_DEVICE_ID_ARG) /* Linux 6.3 */
-@@ -237,10 +406,16 @@ static int max96712_probe(struct i2c_client *client,
+@@ -237,10 +403,16 @@ static int max96712_probe(struct i2c_client *client,
  {
  	struct max96712 *priv;
  	int err = 0;
@@ -330,7 +324,7 @@ index 8e237eef..12729a1e 100644
  	priv->i2c_client = client;
  	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
  				&max96712_regmap_config);
-@@ -249,15 +424,55 @@ static int max96712_probe(struct i2c_client *client,
+@@ -249,15 +421,55 @@ static int max96712_probe(struct i2c_client *client,
  			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
  		return -ENODEV;
  	}
@@ -391,7 +385,7 @@ index 8e237eef..12729a1e 100644
  	err = max96712_debugfs_init(NULL, NULL, NULL, priv);
  	if (err)
  		return err;
-@@ -274,8 +489,11 @@ static int max96712_remove(struct i2c_client *client)
+@@ -274,8 +486,11 @@ static int max96712_remove(struct i2c_client *client)
  static void max96712_remove(struct i2c_client *client)
  #endif
  {
@@ -404,7 +398,7 @@ index 8e237eef..12729a1e 100644
  		i2c_unregister_device(client);
  		client = NULL;
  	}
-@@ -284,13 +502,664 @@ static void max96712_remove(struct i2c_client *client)
+@@ -284,13 +499,759 @@ static void max96712_remove(struct i2c_client *client)
  #endif
  }
  
@@ -608,10 +602,14 @@ index 8e237eef..12729a1e 100644
 +}
 +EXPORT_SYMBOL(max96712_release_pipe);
 +
-+static void max96712_reset_oneshot_link_mask(struct max96712 *priv, uint8_t link_mask)
++static int max96712_reset_oneshot_link_mask(struct max96712 *priv, uint8_t link_mask)
 +{
-+	max96712_write_reg(priv, MAX96712_CTRL1_ADDR, link_mask);
++	int err = max96712_write_reg(priv, MAX96712_CTRL1_ADDR, link_mask);
++
++	if (err)
++		return err;
 +	msleep(100);
++	return 0;
 +}
 +
 +void max96712_reset_oneshot(struct device *dev)
@@ -704,6 +702,7 @@ index 8e237eef..12729a1e 100644
 +	int link_id = vc_id / MAX9295_MAX_STREAMS;
 +	uint32_t map_pipe_offs = 0x40 * pipe_id;
 +	uint32_t ext_vc_offs = 0x10 * pipe_id;
++	unsigned int pipe_en_val = 0;
 +
 +	struct reg_pair map_pipe_control[] = {
 +		// Enable all static mappings
@@ -772,7 +771,13 @@ index 8e237eef..12729a1e 100644
 +		return err;
 +	}
 +
-+	max96712_write_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, 1 << pipe_id);
++	err |= max96712_read_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR,
++				       &pipe_en_val);
++	if (!err) {
++		pipe_en_val |= BIT(pipe_id);
++		err = max96712_write_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR,
++					 pipe_en_val);
++	}
 +
 +	return err;
 +}
@@ -936,6 +941,8 @@ index 8e237eef..12729a1e 100644
 +	unsigned default_ser_addr = MAX9295_DEFAULT_ADDR;
 +	int err = 0;
 +
++	mutex_lock(&priv->lock);
++
 +	/* Iterating over the links and assigning unique serializer i2c addresses */
 +	for (link_id_iter = 0; link_id_iter < MAX96712_MAX_LINKS ; link_id_iter++)
 +	{
@@ -962,9 +969,91 @@ index 8e237eef..12729a1e 100644
 +		}
 +	}
 +	max96712_write_reg(priv, MAX96712_REG6_ADDR, dser_empty_link_mask_reg | link_mask);
++	mutex_unlock(&priv->lock);
 +	return 0;
 +}
 +EXPORT_SYMBOL(max96712_setup_link);
++
++#define MAX96712_RECOVER_MAX_RETRIES	20
++#define MAX96712_RECOVER_RETRY_DELAY_MS	100
++
++int max96712_recover_link(struct device *dev, struct device *ser_dev)
++{
++	struct max96712 *priv = dev_get_drvdata(dev);
++	struct i2c_client *ser_client = to_i2c_client(ser_dev);
++	unsigned int link_id;
++	unsigned int reg_val = 0;
++	u8 target_addr;
++	int restore_err;
++	int err;
++	int retry;
++
++	target_addr = ser_client->addr;
++	if (target_addr < MAX9295_DEFAULT_ADDR ||
++	    target_addr >= MAX9295_DEFAULT_ADDR + MAX96712_MAX_LINKS)
++		return -EINVAL;
++	link_id = target_addr - MAX9295_DEFAULT_ADDR;
++	if (!(priv->link_mask & BIT(link_id)))
++		return -EINVAL;
++
++	mutex_lock(&priv->lock);
++
++	/* Isolate the requested link so a serializer at the default address
++	 * cannot collide with a serializer on another camera module.
++	 */
++	err = max96712_write_reg(priv, MAX96712_REG6_ADDR,
++				   0xF0 | BIT(link_id));
++	if (!err) {
++		msleep(20);
++		err = max96712_reset_oneshot_link_mask(priv, BIT(link_id));
++	}
++
++	if (!err) {
++		/* HKR powers the serializer only after its reboot and GMSL startup.
++		 * Poll the isolated link instead of assuming the fixed host-side delay
++		 * was long enough. Non-zero links may also need address reassignment.
++		 */
++		for (retry = 0; retry < MAX96712_RECOVER_MAX_RETRIES; retry++) {
++			reg_val = 0;
++			err = max96712_read_slave_reg(priv, target_addr, 0, &reg_val);
++			if (!err && reg_val == target_addr << 1)
++				break;
++
++			if (target_addr != MAX9295_DEFAULT_ADDR) {
++				reg_val = 0;
++				err = max96712_read_slave_reg(priv,
++					MAX9295_DEFAULT_ADDR, 0, &reg_val);
++				if (!err && reg_val == MAX9295_DEFAULT_ADDR << 1) {
++					err = max96712_write_slave_reg(priv,
++						MAX9295_DEFAULT_ADDR, 0,
++						target_addr << 1);
++					if (!err)
++						msleep(20);
++				}
++			}
++
++			if (retry < MAX96712_RECOVER_MAX_RETRIES - 1)
++				msleep(MAX96712_RECOVER_RETRY_DELAY_MS);
++		}
++		if (retry == MAX96712_RECOVER_MAX_RETRIES)
++			err = -ETIMEDOUT;
++	}
++
++	restore_err = max96712_write_reg(priv, MAX96712_REG6_ADDR,
++					     0xF0 | priv->link_mask);
++	if (!err)
++		err = restore_err;
++	if (!err && priv->link_multi_vc_pipe[link_id] >= 0) {
++		/* The serializer video path was reset. Reapply this link's complete
++		 * multi-VC mapping on the first post-recovery stream start. */
++		priv->multi_vc_configured[
++			priv->link_multi_vc_pipe[link_id]] = false;
++	}
++
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96712_recover_link);
 +
 +int max96712_setup_control(struct device *dev, struct device *s_dev)
 +{
@@ -1070,7 +1159,7 @@ index 8e237eef..12729a1e 100644
  	{ },
  };
  
-@@ -300,6 +1169,7 @@ static struct i2c_driver max96712_i2c_driver = {
+@@ -300,6 +1261,7 @@ static struct i2c_driver max96712_i2c_driver = {
  	.driver = {
  		.name = "max96712",
  		.owner = THIS_MODULE,
@@ -1078,6 +1167,3 @@ index 8e237eef..12729a1e 100644
  	},
  	.probe = max96712_probe,
  	.remove = max96712_remove,
--- 
-2.43.0
-

--- a/nvidia-oot/max96712.h
+++ b/nvidia-oot/max96712.h
@@ -45,6 +45,7 @@ void max96712_reset_oneshot(struct device *dev);
  * called per-link from d4xx's ds5_hw_reset_with_recovery(). */
 void max96712_reset_oneshot_link(struct device *dev, u32 vc_id);
 int max96712_setup_link(struct device *dev, struct device *s_dev);
+int max96712_recover_link(struct device *dev, struct device *ser_dev);
 int max96712_setup_control(struct device *dev, struct device *s_dev);
 int max96712_reset_control(struct device *dev, struct device *s_dev);
 int max96712_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx);

--- a/nvidia-oot/max96724.c
+++ b/nvidia-oot/max96724.c
@@ -699,6 +699,69 @@ static int max96724_assign_serializer_addresses(struct device *dev)
 	return err;
 }
 
+int max96724_recover_link(struct device *dev, struct device *ser_dev)
+{
+	struct i2c_client *ser_client;
+	struct max96724 *priv;
+	unsigned int reg_val = 0;
+	unsigned int link;
+	u16 dev_reg = MAX96717_DEV_ADDR;
+	u8 target_addr;
+	int restore_err;
+	int err;
+
+	if (!dev || !ser_dev)
+		return -EINVAL;
+
+	priv = dev_get_drvdata(dev);
+	if (!priv)
+		return -ENODEV;
+	ser_client = to_i2c_client(ser_dev);
+
+	target_addr = ser_client->addr;
+	if (target_addr < MAX96717_DEFAULT_ADDR ||
+	    target_addr >= MAX96717_DEFAULT_ADDR + MAX96724_MAX_LINKS)
+		return -EINVAL;
+
+	link = target_addr - MAX96717_DEFAULT_ADDR;
+	if (!(priv->link_mask & BIT(link)))
+		return -EINVAL;
+
+	mutex_lock(&priv->lock);
+
+	/*
+	 * Select only the reset camera's link while its serializer is back at
+	 * the default address, then retrain that link without resetting the
+	 * shared deserializer. Other enabled links are briefly gated and restored
+	 * before this function returns.
+	 */
+	err = max96724_enable_links(dev, BIT(link), true);
+	if (!err)
+		err = max96724_wait_link_lock(dev, link);
+	if (!err) {
+		err = max96724_read_slave_reg(priv, target_addr, dev_reg, &reg_val);
+		if (err || reg_val != target_addr << 1) {
+			err = max96724_write_slave_reg(priv, MAX96717_DEFAULT_ADDR,
+						       dev_reg,
+						       target_addr << 1);
+			if (!err) {
+				msleep(20);
+				err = max96724_read_slave_reg(priv, target_addr, dev_reg, &reg_val);
+				if (!err && reg_val != target_addr << 1)
+					err = -ENODEV;
+			}
+		}
+	}
+
+	restore_err = max96724_enable_links(dev, priv->link_mask, false);
+	if (!err)
+		err = restore_err;
+
+	mutex_unlock(&priv->lock);
+	return err;
+}
+EXPORT_SYMBOL(max96724_recover_link);
+
 int max96724_setup_link(struct device *dev, struct device *s_dev)
 {
 	struct max96724 *priv = dev_get_drvdata(dev);

--- a/nvidia-oot/max96724.h
+++ b/nvidia-oot/max96724.h
@@ -81,6 +81,20 @@ int max96724_setup_control(struct device *dev, struct device *s_dev);
 int max96724_reset_control(struct device *dev, struct device *s_dev);
 
 /**
+ * @brief  Restores one serializer link after a remote power cycle.
+ *
+ * The target link is selected from the serializer's assigned I2C address.
+ * Other enabled links are briefly gated for address isolation, then restored;
+ * the shared deserializer is not reset or fully reconfigured.
+ *
+ * @param  [in]  dev          The deserializer device handle.
+ * @param  [in]  ser_dev      The serializer device handle.
+ *
+ * @return  0 for success, or negative error code.
+ */
+int max96724_recover_link(struct device *dev, struct device *ser_dev);
+
+/**
  * @brief  Registers a source sensor device with the deserializer.
  *
  * @param  [in]  dev          The deserializer device handle.


### PR DESCRIPTION
## Purpose

Staging branch that combines the three open D585-DFU-related driver PRs on top of the latest \`dev\`, so the end-to-end DFU flow can be validated on hardware as one image. **This PR is not intended to merge**; #564, #606 and #595 stay open and get merged independently once this bundle validates on the D585 rig.

Same shape as PR #614 (which bundled #564 + #606), plus #595's transient-0xFFFF retry — the missing piece that PR #614 hit under viewer DFU.

## Included

- **#564** — \`[RSDEV-13621][D58x] Wait for DFU manifest-wait-reset state\`
  Kernel-side handling of the D58x-specific \`dfuMANIFEST_WAIT_RESET (0x0008)\` terminal state.
- **#606** — \`Recover D585 prototype after hardware reset\`
  Post-reset re-probe of the D585 prototype (max96712 patches + d4xx re-probe path + max96724 support files).
- **#595** — \`dfu: retry transient 0xFFFF/0xFF status polls in ds5_dfu_wait_for_get_dfu_status\`
  Bounded 5 × 20 ms retry loop that swallows transient \`Wrong answer len (65535)\` and \`Wrong dfu_status (255)\` when the FW's DFU response registers haven't yet been populated at the moment the driver polls.

## Base

- Rebased on \`origin/dev\` at \`c8dd114\` (Auto-increment version to 1.0.6.7).
- Cherry-picked all three PRs; one merge in \`kernel/realsense/d4xx.c\`'s constants block resolved by keeping both (additive constants). \`ds5_dfu_wait_for_get_dfu_status\` now has both PR #564's outer-loop condition (poll through MANIFEST_SYNC/MANIFEST until WAIT_RESET) and PR #595's inner retry loop.

## Diff summary

Same 8 files as PR #614, plus #595's ~26 lines inside \`ds5_dfu_wait_for_get_dfu_status\`.

## Test plan

- [ ] Build all supported JetPack versions (5.0.2, 5.1.2, 6.0, 6.1, 6.2, 6.2.1) via \`apply_patches.sh\` + \`build_all.sh\`.
- [ ] Deploy to D585 GMSL rig; run \`realsense-viewer\` DFU (with librealsense PR #15575) end-to-end.
- [ ] No \`Wrong answer len (65535)\` or \`Wrong dfu_status (255)\` errors in dmesg during the write (validates #595's retry landing where #564 poll lands).
- [ ] Post-DFU: \`sudo rmmod d4xx && sudo modprobe d4xx\` — D585 re-probes with new FW (validates #606 recovery path).
- [ ] D457 GMSL DFU still works (regression check for #606's max96712 patch changes).

## Do NOT merge

Close this once #564, #606 and #595 have merged individually.