### PR TITLE
Add mixed D5xx + 3x D4xx overlay for FangZhu FG12-4CH

### DIFF
--- a/README_JP6.0.md
+++ b/README_JP6.0.md
@@ -176,6 +176,7 @@ sudo ln -s /boot/initrd.img-5.15.136-tegra /boot/initrd
     | `tegra234-camera-d4xx-overlay-max96712-EVB.dtbo` | max96712 evaluation board |
     | `tegra234-camera-d4xx-overlay-max96712-EVB-cams-0-1.dtbo` | max96712 evaluation board w/ two connected cameras |
     | `tegra234-camera-d4xx-overlay-fg12-4ch-d5xx.dtbo` | Fangzhu fg12-4ch board with a single D5xx camera (max96717 serializer, 4-lane) connected to link A |
+    | `tegra234-camera-d4xx-overlay-fg12-4ch-cams-0-1-2-3-d5xx-d4xx.dtbo` | Fangzhu fg12-4ch board with a D5xx (D585) on cam0 (link A, max96717, 4-lane) and three D4xx on cam1-3 (links B/C/D, max9295, 2-lane) sharing one deserializer |
     | `tegra234-camera-d4xx-overlay-fg12-16ch.dtbo` | Fangzhu fg12-16ch board with a single camera connected to cam0 |
     | `tegra234-camera-d4xx-overlay-fg12-16ch-d5xx.dtbo` | Fangzhu fg12-16ch board with a single D5xx camera (max96717 serializer, 4-lane) connected to cam0 |
     | `tegra234-camera-d4xx-overlay-fg12-16ch-cams-0-1.dtbo` | Fangzhu fg12-16ch board with two cameras connected to cam0 & cam1 |

--- a/README_JP6.2.md
+++ b/README_JP6.2.md
@@ -176,6 +176,7 @@ sudo ln -s /boot/initrd.img-5.15.148-tegra /boot/initrd
     | `tegra234-camera-d4xx-overlay-max96712-EVB.dtbo` | max96712 evaluation board |
     | `tegra234-camera-d4xx-overlay-max96712-EVB-cams-0-1.dtbo` | max96712 evaluation board w/ two connected cameras |
     | `tegra234-camera-d4xx-overlay-fg12-4ch-d5xx.dtbo` | Fangzhu fg12-4ch board with a single D5xx camera (max96717 serializer, 4-lane) connected to link A |
+    | `tegra234-camera-d4xx-overlay-fg12-4ch-cams-0-1-2-3-d5xx-d4xx.dtbo` | Fangzhu fg12-4ch board with a D5xx (D585) on cam0 (link A, max96717, 4-lane) and three D4xx on cam1-3 (links B/C/D, max9295, 2-lane) sharing one deserializer |
     | `tegra234-camera-d4xx-overlay-fg12-16ch.dtbo` | Fangzhu fg12-16ch board with a single camera connected to cam0 |
     | `tegra234-camera-d4xx-overlay-fg12-16ch-d5xx.dtbo` | Fangzhu fg12-16ch board with a single D5xx camera (max96717 serializer, 4-lane) connected to cam0 |
     | `tegra234-camera-d4xx-overlay-fg12-16ch-cams-0-1.dtbo` | Fangzhu fg12-16ch board with two cameras connected to cam0 & cam1 |

--- a/hardware/nvidia/t23x/nv-public/6.x/0001-overlay-enable-d4xx-camera-for-Orin-jp6.patch
+++ b/hardware/nvidia/t23x/nv-public/6.x/0001-overlay-enable-d4xx-camera-for-Orin-jp6.patch
@@ -5,14 +5,14 @@ Subject: [PATCH] overlay: enable d4xx camera for Orin jp6
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- overlay/Makefile | 24 ++++++++++++++++++++++++
- 1 file changed, 24 insertions(+)
+ overlay/Makefile | 25 +++++++++++++++++++++++++
+ 1 file changed, 25 insertions(+)
 
 diff --git a/overlay/Makefile b/overlay/Makefile
 index c88bbe2..cdd125f 100644
 --- a/overlay/Makefile
 +++ b/overlay/Makefile
-@@ -60,6 +60,30 @@ dtbo-y += tegra234-p3767-camera-p3768-imx219-A.dtbo
+@@ -60,6 +60,31 @@ dtbo-y += tegra234-p3767-camera-p3768-imx219-A.dtbo
  dtbo-y += tegra234-p3767-camera-p3768-imx219-imx477.dtbo
  dtbo-y += tegra234-p3767-camera-p3768-imx477-C.dtbo
  dtbo-y += tegra234-p3767-camera-p3768-imx477-A.dtbo
@@ -23,6 +23,7 @@ index c88bbe2..cdd125f 100644
 +dtbo-y += tegra234-camera-d4xx-overlay-fg12-4ch.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay-fg12-4ch-d5xx.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay-fg12-4ch-cams-0-1-2-3.dtbo
++dtbo-y += tegra234-camera-d4xx-overlay-fg12-4ch-cams-0-1-2-3-d5xx-d4xx.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay-fg12-16ch.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay-fg12-16ch-d5xx.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay-fg12-16ch-PWR-only.dtbo

--- a/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-4ch-cams-0-1-2-3-d5xx-d4xx.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-4ch-cams-0-1-2-3-d5xx-d4xx.dts
@@ -1,0 +1,1690 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: Copyright (c) 2018-2023, INTEL CORPORATION.  All rights reserved.
+
+/*
+ * Mixed RealSense overlay for the FangZhu FG12-4CH carrier board on
+ * NVIDIA Jetson Orin Nano (p3768-0000 + p3767-xxxx):
+ * cam0 = D5xx (D585), cam1..cam3 = D4xx (D457).
+ *
+ * Board topology:
+ *   cam0: D5xx --CSI-2 4-lane--> MAX96717 serializer (0x40, link A)
+ *   cam1-3: D4xx x3 --CSI-2 2-lane--> MAX9295 serializers (0x41..0x43,
+ *   links B/C/D); all four --GMSL2--> MAX96712 deserializer (0x29)
+ *   --CSI-2 4-lane--> Orin Nano CSI port C (port-index = 2 / serial_c),
+ *   16 virtual channels (4 per camera).
+ *
+ * Derived from the verified 4-camera FG12-4CH overlay
+ * (tegra234-camera-d4xx-overlay-fg12-4ch-cams-0-1-2-3.dts) with link A
+ * converted to D5xx per the verified mixed FG12-16CH overlay
+ * (tegra234-camera-d4xx-overlay-fg12-16ch-cams-0-1-d5xx-d4xx.dts):
+ *  - cam0 sensor nodes are compatible "realsense,d5xx" with 4-lane
+ *    camera-to-serializer CSI (bus-width / gmsl-link num-lanes = 4).
+ *  - cam1..3 keep the hybrid D4xx config (2-lane camera CSI).
+ * The FangZhu-specific MAX96712 hooks (fg12-poc-enable /
+ * fg12-reverse-lane-polarity) and the GPIO-selected camera I2C mux
+ * (cam_i2cmux / i2c@1) are kept from the verified FG12-4CH overlay.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/clock/tegra234-clock.h>
+#include <dt-bindings/gpio/tegra234-gpio.h>
+#include <dt-bindings/tegra234-p3767-0000-common.h>
+
+/* camera control gpio definitions (from official FangZhu FG12-4CH device tree) */
+#define CAM0_SYNC	TEGRA234_MAIN_GPIO(H, 6)
+#define CAM1_SYNC	TEGRA234_MAIN_GPIO(AC, 0)
+#define CAM_I2C_MUX	TEGRA234_AON_GPIO(CC, 3)
+
+/ {
+	overlay-name = "Jetson RealSense D5xx (link a) + 3x D4xx (links b/c/d) with max96712 for FangZhu FG12-4CH on Orin Nano";
+	jetson-header-name = "Jetson 22pin CSI Connector";
+	compatible = JETSON_COMPATIBLE_P3768;
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			tegra-capture-vi {
+				num-channels = <16>;
+				ports {
+					status = "okay";
+					port@0 {
+						status = "okay";
+						reg = <0>;
+						d4xx_vi_in0: endpoint {
+							status = "okay";
+							vc-id = <0>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d4xx_csi_out0>;
+						};
+					};
+					port@1 {
+						status = "okay";
+						reg = <1>;
+						d4xx_vi_in1: endpoint {
+							status = "okay";
+							vc-id = <1>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d4xx_csi_out1>;
+						};
+					};
+					port@2 {
+						status = "okay";
+						reg = <2>;
+						d4xx_vi_in2: endpoint {
+							status = "okay";
+							vc-id = <2>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d4xx_csi_out2>;
+						};
+					};
+					port@3 {
+						status = "okay";
+						reg = <3>;
+						d4xx_vi_in3: endpoint {
+							status = "okay";
+							vc-id = <3>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d4xx_csi_out3>;
+						};
+					};
+					port@4 {
+						status = "okay";
+						reg = <4>;
+						d4xx_vi_in4: endpoint {
+							status = "okay";
+							vc-id = <4>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d4xx_csi_out4>;
+						};
+					};
+					port@5 {
+						status = "okay";
+						reg = <5>;
+						d4xx_vi_in5: endpoint {
+							status = "okay";
+							vc-id = <5>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d4xx_csi_out5>;
+						};
+					};
+					port@6 {
+						status = "okay";
+						reg = <6>;
+						d4xx_vi_in6: endpoint {
+							status = "okay";
+							vc-id = <6>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d4xx_csi_out6>;
+						};
+					};
+					port@7 {
+						status = "okay";
+						reg = <7>;
+						d4xx_vi_in7: endpoint {
+							status = "okay";
+							vc-id = <7>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d4xx_csi_out7>;
+						};
+					};
+					port@8 {
+						status = "okay";
+						reg = <8>;
+						d4xx_vi_in8: endpoint {
+							status = "okay";
+							vc-id = <8>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d4xx_csi_out8>;
+						};
+					};
+					port@9 {
+						status = "okay";
+						reg = <9>;
+						d4xx_vi_in9: endpoint {
+							status = "okay";
+							vc-id = <9>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d4xx_csi_out9>;
+						};
+					};
+					port@10 {
+						status = "okay";
+						reg = <10>;
+						d4xx_vi_in10: endpoint {
+							status = "okay";
+							vc-id = <10>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d4xx_csi_out10>;
+						};
+					};
+					port@11 {
+						status = "okay";
+						reg = <11>;
+						d4xx_vi_in11: endpoint {
+							status = "okay";
+							vc-id = <11>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d4xx_csi_out11>;
+						};
+					};
+					port@12 {
+						status = "okay";
+						reg = <12>;
+						d4xx_vi_in12: endpoint {
+							status = "okay";
+							vc-id = <12>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d4xx_csi_out12>;
+						};
+					};
+					port@13 {
+						status = "okay";
+						reg = <13>;
+						d4xx_vi_in13: endpoint {
+							status = "okay";
+							vc-id = <13>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d4xx_csi_out13>;
+						};
+					};
+					port@14 {
+						status = "okay";
+						reg = <14>;
+						d4xx_vi_in14: endpoint {
+							status = "okay";
+							vc-id = <14>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d4xx_csi_out14>;
+						};
+					};
+					port@15 {
+						status = "okay";
+						reg = <15>;
+						d4xx_vi_in15: endpoint {
+							status = "okay";
+							vc-id = <15>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d4xx_csi_out15>;
+						};
+					};
+				};
+			};
+			tegra-camera-platform {
+				compatible = "nvidia, tegra-camera-platform";
+				status = "okay";
+				num_csi_lanes = <4>;
+				max_lane_speed = <1500000>;
+				min_bits_per_pixel = <8>;
+				vi_peak_byte_per_pixel = <2>;
+				vi_bw_margin_pct = <25>;
+				max_pixel_rate = <160000>;
+				isp_peak_byte_per_pixel = <5>;
+				isp_bw_margin_pct = <25>;
+				modules {
+					status = "okay";
+					module0 {
+						status = "okay";
+						badge = "d5xx_depth";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-001a";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ds5@1a";
+						};
+					};
+					module1 {
+						status = "okay";
+						badge = "d5xx_rgb";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-001b";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ds5@1b";
+						};
+					};
+					module2 {
+						status = "okay";
+						badge = "d5xx_Y8";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-001c";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ds5@1c";
+						};
+					};
+					module3 {
+						status = "okay";
+						badge = "d5xx_imu";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-001d";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ds5@1d";
+						};
+					};
+					module4 {
+						status = "okay";
+						badge = "d4xx_depth";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-002a";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ds5@2a";
+						};
+					};
+					module5 {
+						status = "okay";
+						badge = "d4xx_rgb";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-002b";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ds5@2b";
+						};
+					};
+					module6 {
+						status = "okay";
+						badge = "d4xx_Y8";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-002c";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ds5@2c";
+						};
+					};
+					module7 {
+						status = "okay";
+						badge = "d4xx_imu";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-002d";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ds5@2d";
+						};
+					};
+					module8 {
+						status = "okay";
+						badge = "d4xx_depth";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-003a";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ds5@3a";
+						};
+					};
+					module9 {
+						status = "okay";
+						badge = "d4xx_rgb";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-003b";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ds5@3b";
+						};
+					};
+					module10 {
+						status = "okay";
+						badge = "d4xx_Y8";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-003c";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ds5@3c";
+						};
+					};
+					module11 {
+						status = "okay";
+						badge = "d4xx_imu";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-003d";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ds5@3d";
+						};
+					};
+					module12 {
+						status = "okay";
+						badge = "d4xx_depth";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-004a";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ds5@4a";
+						};
+					};
+					module13 {
+						status = "okay";
+						badge = "d4xx_rgb";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-004b";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ds5@4b";
+						};
+					};
+					module14 {
+						status = "okay";
+						badge = "d4xx_Y8";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-004c";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ds5@4c";
+						};
+					};
+					module15 {
+						status = "okay";
+						badge = "d4xx_imu";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-004d";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ds5@4d";
+						};
+					};
+				};
+			};
+			bus@0 {
+				host1x@13e00000 {
+					nvcsi@15a00000 {
+						num-channels = <16>;
+						channel@0 {
+							status = "okay";
+							reg = <0>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in0: endpoint@0 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&ds5_0_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out0: endpoint@1 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in0>;
+									};
+								};
+							};
+						};
+						channel@1 {
+							status = "okay";
+							reg = <1>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in1: endpoint@2 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&ds5_1_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out1: endpoint@3 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in1>;
+									};
+								};
+							};
+						};
+						channel@2 {
+							status = "okay";
+							reg = <2>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in2: endpoint@4 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&ds5_2_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out2: endpoint@5 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in2>;
+									};
+								};
+							};
+						};
+						channel@3 {
+							status = "okay";
+							reg = <3>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in3: endpoint@6 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&ds5_3_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out3: endpoint@7 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in3>;
+									};
+								};
+							};
+						};
+						channel@4 {
+							status = "okay";
+							reg = <4>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in4: endpoint@8 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&ds5_4_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out4: endpoint@9 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in4>;
+									};
+								};
+							};
+						};
+						channel@5 {
+							status = "okay";
+							reg = <5>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in5: endpoint@10 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&ds5_5_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out5: endpoint@11 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in5>;
+									};
+								};
+							};
+						};
+						channel@6 {
+							status = "okay";
+							reg = <6>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in6: endpoint@12 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&ds5_6_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out6: endpoint@13 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in6>;
+									};
+								};
+							};
+						};
+						channel@7 {
+							status = "okay";
+							reg = <7>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in7: endpoint@14 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&ds5_7_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out7: endpoint@15 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in7>;
+									};
+								};
+							};
+						};
+						channel@8 {
+							status = "okay";
+							reg = <8>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in8: endpoint@16 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&ds5_8_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out8: endpoint@17 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in8>;
+									};
+								};
+							};
+						};
+						channel@9 {
+							status = "okay";
+							reg = <9>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in9: endpoint@18 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&ds5_9_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out9: endpoint@19 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in9>;
+									};
+								};
+							};
+						};
+						channel@10 {
+							status = "okay";
+							reg = <10>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in10: endpoint@20 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&ds5_10_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out10: endpoint@21 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in10>;
+									};
+								};
+							};
+						};
+						channel@11 {
+							status = "okay";
+							reg = <11>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in11: endpoint@22 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&ds5_11_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out11: endpoint@23 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in11>;
+									};
+								};
+							};
+						};
+						channel@12 {
+							status = "okay";
+							reg = <12>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in12: endpoint@24 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&ds5_12_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out12: endpoint@25 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in12>;
+									};
+								};
+							};
+						};
+						channel@13 {
+							status = "okay";
+							reg = <13>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in13: endpoint@26 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&ds5_13_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out13: endpoint@27 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in13>;
+									};
+								};
+							};
+						};
+						channel@14 {
+							status = "okay";
+							reg = <14>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in14: endpoint@28 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&ds5_14_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out14: endpoint@29 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in14>;
+									};
+								};
+							};
+						};
+						channel@15 {
+							status = "okay";
+							reg = <15>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in15: endpoint@30 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&ds5_15_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out15: endpoint@31 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in15>;
+									};
+								};
+							};
+						};
+					};
+				};
+
+				/*
+				 * FG12-4CH routes the camera I2C through a GPIO-selected mux
+				 * (CAM_I2C_MUX = AON_GPIO(CC,3)).  The deserializer I2C is on the
+				 * i2c@1 branch (gpio HIGH), matching the official FangZhu
+				 * tegra234-p3767-camera-p3768-fzcam-fg12-4ch device tree. The
+				 * CSI video output is configured separately above as
+				 * port-index 2 / serial_c.
+				 */
+				cam_i2cmux {
+					compatible = "i2c-mux-gpio";
+					#address-cells = <1>;
+					#size-cells = <0>;
+					i2c-parent = <&cam_i2c>;
+					mux-gpios = <&gpio_aon CAM_I2C_MUX GPIO_ACTIVE_HIGH>;
+
+					i2c@1 {
+						reg = <1>;
+						#address-cells = <1>;
+						#size-cells = <0>;
+
+					dser: max96712@29 {
+						status = "okay";
+						reg = <0x29>;
+						compatible = "maxim,max96712";
+						csi-mode = "2x4";
+						/* 4-lane CSI output towards the Jetson (1300 Mbps/lane). */
+						lane_cnt = <4>;
+						link-mask = <0xf>;
+						channel = "a";
+						fangzhu,fg12-reverse-lane-polarity;
+						fangzhu,fg12-poc-enable;
+						/* <serializer-vc deserializer-vc> */
+						maxim,link0-vc-remap = <0 0>, <1 1>, <2 2>, <3 3>;
+						maxim,link1-vc-remap = <0 4>, <1 5>, <2 6>, <3 7>;
+						maxim,link2-vc-remap = <0 8>, <1 9>, <2 10>, <3 11>;
+						maxim,link3-vc-remap = <0 12>, <1 13>, <2 14>, <3 15>;
+					};
+
+					ser_a: max96717@40 {
+						status = "okay";
+						compatible = "maxim,max96717";
+						reg = <0x40>;
+						maxim,gmsl-link-id = <0>;
+						maxim,gmsl-dser-device = <&dser>;
+						external_addr_reassign;
+					};
+
+					ser_b: max9295_b@41 {
+						status = "okay";
+						compatible = "maxim,max9295";
+						reg = <0x41>;
+						maxim,gmsl-link-id = <1>;
+						maxim,gmsl-dser-device = <&dser>;
+						external_addr_reassign;
+					};
+
+					ser_c: max9295_c@42 {
+						status = "okay";
+						compatible = "maxim,max9295";
+						reg = <0x42>;
+						maxim,gmsl-link-id = <2>;
+						maxim,gmsl-dser-device = <&dser>;
+						external_addr_reassign;
+					};
+
+					ser_d: max9295_d@43 {
+						status = "okay";
+						compatible = "maxim,max9295";
+						reg = <0x43>;
+						maxim,gmsl-link-id = <3>;
+						maxim,gmsl-dser-device = <&dser>;
+						external_addr_reassign;
+					};
+
+					ds5_15: ds5@4d {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x4d>;
+						override_reg = <0x4a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						cam-type = "IMU";
+						nvidia,gmsl-ser-device = <&ser_d>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_15_out: endpoint {
+									vc-id = <15>;
+									port-index = <2>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in15>;
+								};
+							};
+						};
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "4";
+							csi_pixel_bit_depth = "16";
+							active_w = "640";
+							active_h = "480";
+							tegra_sinterface = "serial_c";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "0";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <15>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_14: ds5@4c {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x4c>;
+						override_reg = <0x4a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						cam-type = "Y8";
+						nvidia,gmsl-ser-device = <&ser_d>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_14_out: endpoint {
+									vc-id = <14>;
+									port-index = <2>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in14>;
+								};
+							};
+						};
+						/* mode0: Y8, mode1: depth D16 */
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "4";
+							csi_pixel_bit_depth = "16";
+							active_w = "1280";
+							active_h = "720";
+							tegra_sinterface = "serial_c";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "1";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <14>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_13: ds5@4b {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x4b>;
+						override_reg = <0x4a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						cam-type = "RGB";
+						nvidia,gmsl-ser-device = <&ser_d>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_13_out: endpoint {
+									vc-id = <13>;
+									port-index = <2>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in13>;
+								};
+							};
+						};
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "4";
+							csi_pixel_bit_depth = "16";
+							active_w = "1920";
+							active_h = "1080";
+							tegra_sinterface = "serial_c";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "1";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <13>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_12: ds5@4a {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x4a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						cam-type = "Depth";
+						nvidia,gmsl-ser-device = <&ser_d>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_12_out: endpoint {
+									vc-id = <12>;
+									port-index = <2>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in12>;
+								};
+							};
+						};
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "4";
+							csi_pixel_bit_depth = "16";
+							active_w = "1280";
+							active_h = "720";
+							tegra_sinterface = "serial_c";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "1";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <12>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_11: ds5@3d {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x3d>;
+						override_reg = <0x3a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						cam-type = "IMU";
+						nvidia,gmsl-ser-device = <&ser_c>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_11_out: endpoint {
+									vc-id = <11>;
+									port-index = <2>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in11>;
+								};
+							};
+						};
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "4";
+							csi_pixel_bit_depth = "16";
+							active_w = "640";
+							active_h = "480";
+							tegra_sinterface = "serial_c";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "0";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <11>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_10: ds5@3c {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x3c>;
+						override_reg = <0x3a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						cam-type = "Y8";
+						nvidia,gmsl-ser-device = <&ser_c>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_10_out: endpoint {
+									vc-id = <10>;
+									port-index = <2>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in10>;
+								};
+							};
+						};
+						/* mode0: Y8, mode1: depth D16 */
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "4";
+							csi_pixel_bit_depth = "16";
+							active_w = "1280";
+							active_h = "720";
+							tegra_sinterface = "serial_c";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "1";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <10>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_9: ds5@3b {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x3b>;
+						override_reg = <0x3a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						cam-type = "RGB";
+						nvidia,gmsl-ser-device = <&ser_c>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_9_out: endpoint {
+									vc-id = <9>;
+									port-index = <2>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in9>;
+								};
+							};
+						};
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "4";
+							csi_pixel_bit_depth = "16";
+							active_w = "1920";
+							active_h = "1080";
+							tegra_sinterface = "serial_c";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "1";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <9>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_8: ds5@3a {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x3a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						cam-type = "Depth";
+						nvidia,gmsl-ser-device = <&ser_c>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_8_out: endpoint {
+									vc-id = <8>;
+									port-index = <2>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in8>;
+								};
+							};
+						};
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "4";
+							csi_pixel_bit_depth = "16";
+							active_w = "1280";
+							active_h = "720";
+							tegra_sinterface = "serial_c";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "1";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <8>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_7: ds5@2d {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x2d>;
+						override_reg = <0x2a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						cam-type = "IMU";
+						nvidia,gmsl-ser-device = <&ser_b>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_7_out: endpoint {
+									vc-id = <7>;
+									port-index = <2>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in7>;
+								};
+							};
+						};
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "4";
+							csi_pixel_bit_depth = "16";
+							active_w = "640";
+							active_h = "480";
+							tegra_sinterface = "serial_c";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "0";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <7>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_6: ds5@2c {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x2c>;
+						override_reg = <0x2a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						cam-type = "Y8";
+						nvidia,gmsl-ser-device = <&ser_b>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_6_out: endpoint {
+									vc-id = <6>;
+									port-index = <2>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in6>;
+								};
+							};
+						};
+						/* mode0: Y8, mode1: depth D16 */
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "4";
+							csi_pixel_bit_depth = "16";
+							active_w = "1280";
+							active_h = "720";
+							tegra_sinterface = "serial_c";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "1";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <6>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_5: ds5@2b {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x2b>;
+						override_reg = <0x2a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						cam-type = "RGB";
+						nvidia,gmsl-ser-device = <&ser_b>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_5_out: endpoint {
+									vc-id = <5>;
+									port-index = <2>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in5>;
+								};
+							};
+						};
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "4";
+							csi_pixel_bit_depth = "16";
+							active_w = "1920";
+							active_h = "1080";
+							tegra_sinterface = "serial_c";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "1";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <5>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_4: ds5@2a {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x2a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						cam-type = "Depth";
+						nvidia,gmsl-ser-device = <&ser_b>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_4_out: endpoint {
+									vc-id = <4>;
+									port-index = <2>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in4>;
+								};
+							};
+						};
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "4";
+							csi_pixel_bit_depth = "16";
+							active_w = "1280";
+							active_h = "720";
+							tegra_sinterface = "serial_c";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "1";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <4>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_3: ds5@1d {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x1d>;
+						override_reg = <0x1a>;
+						compatible = "realsense,d5xx";
+						use_sensor_mode_id = "true";
+						cam-type = "IMU";
+						nvidia,gmsl-ser-device = <&ser_a>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_3_out: endpoint {
+									vc-id = <3>;
+									port-index = <2>;
+									bus-width = <4>;
+									remote-endpoint = <&d4xx_csi_in3>;
+								};
+							};
+						};
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "4";
+							csi_pixel_bit_depth = "16";
+							active_w = "640";
+							active_h = "480";
+							tegra_sinterface = "serial_c";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "0";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <3>;
+							num-lanes = <4>;
+						};
+					};
+
+					ds5_2: ds5@1c {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x1c>;
+						override_reg = <0x1a>;
+						compatible = "realsense,d5xx";
+						use_sensor_mode_id = "true";
+						cam-type = "Y8";
+						nvidia,gmsl-ser-device = <&ser_a>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_2_out: endpoint {
+									vc-id = <2>;
+									port-index = <2>;
+									bus-width = <4>;
+									remote-endpoint = <&d4xx_csi_in2>;
+								};
+							};
+						};
+						/* mode0: Y8, mode1: depth D16 */
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "4";
+							csi_pixel_bit_depth = "16";
+							active_w = "1280";
+							active_h = "720";
+							tegra_sinterface = "serial_c";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "1";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <2>;
+							num-lanes = <4>;
+						};
+					};
+
+					ds5_1: ds5@1b {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x1b>;
+						override_reg = <0x1a>;
+						compatible = "realsense,d5xx";
+						use_sensor_mode_id = "true";
+						cam-type = "RGB";
+						nvidia,gmsl-ser-device = <&ser_a>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_1_out: endpoint {
+									vc-id = <1>;
+									port-index = <2>;
+									bus-width = <4>;
+									remote-endpoint = <&d4xx_csi_in1>;
+								};
+							};
+						};
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "4";
+							csi_pixel_bit_depth = "16";
+							active_w = "1920";
+							active_h = "1080";
+							tegra_sinterface = "serial_c";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "1";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <1>;
+							num-lanes = <4>;
+						};
+					};
+
+					ds5_0: ds5@1a {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x1a>;
+						compatible = "realsense,d5xx";
+						use_sensor_mode_id = "true";
+						cam-type = "Depth";
+						nvidia,gmsl-ser-device = <&ser_a>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_0_out: endpoint {
+									vc-id = <0>;
+									port-index = <2>;
+									bus-width = <4>;
+									remote-endpoint = <&d4xx_csi_in0>;
+								};
+							};
+						};
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "4";
+							csi_pixel_bit_depth = "16";
+							active_w = "1280";
+							active_h = "720";
+							tegra_sinterface = "serial_c";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "1";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <0>;
+							num-lanes = <4>;
+						};
+					};
+					};
+				};
+			};
+		};
+	};
+};


### PR DESCRIPTION
## Summary
New `tegra234-camera-d4xx-overlay-fg12-4ch-cams-0-1-2-3-d5xx-d4xx.dts` for the FangZhu FG12-4CH carrier on Orin Nano:
- **cam0 (link A, vc 0-3): D5xx (D585)** — `maxim,max96717` @0x40, `realsense,d5xx` sensor nodes @0x1a-0x1d, 4-lane camera CSI (`bus-width`/`gmsl-link num-lanes` = 4)
- **cam1-3 (links B/C/D, vc 4-15): D4xx** — `max9295` @0x41-0x43, hybrid 2-lane camera / 4-lane deserializer-to-Jetson config, unchanged from the base overlay
- Shared `max96712` @0x29: `lane_cnt=4`, `link-mask=0xf`, per-link vc-remaps, `serdes_pix_clk_hz=325000000`, FangZhu PoC / lane-polarity hooks kept

Derived from the verified `fg12-4ch-cams-0-1-2-3` overlay with link A converted per the verified mixed `fg12-16ch-cams-0-1-d5xx-d4xx` overlay. `num_csi_lanes` raised to 4 to match the 4-lane deserializer output.

Also registers the dtbo in the JP6 overlay Makefile patch and adds it to the JP6.0/JP6.2 README overlay tables.

## Validation
- Overlay preprocessed + compiled clean with `dtc` (only the usual standalone `reg_format` warnings)
- Edited Makefile patch verified with `git apply --check` against the pristine pre-patch Makefile
- Diff vs. the base 4-camera overlay reviewed: only the intended link-A conversion changes
- **Not yet HW-validated**: this exact 1x D5xx + 3x D4xx combo (and D4xx extended-VC on links >0) pends rig validation