### PR TITLE
[DIAG] runtime DFU I2C diagnostic + PR #564 (foreign-thread I2C during DFU)

### DIFF
--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -31,6 +31,7 @@
 #include <linux/videodev2.h>
 #include <linux/version.h>
 #include <linux/mutex.h>
+#include <linux/sched.h>
 #include <media/media-entity.h>
 #include <media/v4l2-ctrls.h>
 #include <media/v4l2-device.h>
@@ -574,7 +575,18 @@ struct ds5_dfu_dev {
 	u16 msg_write_once;
 	// unsigned char init_v4l_f; // need refactoring
 	u32 bus_clk_rate;
+	/* Diagnostic: task_struct of the userspace thread currently executing
+	 * ds5_dfu_device_write; NULL when idle. Consumed by ds5_dfu_diag_foreign()
+	 * to log any I2C op made by a different thread while DFU is in progress. */
+	struct task_struct *dfu_write_task;
 };
+
+/* Runtime-toggleable DFU I2C diagnostic. 0 = off (default), 1 = log every
+ * I2C op made by a foreign thread while DS5_DFU_IN_PROGRESS. Toggle via
+ * `echo 1 | sudo tee /sys/module/d4xx/parameters/dfu_verbose`. */
+static int dfu_verbose;
+module_param(dfu_verbose, int, 0644);
+MODULE_PARM_DESC(dfu_verbose, "Verbose DFU I2C diagnostics (0=off, 1=on)");
 
 enum {
 	DS5_DS5U,
@@ -875,11 +887,32 @@ static inline void msleep_range(unsigned int delay_base)
 #endif
 #endif
 
+/* dfu_verbose diagnostic: fires when an I2C op runs from a thread that is
+ * NOT the one currently executing ds5_dfu_device_write, while a DFU is in
+ * progress. Zero-overhead early-return when dfu_verbose == 0. */
+static inline void ds5_dfu_diag_foreign(struct ds5 *state, const char *op, u16 reg)
+{
+	struct task_struct *dfu_task;
+
+	if (!dfu_verbose)
+		return;
+	if (state->dfu_dev.dfu_state_flag != DS5_DFU_IN_PROGRESS)
+		return;
+	dfu_task = READ_ONCE(state->dfu_dev.dfu_write_task);
+	if (!dfu_task || dfu_task == current)
+		return;
+	dev_notice(&state->client->dev,
+		"DFU-DIAG: %s(0x%04x) from foreign thread %s (pid=%d) during DFU\n",
+		op, reg, current->comm, current->pid);
+}
+
 static int ds5_write(struct ds5 *state, u16 reg, u16 val)
 {
 	int ret;
 	int retry;
 	u8 value[2];
+
+	ds5_dfu_diag_foreign(state, "ds5_write", reg);
 
 	value[1] = val >> 8;
 	value[0] = val & 0x00FF;
@@ -917,6 +950,8 @@ static int ds5_raw_write(struct ds5 *state, u16 reg,
 	int ret;
 	int retry;
 
+	ds5_dfu_diag_foreign(state, "ds5_raw_write", reg);
+
 	for (retry = 0; retry < DS5_I2C_RETRY_COUNT; retry++) {
 		ret = regmap_raw_write(state->regmap, reg, val, val_len);
 		if (ret == 0)
@@ -946,6 +981,8 @@ static int ds5_read(struct ds5 *state, u16 reg, u16 *val)
 	int ret;
 	int retry;
 
+	ds5_dfu_diag_foreign(state, "ds5_read", reg);
+
 	for (retry = 0; retry < DS5_I2C_RETRY_COUNT; retry++) {
 		ret = regmap_raw_read(state->regmap, reg, val, 2);
 		if (ret == 0)
@@ -971,6 +1008,7 @@ static int ds5_read(struct ds5 *state, u16 reg, u16 *val)
 
 static int ds5_read_poll(struct ds5 *state, u16 reg, u16 *val)
 {
+	ds5_dfu_diag_foreign(state, "ds5_read_poll", reg);
 	return regmap_raw_read(state->regmap, reg, val, 2);
 }
 
@@ -978,6 +1016,8 @@ static int ds5_raw_read(struct ds5 *state, u16 reg, void *val, size_t val_len)
 {
 	int ret;
 	int retry;
+
+	ds5_dfu_diag_foreign(state, "ds5_raw_read", reg);
 
 	for (retry = 0; retry < DS5_I2C_RETRY_COUNT; retry++) {
 		ret = regmap_raw_read(state->regmap, reg, val, val_len);
@@ -6931,13 +6971,15 @@ static int ds5_dfu_wait_for_get_dfu_status(struct ds5 *state,
 		ds5_read_with_check(state, 0x5004, &dfu_state_len);
 		if (dfu_state_len != DFU_WAIT_RET_LEN) {
 			dev_err(&state->client->dev,
-					"%s(): Wrong answer len (%d)\n", __func__, dfu_state_len);
+					"%s(): Wrong answer len (%d) — exp_state=%d dfu_wr_wait_msec=%u\n",
+					__func__, dfu_state_len, exp_state, dfu_wr_wait_msec);
 			return -EINVAL;
 		}
 		ds5_raw_read_with_check(state, 0x4e00, &dfu_asw_buf, DFU_WAIT_RET_LEN);
 		if (dfu_asw_buf[0]) {
 			dev_err(&state->client->dev,
-					"%s(): Wrong dfu_status (%d)\n", __func__, dfu_asw_buf[0]);
+					"%s(): Wrong dfu_status (%d) — exp_state=%d dfu_state=%d\n",
+					__func__, dfu_asw_buf[0], exp_state, dfu_asw_buf[4]);
 			return -EINVAL;
 		}
 		dfu_wr_wait_msec = (((unsigned int)dfu_asw_buf[3]) << 16)
@@ -7049,6 +7091,9 @@ static ssize_t ds5_dfu_device_write(struct file *flip,
 
 	if (mutex_lock_interruptible(&state->lock))
 		return -ERESTARTSYS;
+	/* Diagnostic: remember which task is executing the DFU write so
+	 * ds5_dfu_diag_foreign() can flag any I2C op from a different one. */
+	WRITE_ONCE(state->dfu_dev.dfu_write_task, current);
 	switch (state->dfu_dev.dfu_state_flag) {
 
 	case DS5_DFU_OPEN:
@@ -7119,6 +7164,7 @@ static ssize_t ds5_dfu_device_write(struct file *flip,
 		goto dfu_write_error;
 
 	};
+	WRITE_ONCE(state->dfu_dev.dfu_write_task, NULL);
 	mutex_unlock(&state->lock);
 	return len;
 
@@ -7127,6 +7173,7 @@ dfu_write_error:
 	// Reset DFU device to IDLE states
 	if (!ds5_write(state, 0x5010, 0x0))
 		state->dfu_dev.dfu_state_flag = DS5_DFU_IDLE;
+	WRITE_ONCE(state->dfu_dev.dfu_write_task, NULL);
 	mutex_unlock(&state->lock);
 	return ret;
 };

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -140,6 +140,12 @@ struct ser_interface {
 #define DS5_DEVICE_TYPE_D45X		6
 #define DS5_DEVICE_TYPE_D43X		5
 #define DS5_DEVICE_TYPE_UNKNOWN		0
+/*
+ * FW version major byte identifies the family in recovery, where DEVICE_TYPE
+ * (0x0310) is not served: D58x reports 7 or 8, D4xx reports 5.
+ */
+#define DS5_D58X_FW_MAJOR_MIN		7
+#define DS5_D58X_FW_MAJOR_MAX		8
 
 /* GVD response payload size per product line */
 #define DS5_GVD_LEN_D4XX		276
@@ -286,6 +292,13 @@ enum ds5_mux_pad {
 #define PIPE_NOT_CONFIGURED	-1
 
 #define DFU_WAIT_RET_LEN 6
+
+/*
+ * Deadline for the D58x manifest wait; the manifest can legitimately take
+ * up to ~90 s, so the bound is generous and only guards against a device
+ * stuck in an intermediate manifest state.
+ */
+#define DFU_MANIFEST_TIMEOUT_MS 180000
 
 #define DS5_START_POLL_TIME	10
 #define DS5_START_MAX_TIME	2000
@@ -571,6 +584,7 @@ struct ds5_dfu_dev {
 	struct class *ds5_class;
 	int device_open_count;
 	enum dfu_state dfu_state_flag;
+	enum dfu_fw_state manifest_state;
 	unsigned char *dfu_msg;
 	u16 msg_write_once;
 	// unsigned char init_v4l_f; // need refactoring
@@ -6952,6 +6966,8 @@ static int ds5_dfu_wait_for_get_dfu_status(struct ds5 *state,
 	u16 status, dfu_state_len = 0x0000;
 	unsigned char dfu_asw_buf[DFU_WAIT_RET_LEN];
 	unsigned int dfu_wr_wait_msec = 0;
+	unsigned long manifest_deadline = jiffies +
+			msecs_to_jiffies(DFU_MANIFEST_TIMEOUT_MS);
 
 	do {
 		ds5_write_with_check(state, 0x5008, 0x0003); // Get Write state
@@ -6985,7 +7001,18 @@ static int ds5_dfu_wait_for_get_dfu_status(struct ds5 *state,
 		dfu_wr_wait_msec = (((unsigned int)dfu_asw_buf[3]) << 16)
 						| (((unsigned int)dfu_asw_buf[2]) << 8)
 						| dfu_asw_buf[1];
-	} while (dfu_asw_buf[4] == dfuDNBUSY && exp_state == dfuDNLOAD_IDLE);
+	/*
+	 * D58x manifestation runs dfuMANIFEST_SYNC -> dfuMANIFEST ->
+	 * dfuMANIFEST_WAIT_RESET; keep polling through the intermediate
+	 * states until the terminal wait-reset state is reached, bounded by
+	 * manifest_deadline so a stuck device errors out instead of hanging.
+	 */
+	} while ((dfu_asw_buf[4] == dfuDNBUSY &&
+		  exp_state == dfuDNLOAD_IDLE) ||
+		 ((dfu_asw_buf[4] == dfuMANIFEST_SYNC ||
+		   dfu_asw_buf[4] == dfuMANIFEST) &&
+		  exp_state == dfuMANIFEST_WAIT_RESET &&
+		  time_before(jiffies, manifest_deadline)));
 
 	if (dfu_asw_buf[4] != exp_state) {
 		dev_notice(&state->client->dev,
@@ -7021,6 +7048,7 @@ static int ds5_dfu_get_dev_info(struct ds5 *state, struct __fw_status *buf)
 static int ds5_dfu_detach(struct ds5 *state)
 {
 	int ret;
+	u8 fw_major;
 	struct __fw_status buf = {0};
 
 	ds5_write_with_check(state, 0x500c, 0x00);
@@ -7033,6 +7061,15 @@ static int ds5_dfu_detach(struct ds5 *state)
 			__func__, buf.FW_lastVersion);
 	dev_notice(&state->client->dev, "%s():FW status (%s)\n",
 			__func__, buf.DFU_isLocked ? "locked" : "unlocked");
+	/* Recovery never ran ds5_wait_device_type(), so use the known D58x FW
+	 * major range only as a DFU-session hint. Do not write cached_device_type:
+	 * that cache is reserved for a value read from DS5_DEVICE_TYPE and is also
+	 * used outside DFU for readiness and register routing.
+	 */
+	fw_major = (buf.FW_lastVersion >> 24) & 0xff;
+	if (!ret && fw_major >= DS5_D58X_FW_MAJOR_MIN &&
+	    fw_major <= DS5_D58X_FW_MAJOR_MAX)
+		state->dfu_dev.manifest_state = dfuMANIFEST_WAIT_RESET;
 	return ret;
 };
 
@@ -7081,6 +7118,21 @@ e_dfu_read_failed:
 	mutex_unlock(&state->lock);
 	return ret;
 };
+
+/* The caller must hold state->lock. */
+static int ds5_dfu_finalize_download(struct ds5 *state)
+{
+	enum dfu_fw_state manifest_state = state->dfu_dev.manifest_state;
+	int ret;
+
+	ret = ds5_write(state, 0x4a04, 0x00); /* Download complete */
+	if (!ret)
+		ret = ds5_dfu_wait_for_get_dfu_status(state, manifest_state);
+	if (!ret)
+		state->dfu_dev.dfu_state_flag = DS5_DFU_DONE;
+
+	return ret;
+}
 
 static ssize_t ds5_dfu_device_write(struct file *flip,
 		const char __user *buffer, size_t len, loff_t *offset)
@@ -7145,12 +7197,9 @@ static ssize_t ds5_dfu_device_write(struct file *flip,
 			if (!ret)
 				ret = ds5_dfu_wait_for_get_dfu_status(state, dfuDNLOAD_IDLE);
 			if (!ret)
-				ret = ds5_write(state, 0x4a04, 0x00); /*Download complete */
-			if (!ret)
-				ret = ds5_dfu_wait_for_get_dfu_status(state, dfuMANIFEST);
+				ret = ds5_dfu_finalize_download(state);
 			if (ret < 0)
 				goto dfu_write_error;
-			state->dfu_dev.dfu_state_flag = DS5_DFU_DONE;
 		}
 		if (len)
 			dev_notice(&state->client->dev, "%s(): DFU block (%d) bytes written\n",
@@ -7194,6 +7243,12 @@ static int ds5_dfu_device_open(struct inode *inode, struct file *file)
 	state->dfu_dev.device_open_count++;
 	if (state->dfu_dev.dfu_state_flag != DS5_DFU_RECOVERY)
 		state->dfu_dev.dfu_state_flag = DS5_DFU_OPEN;
+	/*
+	 * Operational probe has an authoritative type; recovery defaults to the
+	 * D4xx terminal state until ds5_dfu_detach() obtains a D58x-only hint.
+	 */
+	state->dfu_dev.manifest_state = ds5_is_d58x(state) ?
+		dfuMANIFEST_WAIT_RESET : dfuMANIFEST;
 	state->dfu_dev.dfu_msg = devm_kzalloc(&state->client->dev,
 			DFU_BLOCK_SIZE, GFP_KERNEL);
 	if (!state->dfu_dev.dfu_msg) {
@@ -7222,6 +7277,30 @@ static int ds5_dfu_device_open(struct inode *inode, struct file *file)
 	mutex_unlock(&state->lock);
 	return 0;
 };
+
+static int ds5_dfu_device_flush(struct file *file, fl_owner_t id)
+{
+	struct ds5 *state = file->private_data;
+	int ret = 0;
+
+	(void)id;
+	mutex_lock(&state->lock);
+	/* A partial block finalizes in write(). Use close as the end signal for an
+	 * aligned image because userspace may split it across multiple writes.
+	 */
+	if (state->dfu_dev.dfu_state_flag == DS5_DFU_IN_PROGRESS) {
+		ret = ds5_dfu_finalize_download(state);
+		if (ret < 0) {
+			state->dfu_dev.dfu_state_flag = DS5_DFU_ERROR;
+			/* Reset the DFU device to IDLE, matching the write error path. */
+			if (!ds5_write(state, 0x5010, 0x0))
+				state->dfu_dev.dfu_state_flag = DS5_DFU_IDLE;
+		}
+	}
+	mutex_unlock(&state->lock);
+
+	return ret;
+}
 
 /* Adjust sync_mode control range based on device type.
  * Must be called after ds5_mux_init() which creates the control.
@@ -7428,6 +7507,7 @@ static const struct file_operations ds5_device_file_ops = {
 	.read = &ds5_dfu_device_read,
 	.write = &ds5_dfu_device_write,
 	.open = &ds5_dfu_device_open,
+	.flush = &ds5_dfu_device_flush,
 	.release = &ds5_dfu_device_release
 };
 


### PR DESCRIPTION
## Purpose

**Diagnostic build — not intended to merge.**

`rs-fw-update` completes ~30-min DFU on operational D585 GMSL cleanly, but `realsense-viewer`'s DFU on the same rig fails at random points during the write with:

```
d4xx 2-001a: ds5_dfu_wait_for_get_dfu_status(): Wrong answer len (65535)
```

Both paths issue a single `write(2)` on `/dev/d4xx-dfu-*` which the driver services entirely inside `ds5_dfu_device_write` while holding `state->lock`. Nothing else should be able to touch the D5xx I²C bus during that window. This PR adds instrumentation to prove or disprove that assumption on the failing rig.

## Contents

Two commits on top of `dev`:

1. **#564** — `[RSDEV-13621][D58x] Wait for DFU manifest-wait-reset state` (cherry-picked). The D58x-specific `dfuMANIFEST_WAIT_RESET (0x0008)` terminal state handling.
2. **`[DIAG]`** — the runtime-toggleable I²C diagnostic. See details below.

The auto-merge on `d4xx.c` in `ds5_dfu_wait_for_get_dfu_status` combined both #564's outer-loop MANIFEST_SYNC/MANIFEST condition and this PR's expanded error messages.

## What the [DIAG] commit does

- **New module param** `dfu_verbose` (default 0, off), toggleable at runtime:
  ```bash
  echo 1 | sudo tee /sys/module/d4xx/parameters/dfu_verbose   # on
  echo 0 | sudo tee /sys/module/d4xx/parameters/dfu_verbose   # off
  ```
- Remembers the DFU thread's `task_struct` in `struct ds5_dfu_dev.dfu_write_task` (set in the write handler's mutex-locked prologue, cleared on both success and error exits).
- `ds5_dfu_diag_foreign()` is called from **every** I²C primitive (`ds5_write`, `ds5_raw_write`, `ds5_read`, `ds5_read_poll`, `ds5_raw_read`). Zero overhead when the module param is off.
- Fires as `dev_notice`:
  ```
  d4xx 2-001a: DFU-DIAG: <op>(0x<reg>) from foreign thread <comm> (pid=<N>) during DFU
  ```
- **Also** expands `Wrong answer len` / `Wrong dfu_status` messages with the expected state and pending FW wait timeout, so the exact position in the DFU state machine at which the FF race fires is visible.

## Expected outcomes

- **No `DFU-DIAG:` lines in the failing viewer run** → the FF race is FW-intrinsic (no concurrent I²C exists). Driver-side retry (#595) is the correct fix.
- **`DFU-DIAG:` lines show a foreign thread touching the bus** → the exact caller is identified by thread name + register, and we chase it in the SDK.

## Usage

```bash
# Load driver
sudo rmmod d4xx && sudo modprobe d4xx
sleep 2

# Enable diagnostic, clear dmesg
sudo dmesg -C
echo 1 | sudo tee /sys/module/d4xx/parameters/dfu_verbose

# Reproduce
realsense-viewer   # click Update Firmware, load .img, wait

# Capture
sudo dmesg > /tmp/dfu-diag-viewer.log
echo 0 | sudo tee /sys/module/d4xx/parameters/dfu_verbose
```

For an A/B run, `sudo rmmod d4xx && sudo modprobe d4xx` between attempts to reset the DFU state cleanly.

## Files

- `kernel/realsense/d4xx.c` — single file, 130+ additions (49 diag + 85 #564).

## NOT INTENDED TO MERGE

Close once the diagnosis is done. #564 stays open and gets merged independently.