### PR TITLE
[RSDSO-21854] Reset the camera on a colour source-DT change

### DIFF
--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -692,6 +692,11 @@ struct ds5_dev {
 	bool ir_streaming;
 	bool rgb_streaming;
 	bool imu_streaming;
+
+	/* RSDSO-21854: source DT of the last colour stream that actually ran, 0 if none.
+	 * The camera cannot switch its colour path between ISP YUV422 and raw pass-through.
+	 */
+	u8 rgb_last_streamed_dt;
 };
 
 #ifdef CONFIG_VIDEO_D4XX_SERDES
@@ -6222,6 +6227,45 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 	dev_dbg(&state->client->dev, "s_stream for stream %s, vc:%d, SENSOR=%s on = %d\n",
 			sensor->sd.name, vc_id, ds5_get_sensor_name(state), on);
 
+	/* RSDSO-21854: a colour source-DT change needs a camera reset - no firmware-reachable
+	 * reset recovers the other mode. Gated on idle: a reset would kill a live sibling.
+	 */
+	if (on && state->is_rgb && sensor->config.format) {
+		u8 dt = sensor->config.format->data_type;
+		bool switched, idle;
+
+		mutex_lock(&state->ds5_dev->lock);
+		switched = state->ds5_dev->rgb_last_streamed_dt &&
+			   state->ds5_dev->rgb_last_streamed_dt != dt;
+		idle = d500_camera_is_idle_locked(state);
+		mutex_unlock(&state->ds5_dev->lock);
+
+		if (switched && idle) {
+			dev_info(&state->client->dev,
+				 "%s(): colour source DT 0x%02x -> 0x%02x, resetting camera\n",
+				 __func__, state->ds5_dev->rgb_last_streamed_dt, dt);
+			ret = ds5_hw_reset_with_recovery(state);
+			if (ret < 0)
+				dev_warn(&state->client->dev,
+					 "%s(): reset on colour DT change failed: %d\n",
+					 __func__, ret);
+			ret = 0;
+
+			/* Repeat the lazy invalidation: it already ran above for this call,
+			 * so without this the start below uses pipe state the reset discarded.
+			 */
+			ds5_invalidate_sensor(state, sensor);
+			sensor->streaming = false;
+			reset_invalidated = true;
+			state->reset_ref_ds5 = atomic_read(ds5_get_reset_gen(state));
+		} else if (switched) {
+			dev_warn(&state->client->dev,
+				 "%s(): colour source DT 0x%02x -> 0x%02x while other streams are "
+				 "live - cannot reset, this stream will not deliver frames\n",
+				 __func__, state->ds5_dev->rgb_last_streamed_dt, dt);
+		}
+	}
+
 	if (on) {
 		stream_cmd = (DS5_STREAM_START | stream_id);
 		expected_streaming_state = DS5_STREAM_STREAMING;
@@ -6456,6 +6500,15 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 	if (on && ret >= 0 && state->dser_ops->retrigger_datapath)
 		state->dser_ops->retrigger_datapath(state->dser_dev);
 #endif
+	/* Only a start that succeeded put the camera into this mode, so only that arms the
+	 * switch detection for the next start.
+	 */
+	if (on && ret >= 0 && state->is_rgb && sensor->config.format) {
+		mutex_lock(&state->ds5_dev->lock);
+		state->ds5_dev->rgb_last_streamed_dt = sensor->config.format->data_type;
+		mutex_unlock(&state->ds5_dev->lock);
+	}
+
 	return ret;
 }
 


### PR DESCRIPTION
## What this fixes

D401 serves colour two ways — ISP YUV422 (`848x480 YUYV`) and raw Bayer pass-through
(`1612x808 BA81`). The camera cannot switch between them: whichever mode streams first keeps
working, the other returns empty frames until a HW reset. That reset is what RSDSO-21854 reports
as required, and this makes the driver issue it instead of the user.

## Why here and not in firmware

Ten firmware builds were spent on the camera side first. The fault is a VDF-A frame-start failure
— CAM asserts vvalid at full rate while the colour endpoint buffer never registers a SOF — and it
is specific to that datapath: the sibling VDF-B pass-through path and colour-ISP itself both keep
working after the poison. Every firmware-reachable reset fails to clear it, **including the
chip-level core data-path reset** (`RegCsrSwClkrstCtl` bit 5), which was verified to execute and
change nothing. Teardown ordering, a frame-period drain, an LP-11 wait, `CCI_PRVW_STOP`, a pause
retry, an inter-frame-gap close and leaving the MIPI receiver up were all tried and rejected by
direct test. Only a camera reset recovers it.

## The change

Track the colour source DT that last actually streamed. On a start whose DT differs, reset the
camera first, and only while nothing else is streaming — a reset would kill a live sibling. The
existing `ds5_hw_reset_with_recovery()` already carries the cooldown and readiness polling.

Two details worth review:
- The reset bumps the generation counter, but this call already passed the lazy-invalidation block
  at the top of `ds5_mux_s_stream()`. Without repeating it, the start below runs on pipe state the
  reset discarded — measured as full-rate **black** frames rather than none.
- Only a start that *succeeded* records the DT, so a failed start cannot arm a spurious reset.

When siblings are streaming the switch cannot be made safe; that case logs a warning and proceeds,
which is today's behaviour.

## Validation

Two D401 rigs, stock master firmware, predecessor-gated (each transition scored only when the one
before it was verified healthy), scored on frames **and** fps **and** non-zero payload **and** VI
`uncorr_err` delta:

| leg | before | after |
|---|---|---|
| ISP → pass-through | 5-10 frames, **payload 0**, VI timeouts | 300/301 frames, full payload, `uncorr_err` 0 |
| pass-through → ISP | fails | 300/301 frames, full payload |

- 6/6 both directions on one rig, 5/5 on a second — **11/11**.
- Blast radius: depth and IR unchanged before and after a colour session (30.6 fps, full payload);
  a repeated same-format colour start triggers **no** reset.

## Not validated

- Only D401 rigs. Other SKUs' colour nodes advertise a single format, so the DT never changes and
  the path is inert, but that is reasoned rather than exercised.
- A rig running driver 1.0.6.7 with an older device-tree overlay failed to probe this build
  (`missing deserializer driver`) — a deployment/overlay mismatch unrelated to this change; it was
  restored to its original modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)