### PR TITLE
[D585][GMSL][reference] Preserve all-UD32 tunnel contracts

### DIFF
--- a/hardware/realsense/tegra234-camera-d4xx-overlay-fg24-4ch-d5xx.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-fg24-4ch-d5xx.dts
@@ -14,6 +14,7 @@
  *   VC1 = RGB    (YUY2, 1920x1080 @30fps)
  *   VC2 = IR     (Y8/Y8I/Y12I, 1280x720 @60fps)
  *   VC3 = IMU    (RAW8)
+ *   VC4 = RGB-right on D585 2C (same profiles as VC1)
  *
  * GMSL link:
  *   GMSL2 Tunnel Mode, 6 Gbps
@@ -34,7 +35,8 @@
  *   MAX96724 deser:  0x27
  *   MAX96717 ser:    0x40 (default), 0x60 (aliased)
  *   HKR camera SoC:  0x10 (def-addr)
- *   Sensor aliases:   0x1a (Depth), 0x1b (RGB), 0x1c (IR), 0x1d (IMU)
+ *   Sensor aliases:   0x1a (Depth), 0x1b (RGB), 0x1c (IR), 0x1d (IMU),
+ *                     0x1e (RGB-right)
  *
  * CSI lane properties:
  *   mipi-lane-rate-mbps = HKR-to-MAX96717 input rate per lane
@@ -66,7 +68,7 @@
 		target-path = "/";
 		__overlay__ {
 			tegra-capture-vi {
-				num-channels = <4>;
+				num-channels = <5>;
 				ports {
 					#address-cells = <1>;
 					#size-cells = <0>;
@@ -122,6 +124,19 @@
 							remote-endpoint = <&d5xx_csi_out3>;
 						};
 					};
+
+					/* VC4: RGB-right on D585 2C */
+					port@4 {
+						status = "okay";
+						reg = <4>;
+						d5xx_vi_in4: endpoint {
+							status = "okay";
+							vc-id = <4>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d5xx_csi_out4>;
+						};
+					};
 				};
 			};
 
@@ -131,8 +146,8 @@
 			 * tegra_camera_misc.parent == NULL. At STREAMON,
 			 * vi5_power_on() -> tegra_camera_emc_clk_enable() calls
 			 * dev_get_drvdata(NULL) -> NULL deref at offset 0x78 ->
-			 * kernel panic / instant reboot. The 4 modules below map
-			 * the 4 D5xx streams (Depth/RGB/IR/IMU) for bandwidth calc.
+			 * kernel panic / instant reboot. The modules below map the
+			 * D5xx streams for bandwidth calculation.
 			 */
 			tegra-camera-platform {
 				status = "okay";
@@ -183,13 +198,22 @@
 							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/d5xx@1d";
 						};
 					};
+					cam_module4: module4 {
+						badge = "d5xx_dualrgb_right";
+						position = "centerright";
+						orientation = "1";
+						cam_module4_drivernode0: drivernode0 {
+							pcl_id = "v4l2_sensor";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/d5xx@1e";
+						};
+					};
 				};
 			};
 
 			bus@0 {
 				host1x@13e00000 {
 					nvcsi@15a00000 {
-						num-channels = <4>;
+						num-channels = <5>;
 						#address-cells = <1>;
 						#size-cells = <0>;
 
@@ -308,6 +332,36 @@
 									d5xx_csi_out3: endpoint@7 {
 										status = "okay";
 										remote-endpoint = <&d5xx_vi_in3>;
+									};
+								};
+							};
+						};
+
+						/* NVCSI channel 4: RGB-right (VC4) */
+						channel@4 {
+							status = "okay";
+							reg = <4>;
+							ports {
+								status = "okay";
+								#address-cells = <1>;
+								#size-cells = <0>;
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d5xx_csi_in4: endpoint@8 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										vc-id = <4>;
+										remote-endpoint = <&d5xx_dualrgb_right_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d5xx_csi_out4: endpoint@9 {
+										status = "okay";
+										remote-endpoint = <&d5xx_vi_in4>;
 									};
 								};
 							};
@@ -565,6 +619,64 @@
 								csi-mode = "1x4";
 								st-vc = <1>;
 								vc-id = <1>;
+								num-lanes = <4>;
+							};
+						};
+
+						/* D585 2C RGB-right stream on VC4. */
+						d5xx_dualrgb_right: d5xx@1e {
+							status = "okay";
+							def-addr = <0x10>;
+							reg = <0x1e>;
+							override_reg = <0x1a>;
+							compatible = "realsense,d5xx";
+							use_sensor_mode_id = "true";
+							cam-type = "DUALRGB_RIGHT";
+							mipi-lane-rate-mbps = <1300>;
+							nvidia,gmsl-ser-device = <&ser_a>;
+							nvidia,gmsl-dser-device = <&dser>;
+
+							ports {
+								#address-cells = <1>;
+								#size-cells = <0>;
+
+								port@0 {
+									reg = <0>;
+									d5xx_dualrgb_right_out: endpoint {
+										vc-id = <4>;
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&d5xx_csi_in4>;
+									};
+								};
+							};
+
+							mode0 {
+								pixel_t = "yuv_yuyv16";
+								num_lanes = "4";
+								csi_pixel_bit_depth = "16";
+								active_w = "1920";
+								active_h = "1080";
+								tegra_sinterface = "serial_c";
+								phy_mode = "DPHY";
+								discontinuous_clk = "no";
+								cil_settletime = "0";
+								deskew_initial_enable = "false";
+								deskew_periodic_enable = "false";
+								mclk_khz = "24000";
+								pix_clk_hz = "325000000";
+								serdes_pix_clk_hz = "375000000";
+								line_length = "1920";
+								embedded_metadata_height = "1";
+							};
+
+							gmsl-link {
+								src-csi-port = "a";
+								dst-csi-port = "a";
+								serdes-csi-link = "a";
+								csi-mode = "1x4";
+								st-vc = <4>;
+								vc-id = <4>;
 								num-lanes = <4>;
 							};
 						};

--- a/kernel/kernel-5.10/5.0.2/0005-Add-Realsense-NV12-User-Defined-media-bus-format.patch
+++ b/kernel/kernel-5.10/5.0.2/0005-Add-Realsense-NV12-User-Defined-media-bus-format.patch
@@ -2,10 +2,14 @@ diff --git a/include/uapi/linux/media-bus-format.h b/include/uapi/linux/media-bu
 index b2362999fd3d..2327f0a740aa 100644
 --- a/include/uapi/linux/media-bus-format.h
 +++ b/include/uapi/linux/media-bus-format.h
-@@ -159,4 +159,6 @@
+@@ -159,4 +159,10 @@
  #define MEDIA_BUS_FMT_S5C_UYVY_JPEG_1X8		0x5001
 -
-+/* RealSense flat NV12 bytes over an opaque 8-bit CSI carrier */
++/* RealSense byte surfaces carried over CSI-2 User Defined data types */
++#define MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10	0x5002
++#define MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16	0x5003
++#define MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8		0x5005
++#define MEDIA_BUS_FMT_RS_NV12_UD32_1X8		0x5008
 +#define MEDIA_BUS_FMT_RS_NV12_FLAT_1X8		0x5008
 +
  /* HSV - next is	0x6002 */

--- a/kernel/kernel-5.10/5.1.2/0003-Add-Realsense-NV12-User-Defined-media-bus-format.patch
+++ b/kernel/kernel-5.10/5.1.2/0003-Add-Realsense-NV12-User-Defined-media-bus-format.patch
@@ -2,10 +2,14 @@ diff --git a/include/uapi/linux/media-bus-format.h b/include/uapi/linux/media-bu
 index b2362999fd3d..2327f0a740aa 100644
 --- a/include/uapi/linux/media-bus-format.h
 +++ b/include/uapi/linux/media-bus-format.h
-@@ -159,4 +159,6 @@
+@@ -159,4 +159,10 @@
  #define MEDIA_BUS_FMT_S5C_UYVY_JPEG_1X8		0x5001
 -
-+/* RealSense flat NV12 bytes over an opaque 8-bit CSI carrier */
++/* RealSense byte surfaces carried over CSI-2 User Defined data types */
++#define MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10	0x5002
++#define MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16	0x5003
++#define MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8		0x5005
++#define MEDIA_BUS_FMT_RS_NV12_UD32_1X8		0x5008
 +#define MEDIA_BUS_FMT_RS_NV12_FLAT_1X8		0x5008
 +
  /* HSV - next is	0x6002 */

--- a/kernel/kernel-jammy-src/6.0/0002-realsense-camera-formats-jammy-master.patch
+++ b/kernel/kernel-jammy-src/6.0/0002-realsense-camera-formats-jammy-master.patch
@@ -10,9 +10,9 @@ Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
  drivers/media/usb/uvc/uvc_driver.c   | 57 ++++++++++++++++++++++++++++
  drivers/media/usb/uvc/uvcvideo.h     | 34 +++++++++++++++++
  drivers/media/v4l2-core/v4l2-ioctl.c |  9 +++++
- include/uapi/linux/media-bus-format.h |  3 +++
+ include/uapi/linux/media-bus-format.h |  7 +++++++
  include/uapi/linux/videodev2.h       |  9 +++++
- 5 files changed, 112 insertions(+)
+ 5 files changed, 116 insertions(+)
 
 diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
 index 9a791d8ef200..205d524128da 100644
@@ -197,8 +197,12 @@ index 9260791b8438..fd50e9c34a0e 100644
 diff --git a/include/uapi/linux/media-bus-format.h b/include/uapi/linux/media-bus-format.h
 --- a/include/uapi/linux/media-bus-format.h
 +++ b/include/uapi/linux/media-bus-format.h
-@@ -162,1 +162,4 @@
-+/* RealSense flat NV12 bytes over an opaque 8-bit CSI carrier */
+@@ -162,1 +162,8 @@
++/* RealSense byte surfaces carried over CSI-2 User Defined data types */
++#define MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10	0x5002
++#define MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16	0x5003
++#define MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8		0x5005
++#define MEDIA_BUS_FMT_RS_NV12_UD32_1X8		0x5008
 +#define MEDIA_BUS_FMT_RS_NV12_FLAT_1X8		0x5008
 +
  /* HSV - next is	0x6002 */

--- a/kernel/kernel-jammy-src/6.2.1/0002-realsense-camera-formats-jammy-master.patch
+++ b/kernel/kernel-jammy-src/6.2.1/0002-realsense-camera-formats-jammy-master.patch
@@ -10,9 +10,9 @@ Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
  drivers/media/usb/uvc/uvc_driver.c   | 57 ++++++++++++++++++++++++++++
  drivers/media/usb/uvc/uvcvideo.h     | 34 +++++++++++++++++
  drivers/media/v4l2-core/v4l2-ioctl.c |  9 +++++
- include/uapi/linux/media-bus-format.h |  3 +++
+ include/uapi/linux/media-bus-format.h |  7 +++++++
  include/uapi/linux/videodev2.h       |  9 +++++
- 5 files changed, 112 insertions(+)
+ 5 files changed, 116 insertions(+)
 
 diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
 index 9a791d8ef200..205d524128da 100644
@@ -197,8 +197,12 @@ index 9260791b8438..fd50e9c34a0e 100644
 diff --git a/include/uapi/linux/media-bus-format.h b/include/uapi/linux/media-bus-format.h
 --- a/include/uapi/linux/media-bus-format.h
 +++ b/include/uapi/linux/media-bus-format.h
-@@ -162,1 +162,4 @@
-+/* RealSense flat NV12 bytes over an opaque 8-bit CSI carrier */
+@@ -162,1 +162,8 @@
++/* RealSense byte surfaces carried over CSI-2 User Defined data types */
++#define MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10	0x5002
++#define MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16	0x5003
++#define MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8		0x5005
++#define MEDIA_BUS_FMT_RS_NV12_UD32_1X8		0x5008
 +#define MEDIA_BUS_FMT_RS_NV12_FLAT_1X8		0x5008
 +
  /* HSV - next is	0x6002 */

--- a/kernel/kernel-jammy-src/6.2/0002-realsense-camera-formats-jammy-master.patch
+++ b/kernel/kernel-jammy-src/6.2/0002-realsense-camera-formats-jammy-master.patch
@@ -10,9 +10,9 @@ Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
  drivers/media/usb/uvc/uvc_driver.c   | 57 ++++++++++++++++++++++++++++
  drivers/media/usb/uvc/uvcvideo.h     | 34 +++++++++++++++++
  drivers/media/v4l2-core/v4l2-ioctl.c |  9 +++++
- include/uapi/linux/media-bus-format.h |  3 +++
+ include/uapi/linux/media-bus-format.h |  7 +++++++
  include/uapi/linux/videodev2.h       |  9 +++++
- 5 files changed, 112 insertions(+)
+ 5 files changed, 116 insertions(+)
 
 diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
 index 9a791d8ef200..205d524128da 100644
@@ -197,8 +197,12 @@ index 9260791b8438..fd50e9c34a0e 100644
 diff --git a/include/uapi/linux/media-bus-format.h b/include/uapi/linux/media-bus-format.h
 --- a/include/uapi/linux/media-bus-format.h
 +++ b/include/uapi/linux/media-bus-format.h
-@@ -162,1 +162,4 @@
-+/* RealSense flat NV12 bytes over an opaque 8-bit CSI carrier */
+@@ -162,1 +162,8 @@
++/* RealSense byte surfaces carried over CSI-2 User Defined data types */
++#define MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10	0x5002
++#define MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16	0x5003
++#define MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8		0x5005
++#define MEDIA_BUS_FMT_RS_NV12_UD32_1X8		0x5008
 +#define MEDIA_BUS_FMT_RS_NV12_FLAT_1X8		0x5008
 +
  /* HSV - next is	0x6002 */

--- a/kernel/kernel-noble-src/7.0/0002-realsense-camera-formats-jammy-master.patch
+++ b/kernel/kernel-noble-src/7.0/0002-realsense-camera-formats-jammy-master.patch
@@ -10,9 +10,9 @@ Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
  drivers/media/common/uvc.c   | 57 ++++++++++++++++++++++++++++
  drivers/include/linux/usb/uvc.h     | 34 +++++++++++++++++
  drivers/media/v4l2-core/v4l2-ioctl.c |  9 +++++
- include/uapi/linux/media-bus-format.h |  3 +++
+ include/uapi/linux/media-bus-format.h |  7 +++++++
  include/uapi/linux/videodev2.h       |  9 +++++
- 5 files changed, 112 insertions(+)
+ 5 files changed, 116 insertions(+)
 
 diff --git a/drivers/media/common/uvc.c b/drivers/media/common/uvc.c
 index 9a791d8ef200..205d524128da 100644
@@ -193,8 +193,12 @@ index 9260791b8438..fd50e9c34a0e 100644
 diff --git a/include/uapi/linux/media-bus-format.h b/include/uapi/linux/media-bus-format.h
 --- a/include/uapi/linux/media-bus-format.h
 +++ b/include/uapi/linux/media-bus-format.h
-@@ -162,1 +162,4 @@
-+/* RealSense flat NV12 bytes over an opaque 8-bit CSI carrier */
+@@ -162,1 +162,8 @@
++/* RealSense byte surfaces carried over CSI-2 User Defined data types */
++#define MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10	0x5002
++#define MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16	0x5003
++#define MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8		0x5005
++#define MEDIA_BUS_FMT_RS_NV12_UD32_1X8		0x5008
 +#define MEDIA_BUS_FMT_RS_NV12_FLAT_1X8		0x5008
 +
  /* HSV - next is	0x6002 */

--- a/kernel/kernel-noble-src/7.1/0002-realsense-camera-formats-jammy-master.patch
+++ b/kernel/kernel-noble-src/7.1/0002-realsense-camera-formats-jammy-master.patch
@@ -10,9 +10,9 @@ Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
  drivers/media/common/uvc.c   | 57 ++++++++++++++++++++++++++++
  drivers/include/linux/usb/uvc.h     | 34 +++++++++++++++++
  drivers/media/v4l2-core/v4l2-ioctl.c |  9 +++++
- include/uapi/linux/media-bus-format.h |  3 +++
+ include/uapi/linux/media-bus-format.h |  7 +++++++
  include/uapi/linux/videodev2.h       |  9 +++++
- 5 files changed, 112 insertions(+)
+ 5 files changed, 116 insertions(+)
 
 diff --git a/drivers/media/common/uvc.c b/drivers/media/common/uvc.c
 index 9a791d8ef200..205d524128da 100644
@@ -193,8 +193,12 @@ index 9260791b8438..fd50e9c34a0e 100644
 diff --git a/include/uapi/linux/media-bus-format.h b/include/uapi/linux/media-bus-format.h
 --- a/include/uapi/linux/media-bus-format.h
 +++ b/include/uapi/linux/media-bus-format.h
-@@ -162,1 +162,4 @@
-+/* RealSense flat NV12 bytes over an opaque 8-bit CSI carrier */
+@@ -162,1 +162,8 @@
++/* RealSense byte surfaces carried over CSI-2 User Defined data types */
++#define MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10	0x5002
++#define MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16	0x5003
++#define MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8		0x5005
++#define MEDIA_BUS_FMT_RS_NV12_UD32_1X8		0x5008
 +#define MEDIA_BUS_FMT_RS_NV12_FLAT_1X8		0x5008
 +
  /* HSV - next is	0x6002 */

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -36,6 +36,7 @@
 #include <media/v4l2-device.h>
 #include <media/v4l2-subdev.h>
 #include <media/v4l2-mediabus.h>
+#include <media/gmsl-link.h>
 
 #ifdef CONFIG_VIDEO_D4XX_SERDES
 #include <media/max9295.h>
@@ -114,12 +115,6 @@ struct ser_interface {
 	const char *name;
 };
 
-#else
-#include <media/gmsl-link.h>
-#define GMSL_CSI_DT_YUV422_8 0x1E
-#define GMSL_CSI_DT_RGB_888 0x24
-#define GMSL_CSI_DT_RAW_8 0x2A
-#define GMSL_CSI_DT_EMBED 0x12
 #endif
 
 /* D40x FW CSI-PT mode selector for the OV9782 (not a MIPI wire DT). */
@@ -149,6 +144,8 @@ struct ser_interface {
 /* GVD response payload size per product line */
 #define DS5_GVD_LEN_D4XX		276
 #define DS5_GVD_LEN_D5XX		606
+#define DS5_DUAL_RGB_MAX_OUTPUT_FPS	30
+/* 4-byte HWM opcode + 8-byte GVD header + skuComponent + USBVID. */
 #define D585_GVD_PID_OFFSET		18
 #define D585_2C_PROTO_PID		0x0C07
 #define D585_3C_PROTO_PID		0x0C08
@@ -162,11 +159,13 @@ struct ser_interface {
 #define DS5_DEPTH_STREAM_STATUS		0x1004
 #define DS5_RGB_STREAM_STATUS		0x1008
 #define DS5_IMU_STREAM_STATUS		0x100C
+#define DS5_DUALRGB_RIGHT_STREAM_STATUS	0x1010
 #define DS5_IR_STREAM_STATUS		0x1014
 
 #define DS5_STREAM_DEPTH		0x0
 #define DS5_STREAM_RGB			0x1
 #define DS5_STREAM_IMU			0x2
+#define DS5_STREAM_DUALRGB_RIGHT		0x3
 #define DS5_STREAM_IR			0x4
 #define DS5_STREAM_STOP			0x100
 #define DS5_STREAM_START		0x200
@@ -188,6 +187,14 @@ struct ser_interface {
 #define DS5_RGB_FPS				0x402C
 #define DS5_RGB_CONTROL_STATUS 	0x402E
 #define DS5_RGB_OVERRIDE		0x403C
+
+#define DS5_DUALRGB_RIGHT_STREAM_DT	0x4060
+#define DS5_DUALRGB_RIGHT_STREAM_MD	0x4062
+#define DS5_DUALRGB_RIGHT_RES_WIDTH	0x4064
+#define DS5_DUALRGB_RIGHT_RES_HEIGHT	0x4068
+#define DS5_DUALRGB_RIGHT_FPS		0x406C
+#define DS5_DUALRGB_RIGHT_OVERRIDE	0x407C
+#define DS5_DUALRGB_RIGHT_CONTROL_STATUS	0x407E
 
 /* SerDes startup I2C readiness polling (defer probe if not responsive) */
 #define DS5_SERDES_STARTUP_TIMEOUT_MS 2000
@@ -263,6 +270,7 @@ struct ser_interface {
 #define DS5_DEPTH_CONFIG_STATUS		0x4800
 #define DS5_RGB_CONFIG_STATUS		0x4802
 #define DS5_IMU_CONFIG_STATUS		0x4804
+#define DS5_DUALRGB_RIGHT_CONFIG_STATUS	0x4806
 #define DS5_IR_CONFIG_STATUS		0x4808
 
 #define DS5_STATUS_STREAMING		0x1
@@ -613,7 +621,7 @@ struct ds5 {
 	struct regmap *regmap;
 	struct regulator *vcc;
 	const struct ds5_variant *variant;
-	int is_depth, is_y8, is_rgb, is_imu;
+	int is_depth, is_y8, is_rgb, is_dualrgb_right, is_imu;
 	bool metadata_enabled;
 	int aggregated;
 	int reset_ref_ds5;
@@ -691,8 +699,26 @@ struct ds5_dev {
 	bool depth_streaming;
 	bool ir_streaming;
 	bool rgb_streaming;
+	bool dualrgb_right_streaming;
 	bool imu_streaming;
 };
+
+static bool ds5_is_dual_rgb_2c(const struct ds5 *state)
+{
+	return state->ds5_dev &&
+		READ_ONCE(state->ds5_dev->d585_product_id) == D585_2C_PROTO_PID;
+}
+
+static bool ds5_is_dual_rgb_tdm_image(const struct ds5 *state)
+{
+	return ds5_is_dual_rgb_2c(state) &&
+		(state->is_depth || state->is_y8 || state->is_rgb);
+}
+
+static bool ds5_is_dualrgb_left(const struct ds5 *state)
+{
+	return state->is_rgb && !state->is_dualrgb_right;
+}
 
 #ifdef CONFIG_VIDEO_D4XX_SERDES
 static DEFINE_MUTEX(serdes_lock__);
@@ -772,6 +798,7 @@ static const struct dser_interface max96712_interface = {
 
 static const struct dser_interface max96724_interface = {
 	.get_available_pipe_id = max96724_get_available_pipe_id,
+	.get_multi_vc_pipe_id = max96724_get_multi_vc_pipe_id,
 	.bind_ser_to_dser_pipe = max96724_bind_ser_to_dser_pipe,
 	.set_pipe = max96724_set_pipe,
 	.release_pipe = max96724_release_pipe,
@@ -1704,6 +1731,27 @@ static const struct ds5_format ds5_y_formats_d58x[] = {
 	},
 };
 
+static const struct ds5_format ds5_y_formats_d58x_tunnel[] = {
+	{
+		/* First format: default */
+		.data_type = GMSL_CSI_DT_RAW_8,		/* Y8 */
+		.mbus_code = MEDIA_BUS_FMT_Y8_1X8,
+		.n_resolutions = ARRAY_SIZE(d58x_y8_sizes),
+		.resolutions = d58x_y8_sizes,
+	}, {
+		.data_type = GMSL_CSI_DT_YUV422_8,	/* Y8I */
+		.mbus_code = MEDIA_BUS_FMT_VYUY8_1X16,
+		.n_resolutions = ARRAY_SIZE(d58x_y8_sizes),
+		.resolutions = d58x_y8_sizes,
+	}, {
+		.data_type = GMSL_CSI_DT_RAW_16,
+		.override_data_type = GMSL_CSI_DT_UED_U3,
+		.mbus_code = MEDIA_BUS_FMT_RS_Y12I_UDP8_4X8,
+		.n_resolutions = ARRAY_SIZE(d58x_calibration_sizes),
+		.resolutions = d58x_calibration_sizes,
+	},
+};
+
 static const struct ds5_format ds5_rgb_formats_d58x[] = {
 	{
 		/* First format: default */
@@ -1724,6 +1772,37 @@ static const struct ds5_format ds5_rgb_formats_d58x[] = {
 		 */
 		.data_type = GMSL_CSI_DT_RAW_16,
 		.mbus_code = MEDIA_BUS_FMT_SGRBG16_1X16,
+		.n_resolutions = ARRAY_SIZE(d58x_calibration_sizes),
+		.resolutions = d58x_calibration_sizes,
+	},
+};
+/* Keep shared YUYV and calibration entries aligned with the base table. */
+static const struct ds5_format ds5_rgb_formats_d58x_tunnel[] = {
+	{
+		/* First format: default */
+		.data_type = GMSL_CSI_DT_YUV422_8,	/* UYVY */
+		.mbus_code = MEDIA_BUS_FMT_YUYV8_1X16,
+		.n_resolutions = ARRAY_SIZE(d58x_rgb_sizes),
+		.resolutions = d58x_rgb_sizes,
+	}, {
+		/* Flat NV12 bytes use the UDP8 carrier as an opaque byte stream. */
+		.data_type = GMSL_CSI_DT_YUV420_8,
+		.override_data_type = GMSL_CSI_DT_UED_U3,
+		.mbus_code = MEDIA_BUS_FMT_RS_NV12_FLAT_1X8,
+		.n_resolutions = ARRAY_SIZE(d58x_rgb_sizes),
+		.resolutions = d58x_rgb_sizes,
+	}, {
+		/* Unpacked GRBG10 keeps one sample in each 16-bit container. */
+		.data_type = GMSL_CSI_DT_RAW_16,
+		.override_data_type = GMSL_CSI_DT_UED_U3,
+		.mbus_code = MEDIA_BUS_FMT_RS_SGRBG10_UDP8_1X16,
+		.n_resolutions = ARRAY_SIZE(d58x_calibration_sizes),
+		.resolutions = d58x_calibration_sizes,
+	}, {
+		/* Packed GRBG10 keeps the native HKR cache-line byte layout. */
+		.data_type = GMSL_CSI_DT_RAW_10,
+		.override_data_type = GMSL_CSI_DT_UED_U3,
+		.mbus_code = MEDIA_BUS_FMT_RS_SGRBG10P_UDP8_1X10,
 		.n_resolutions = ARRAY_SIZE(d58x_calibration_sizes),
 		.resolutions = d58x_calibration_sizes,
 	},
@@ -1793,6 +1872,9 @@ static const char *ds5_get_sensor_name(struct ds5 *state)
 	static const char *sensor_name[] = {"unknown", "RGB", "DEPTH", "Y8", "IMU"};
 	int sensor_id = state->is_rgb * 1 + state->is_depth * 2 + \
 			state->is_y8 * 3 + state->is_imu * 4;
+
+	if (state->is_dualrgb_right)
+		return "DUALRGB_RIGHT";
 	if (sensor_id >= (sizeof(sensor_name)/sizeof(*sensor_name)))
 		sensor_id = 0;
 
@@ -1913,6 +1995,7 @@ static int ds5_sensor_enum_frame_interval(struct v4l2_subdev *sd,
 #endif
 		struct v4l2_subdev_frame_interval_enum *fie)
 {
+	struct ds5 *ds5_state = v4l2_get_subdevdata(sd);
 	struct ds5_sensor *sensor = container_of(sd, struct ds5_sensor, sd);
 	const struct ds5_format *fmt;
 	const struct ds5_resolution *res;
@@ -1933,6 +2016,9 @@ static int ds5_sensor_enum_frame_interval(struct v4l2_subdev *sd,
 		return -EINVAL;
 
 	if (fie->index >= res->n_framerates)
+		return -EINVAL;
+	if (ds5_is_dual_rgb_tdm_image(ds5_state) &&
+	    res->framerates[fie->index] > DS5_DUAL_RGB_MAX_OUTPUT_FPS)
 		return -EINVAL;
 
 	fie->interval.numerator = 1;
@@ -2194,11 +2280,13 @@ static void ds5_invalidate_sensor(struct ds5 *state, struct ds5_sensor *sensor)
 	sensor->pipe_vc_id = 0xFFFF;
 }
 
+#ifdef CONFIG_VIDEO_D4XX_SERDES
 static u8 ds5_wire_data_type(const struct ds5_format *format)
 {
 	return format->override_data_type ? format->override_data_type :
 		format->data_type;
 }
+#endif
 
 static int ds5_configure(struct ds5 *state)
 {
@@ -2226,11 +2314,24 @@ static int ds5_configure(struct ds5 *state)
 		fps_addr = DS5_DEPTH_FPS;
 		width_addr = DS5_DEPTH_RES_WIDTH;
 		height_addr = DS5_DEPTH_RES_HEIGHT;
+	} else if (state->is_dualrgb_right) {
+		sensor = &state->rgb.sensor;
+		dt_addr = DS5_DUALRGB_RIGHT_STREAM_DT;
+		md_addr = DS5_DUALRGB_RIGHT_STREAM_MD;
+		override_addr = DS5_DUALRGB_RIGHT_OVERRIDE;
+		fps_addr = DS5_DUALRGB_RIGHT_FPS;
+		width_addr = DS5_DUALRGB_RIGHT_RES_WIDTH;
+		height_addr = DS5_DUALRGB_RIGHT_RES_HEIGHT;
 	} else if (state->is_rgb) {
 		sensor = &state->rgb.sensor;
 		dt_addr = DS5_RGB_STREAM_DT;
 		md_addr = DS5_RGB_STREAM_MD;
-		override_addr = DS5_RGB_OVERRIDE;
+		/* D58x tunnel formats always program the stream override contract:
+		 * non-zero selects a carrier DT and zero clears any prior carrier.
+		 * The format cache avoids redundant I2C writes. D4xx is unchanged. */
+		override_addr = (ds5_is_d58x(state) && !state->d58x_pixel_mode) ||
+			sensor->config.format->mbus_code == MEDIA_BUS_FMT_SBGGR8_1X8 ?
+			DS5_RGB_OVERRIDE : 0;
 		fps_addr = DS5_RGB_FPS;
 		width_addr = DS5_RGB_RES_WIDTH;
 		height_addr = DS5_RGB_RES_HEIGHT;
@@ -2334,7 +2435,8 @@ static int ds5_configure(struct ds5 *state)
 				sensor->pipe_id, data_type1, data_type2, vc_id);
 	}
 #else /* Non-SERDES configuration */
-	vc_id = (state->is_depth) ? 0 : (state->is_rgb) ? 1 : (state->is_y8) ? 2 : 3;
+	vc_id = state->is_depth ? 0 : state->is_dualrgb_right ? 4 :
+		state->is_rgb ? 1 : state->is_y8 ? 2 : 3;
 	md_vc = vc_id;
 #endif
 
@@ -2370,8 +2472,20 @@ static int ds5_configure(struct ds5 *state)
 	}
 
 	if (override_addr != 0) {
-		/* The override register always carries the wire DT. */
-		dt_value = ds5_wire_data_type(sensor->config.format);
+		/* D58x tunnel uses an explicit per-format carrier contract, including
+		 * zero to clear a previous override. Preserve the existing D4xx
+		 * depth/IR override values. */
+		if (ds5_is_d58x(state) && !state->d58x_pixel_mode &&
+		    (state->is_rgb ||
+		     sensor->config.format->override_data_type))
+			dt_value = sensor->config.format->override_data_type;
+		else
+			dt_value = sensor->config.format->data_type;
+		/* RAW8 CSI passthrough: FW runs in CSI-PT mode (0x2E → dt_addr) and
+		 * remaps all wire DTs to RAW8 via override_addr=0x2A.
+		 */
+		if (sensor->config.format->mbus_code == MEDIA_BUS_FMT_SBGGR8_1X8)
+			dt_value = MIPI_CSI2_TYPE_RAW8;
 		if (sensor->cached_override_value != dt_value) {
 			ret = ds5_write(state, override_addr, dt_value);
 			if (ret < 0)
@@ -2443,6 +2557,7 @@ static int ds5_sensor_s_frame_interval(struct v4l2_subdev *sd,
 #endif
 		struct v4l2_subdev_frame_interval *fi)
 {
+	struct ds5 *ds5_state = v4l2_get_subdevdata(sd);
 	struct ds5_sensor *sensor = container_of(sd, struct ds5_sensor, sd);
 	u16 framerate = 1;
 
@@ -2450,6 +2565,9 @@ static int ds5_sensor_s_frame_interval(struct v4l2_subdev *sd,
 		return -EINVAL;
 
 	framerate = fi->interval.denominator / fi->interval.numerator;
+	if (ds5_is_dual_rgb_tdm_image(ds5_state) &&
+	    framerate > DS5_DUAL_RGB_MAX_OUTPUT_FPS)
+		return -EINVAL;
 	framerate = __ds5_probe_framerate(sensor->config.resolution, framerate);
 	sensor->config.framerate = framerate;
 	fi->interval.numerator = 1;
@@ -2962,6 +3080,7 @@ static void ds5_reset_streaming_flags(struct ds5_dev *ds5_dev)
 	ds5_dev->depth_streaming = false;
 	ds5_dev->ir_streaming = false;
 	ds5_dev->rgb_streaming = false;
+	ds5_dev->dualrgb_right_streaming = false;
 	ds5_dev->imu_streaming = false;
 	mutex_unlock(&ds5_dev->lock);
 }
@@ -3034,6 +3153,7 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	struct hwm_cmd reset_cmd;
 	bool depth_streaming;
 	bool rgb_streaming;
+	bool dualrgb_right_streaming;
 	bool ir_streaming;
 	bool imu_streaming;
 	u16 d585_product_id = READ_ONCE(state->ds5_dev->d585_product_id);
@@ -3078,6 +3198,7 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	mutex_lock(&state->ds5_dev->lock);
 	depth_streaming = state->ds5_dev->depth_streaming;
 	rgb_streaming = state->ds5_dev->rgb_streaming;
+	dualrgb_right_streaming = state->ds5_dev->dualrgb_right_streaming;
 	ir_streaming = state->ds5_dev->ir_streaming;
 	imu_streaming = state->ds5_dev->imu_streaming;
 	mutex_unlock(&state->ds5_dev->lock);
@@ -3086,6 +3207,9 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 		ds5_write(state, DS5_START_STOP_STREAM,	DS5_STREAM_STOP | DS5_STREAM_DEPTH);
 	if (rgb_streaming)
 		ds5_write(state, DS5_START_STOP_STREAM,	DS5_STREAM_STOP | DS5_STREAM_RGB);
+	if (dualrgb_right_streaming)
+		ds5_write(state, DS5_START_STOP_STREAM,
+			  DS5_STREAM_STOP | DS5_STREAM_DUALRGB_RIGHT);
 	if (ir_streaming)
 		ds5_write(state, DS5_START_STOP_STREAM,	DS5_STREAM_STOP | DS5_STREAM_IR);
 	if (imu_streaming)
@@ -3821,6 +3945,47 @@ static int ds5_gvd(struct ds5 *state, unsigned char *data, u32 buf_len)
 	ds5_raw_read_with_check(state, DS5_HWMC_DATA, data, length); /* Read response data */
 
 	return 0;
+}
+
+static int ds5_cache_product_pid(struct ds5 *state)
+{
+	unsigned char *data;
+	u16 pid;
+	int ret = 0;
+
+	if (READ_ONCE(state->ds5_dev->d585_product_id))
+		return 0;
+
+	data = kzalloc(DS5_GVD_LEN_D5XX, GFP_KERNEL);
+	if (!data)
+		return -ENOMEM;
+
+	mutex_lock(&state->ds5_dev->lock);
+	if (state->ds5_dev->d585_product_id)
+		goto unlock;
+
+	ret = ds5_gvd(state, data, DS5_GVD_LEN_D5XX);
+	if (ret)
+		goto unlock;
+	if (data[0] != 0x10 || data[1] || data[2] || data[3]) {
+		ret = -EPROTO;
+		goto unlock;
+	}
+
+	pid = data[D585_GVD_PID_OFFSET] |
+		((u16)data[D585_GVD_PID_OFFSET + 1] << 8);
+	if (!pid) {
+		ret = -ENODATA;
+		goto unlock;
+	}
+
+	state->ds5_dev->d585_product_id = pid;
+	dev_info(&state->client->dev, "D5xx GVD product PID: 0x%04x\n", pid);
+
+unlock:
+	mutex_unlock(&state->ds5_dev->lock);
+	kfree(data);
+	return ret;
 }
 
 static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
@@ -5642,6 +5807,7 @@ static int ds5_sensor_init(struct i2c_client *c, struct ds5 *state,
 	char suffix = dpdata->suffix;
 #endif
 	sensor->pipe_id = PIPE_NOT_CONFIGURED;
+	ds5_config_cache_clear(sensor);
 	v4l2_i2c_subdev_init(sd, c, ops);
 	// See tegracam_v4l2.c tegracam_v4l2subdev_register()
 	// Set owner to NULL so we can unload the driver module
@@ -5787,8 +5953,15 @@ static int ds5_mux_enum_mbus_code(struct v4l2_subdev *sd,
 	}
 
 	tmp.pad = 0;
-	if (state->is_rgb)
+	if (state->is_rgb) {
 		remote_sd = &state->rgb.sensor.sd;
+		/* The external-pad aggregation above offsets indexes after the IR
+		 * format count. D58x tunnel RGB has more entries than IR, so keep
+		 * the RGB sensor's original index to expose its final format.
+		 */
+		if (ds5_is_d58x(state) && !state->d58x_pixel_mode)
+			tmp.index = mce->index;
+	}
 	if (state->is_depth)
 		remote_sd = &state->depth.sensor.sd;
 	if (state->is_y8)
@@ -6124,6 +6297,9 @@ static int ds5_mux_s_frame_interval(struct v4l2_subdev *sd,
 	sensor = ds5_state->mux.last_set;
 
 	framerate = fi->interval.denominator / fi->interval.numerator;
+	if (ds5_is_dual_rgb_tdm_image(ds5_state) &&
+	    framerate > DS5_DUAL_RGB_MAX_OUTPUT_FPS)
+		return -EINVAL;
 	framerate = __ds5_probe_framerate(sensor->config.resolution, framerate);
 	sensor->config.framerate = framerate;
 	fi->interval.numerator = 1;
@@ -6193,6 +6369,12 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		stream_id = DS5_STREAM_DEPTH;
 		vc_id = 0;
 		streaming_flag = &state->ds5_dev->depth_streaming;
+	} else if (state->is_dualrgb_right) {
+		config_status_base = DS5_DUALRGB_RIGHT_CONFIG_STATUS;
+		stream_status_base = DS5_DUALRGB_RIGHT_STREAM_STATUS;
+		stream_id = DS5_STREAM_DUALRGB_RIGHT;
+		vc_id = 4;
+		streaming_flag = &state->ds5_dev->dualrgb_right_streaming;
 	} else if (state->is_rgb) {
 		config_status_base = DS5_RGB_CONFIG_STATUS;
 		stream_status_base = DS5_RGB_STREAM_STATUS;
@@ -6303,6 +6485,7 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 	 * so the flush cannot truncate a sibling's in-flight frames. */
 	if (on && !(state->ds5_dev->depth_streaming ||
 		    state->ds5_dev->rgb_streaming ||
+		    state->ds5_dev->dualrgb_right_streaming ||
 		    state->ds5_dev->ir_streaming ||
 		    state->ds5_dev->imu_streaming))
 		state->ds5_dev->link_flush_pending = true;
@@ -6718,7 +6901,7 @@ static int ds5_mux_init(struct i2c_client *c, struct ds5 *state)
 #endif
 		state->mux.last_set = &state->depth.sensor;
 	}
-	else if (state->is_rgb) {
+	else if (ds5_is_dualrgb_left(state)) {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 20, 0)
 		v4l2_ctrl_add_handler(&state->ctrls.handler,
 					&state->ctrls.handler_rgb, NULL);
@@ -6728,6 +6911,8 @@ static int ds5_mux_init(struct i2c_client *c, struct ds5 *state)
 #endif
 		state->mux.last_set = &state->rgb.sensor;
 	}
+	else if (state->is_dualrgb_right)
+		state->mux.last_set = &state->rgb.sensor;
 	else if (state->is_y8) {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 20, 0)
 		v4l2_ctrl_add_handler(&state->ctrls.handler,
@@ -6798,6 +6983,12 @@ static int ds5_fixed_configuration(struct i2c_client *client, struct ds5 *state)
 
 	sensor = &state->depth.sensor;
 	dev_type = ds5_dev_type(state, dev_type);
+	state->d58x_pixel_mode = false;
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+	state->d58x_pixel_mode = (dev_type == DS5_DEVICE_TYPE_D58X) &&
+				 (state->dser_ops == &max96712_interface);
+#endif
+
 	switch (dev_type) {
 	case DS5_DEVICE_TYPE_D41X:
 		sensor->formats = ds5_depth_formats_d41x;
@@ -6838,8 +7029,13 @@ static int ds5_fixed_configuration(struct i2c_client *client, struct ds5 *state)
 		sensor->n_formats = ARRAY_SIZE(ds5_y_formats_45x);
 		break;
 	case DS5_DEVICE_TYPE_D58X:
-		sensor->formats = ds5_y_formats_d58x;
-		sensor->n_formats = ARRAY_SIZE(ds5_y_formats_d58x);
+		if (!state->d58x_pixel_mode) {
+			sensor->formats = ds5_y_formats_d58x_tunnel;
+			sensor->n_formats = ARRAY_SIZE(ds5_y_formats_d58x_tunnel);
+		} else {
+			sensor->formats = ds5_y_formats_d58x;
+			sensor->n_formats = ARRAY_SIZE(ds5_y_formats_d58x);
+		}
 		break;
 	default:
 		sensor->formats = state->variant->formats;
@@ -6866,8 +7062,13 @@ static int ds5_fixed_configuration(struct i2c_client *client, struct ds5 *state)
 		sensor->n_formats = DS5_RLT_RGB_N_FORMATS;
 		break;
 	case DS5_DEVICE_TYPE_D58X:
-		sensor->formats = ds5_rgb_formats_d58x;
-		sensor->n_formats = ARRAY_SIZE(ds5_rgb_formats_d58x);
+		if (!state->d58x_pixel_mode) {
+			sensor->formats = ds5_rgb_formats_d58x_tunnel;
+			sensor->n_formats = ARRAY_SIZE(ds5_rgb_formats_d58x_tunnel);
+		} else {
+			sensor->formats = ds5_rgb_formats_d58x;
+			sensor->n_formats = ARRAY_SIZE(ds5_rgb_formats_d58x);
+		}
 		break;
 	default:
 		sensor->formats = &ds5_onsemi_rgb_format;
@@ -6876,13 +7077,6 @@ static int ds5_fixed_configuration(struct i2c_client *client, struct ds5 *state)
 	sensor->mux_pad = DS5_MUX_PAD_RGB;
 
 	sensor = &state->imu.sensor;
-
-	state->d58x_pixel_mode = false;
-#ifdef CONFIG_VIDEO_D4XX_SERDES
-	/* D58x on a MAX96712 deserializer runs the serdes link in PIXEL mode. */
-	state->d58x_pixel_mode = (dev_type == DS5_DEVICE_TYPE_D58X) &&
-				 (state->dser_ops == &max96712_interface);
-#endif
 
 	/* For fimware version starting from: 5.16,
 	   IMU will have 32bit axis values.
@@ -7790,6 +7984,7 @@ static int ds5_probe(struct i2c_client *c
 	state->is_depth = 0;
 	state->is_y8 = 0;
 	state->is_rgb = 0;
+	state->is_dualrgb_right = 0;
 	state->is_imu = 0;
 #ifdef CONFIG_OF
 	ret = of_property_read_string(c->dev.of_node, "cam-type", &str);
@@ -7803,10 +7998,13 @@ static int ds5_probe(struct i2c_client *c
 		state->control_base = DS5_DEPTH_CONTROL_BASE;
 		state->control_status_reg = DS5_DEPTH_CONTROL_STATUS;
 	}
-	if (!ret && !strncmp(str, "RGB", strlen("RGB"))) {
+	if (!ret && (!strncmp(str, "RGB", strlen("RGB")) ||
+		     !strncmp(str, "DUALRGB_", strlen("DUALRGB_")))) {
 		state->is_rgb = 1;
+		state->is_dualrgb_right = !strcmp(str, "DUALRGB_RIGHT");
 		state->control_base = DS5_RGB_CONTROL_BASE;
-		state->control_status_reg = DS5_RGB_CONTROL_STATUS;
+		state->control_status_reg = state->is_dualrgb_right ?
+			DS5_DUALRGB_RIGHT_CONTROL_STATUS : DS5_RGB_CONTROL_STATUS;
 	}
 	if (!ret && !strncmp(str, "IMU", strlen("IMU"))) {
 		state->is_imu = 1;
@@ -7876,26 +8074,18 @@ static int ds5_probe(struct i2c_client *c
 		goto e_chardev;
 	}
 
-	if (rec_state == DS5_DEVICE_TYPE_D58X &&
-	    !READ_ONCE(state->ds5_dev->d585_product_id)) {
-		unsigned char *gvd_data = kzalloc(DS5_GVD_LEN_D5XX, GFP_KERNEL);
-
-		if (gvd_data) {
-			ret = ds5_gvd(state, gvd_data, DS5_GVD_LEN_D5XX);
-			if (ret) {
-				dev_warn(&c->dev,
-					 "%s(): cannot cache D585 PID from GVD (%d)\n",
-					 __func__, ret);
-			} else {
-				u16 pid = gvd_data[D585_GVD_PID_OFFSET] |
-					  (gvd_data[D585_GVD_PID_OFFSET + 1] << 8);
-
-				WRITE_ONCE(state->ds5_dev->d585_product_id, pid);
-				dev_info(&c->dev, "%s(): D585 PID 0x%04x\n",
-					 __func__, pid);
-			}
-			kfree(gvd_data);
-		}
+	if (rec_state == DS5_DEVICE_TYPE_D58X) {
+		ret = ds5_cache_product_pid(state);
+		if (ret < 0)
+			dev_warn(&c->dev, "%s(): failed to read product PID: %d\n",
+				 __func__, ret);
+	}
+	if (state->is_dualrgb_right &&
+	    (ret < 0 || !ds5_is_dual_rgb_2c(state))) {
+		dev_info(&c->dev, "%s(): RGB-right is not present on this product\n",
+			 __func__);
+		ret = -ENODEV;
+		goto e_chardev;
 	}
 
 	ds5_read_with_check(state, DS5_FW_VERSION, &state->fw_version);

--- a/nvidia-oot/6.2/0013-Per-format-VI-datatype-override-for-wire-order-capture.patch
+++ b/nvidia-oot/6.2/0013-Per-format-VI-datatype-override-for-wire-order-capture.patch
@@ -16,10 +16,10 @@ the NVCSI RAW16 rule byte-swaps (CSI-2 defines RAW16 MSB-first); both
 override to YUV422-8 + T_Y8_U8__Y8_V8 for byte-identical little-endian
 capture, and Y16I declares frame_x_scale = 2/1 (32bpp L/R pair on a
 16bpp wire), replacing the fourcc-gated width doubling formerly in the
-0001 patches. Flat NV12 rides a RAW8 wire carrier with native matching (a
-geometry-only row; the MAX96717 pixel pipe forwards standard 8-bit DTs but drops user-defined ones) and
-frame_y_scale = 3/2 transport rows, replacing the per-format special
-cases of the earlier flat-NV12 receive path.
+0001 patches. Flat NV12 uses a descriptor-local RAW8 parser override so
+both the generic RAW8 carrier and tunnel UD32 retain byte-identical
+capture, plus frame_y_scale = 3/2 transport rows, replacing the
+per-format special cases of the earlier flat-NV12 receive path.
 
 HW-verified (JP6.2, fw-orin-5, D585): GR16 30/30 clean frames, Y16I
 5/5, LE payload on both, coexists with concurrent embedded-metadata
@@ -113,7 +113,7 @@ diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/medi
 index 73c1d84..2386594 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-@@ -149,6 +149,23 @@ static const struct tegra_video_format vi5_video_formats[] = {
+@@ -149,6 +149,24 @@ static const struct tegra_video_format vi5_video_formats[] = {
  	// R[7:3]R[3:0] | L[3:0]R[11:8] | L[11:8]L[7:4] | ALIGN[7:0]
  	TEGRA_VIDEO_FORMAT(RGB888, 24, RGB888_1X24, 4, 1, T_A8R8G8B8,
  				RGB888, Y12I, "Y12I 24"),
@@ -129,11 +129,12 @@ index 73c1d84..2386594 100644
 +				RAW16, SGRBG16, "GRBG16 16 LE",
 +				TEGRA_IMAGE_DT_YUV422_8,
 +				TEGRA_IMAGE_FORMAT_T_Y8_U8__Y8_V8, 1, 1, 1, 1),
-+	// Flat NV12 bytes over a RAW8 wire carrier: native match and byte
-+	// rule, one byte per wire pixel. Transport rows = H * 3/2.
++	// Flat NV12 bytes use the RAW8 byte rule. A descriptor-local RAW8
++	// override accepts both the generic RAW8 carrier and tunnel UD32.
++	// Transport rows = H * 3/2.
 +	TEGRA_VIDEO_FORMAT_OVERRIDE(RAW8, 8, RS_NV12_FLAT_1X8, 1, 1, T_R8,
 +				RAW8, NV12, "NV12 flat over RAW8",
-+				0, 0, 1, 1, 3, 2),
++				TEGRA_IMAGE_DT_RAW8, 0, 1, 1, 3, 2),
  
  };
  

--- a/nvidia-oot/6.2/0013-Per-format-VI-datatype-override-for-wire-order-capture.patch
+++ b/nvidia-oot/6.2/0013-Per-format-VI-datatype-override-for-wire-order-capture.patch
@@ -195,6 +195,20 @@ index a4c6978..a7394b7 100644
  u32 tegra_core_get_word_count(unsigned int frame_width,
  		const struct tegra_video_format *fmt);
  u32 tegra_core_bytes_per_line(unsigned int width, unsigned int align,
+diff --git a/include/media/gmsl-link.h b/include/media/gmsl-link.h
+index 48939537..868865ab 100644
+--- a/include/media/gmsl-link.h
++++ b/include/media/gmsl-link.h
+@@ -38,8 +38,10 @@
+ 
+ /* Didn't find kernel defintions, for now adding here */
+ #define GMSL_CSI_DT_RAW_12 0x2C
++#define GMSL_CSI_DT_RAW_10 0x2B
+ #define GMSL_CSI_DT_UED_U1 0x30
++#define GMSL_CSI_DT_UED_U3 0x32
+ #define GMSL_CSI_DT_EMBED 0x12
+ #define GMSL_CSI_DT_YUV422_8 0x1E
+ #define GMSL_CSI_DT_RGB_888 0x24
+ #define GMSL_CSI_DT_RAW_8 0x2A
 -- 
 2.43.0
-

--- a/nvidia-oot/7.0/0013-Per-format-VI-datatype-override-for-wire-order-capture.patch
+++ b/nvidia-oot/7.0/0013-Per-format-VI-datatype-override-for-wire-order-capture.patch
@@ -195,6 +195,20 @@ index 0e8acb1..edc16a5 100644
  u32 tegra_core_get_word_count(unsigned int frame_width,
  		const struct tegra_video_format *fmt);
  u32 tegra_core_bytes_per_line(unsigned int width, unsigned int align,
+diff --git a/include/media/gmsl-link.h b/include/media/gmsl-link.h
+index 48939537..868865ab 100644
+--- a/include/media/gmsl-link.h
++++ b/include/media/gmsl-link.h
+@@ -38,8 +38,10 @@
+ 
+ /* Didn't find kernel defintions, for now adding here */
+ #define GMSL_CSI_DT_RAW_12 0x2C
++#define GMSL_CSI_DT_RAW_10 0x2B
+ #define GMSL_CSI_DT_UED_U1 0x30
++#define GMSL_CSI_DT_UED_U3 0x32
+ #define GMSL_CSI_DT_EMBED 0x12
+ #define GMSL_CSI_DT_YUV422_8 0x1E
+ #define GMSL_CSI_DT_RGB_888 0x24
+ #define GMSL_CSI_DT_RAW_8 0x2A
 -- 
 2.43.0
-

--- a/nvidia-oot/7.0/0013-Per-format-VI-datatype-override-for-wire-order-capture.patch
+++ b/nvidia-oot/7.0/0013-Per-format-VI-datatype-override-for-wire-order-capture.patch
@@ -16,10 +16,10 @@ the NVCSI RAW16 rule byte-swaps (CSI-2 defines RAW16 MSB-first); both
 override to YUV422-8 + T_Y8_U8__Y8_V8 for byte-identical little-endian
 capture, and Y16I declares frame_x_scale = 2/1 (32bpp L/R pair on a
 16bpp wire), replacing the fourcc-gated width doubling formerly in the
-0001 patches. Flat NV12 rides a RAW8 wire carrier with native matching (a
-geometry-only row; the MAX96717 pixel pipe forwards standard 8-bit DTs but drops user-defined ones) and
-frame_y_scale = 3/2 transport rows, replacing the per-format special
-cases of the earlier flat-NV12 receive path.
+0001 patches. Flat NV12 uses a descriptor-local RAW8 parser override so
+both the generic RAW8 carrier and tunnel UD32 retain byte-identical
+capture, plus frame_y_scale = 3/2 transport rows, replacing the
+per-format special cases of the earlier flat-NV12 receive path.
 
 HW-verified (JP6.2, fw-orin-5, D585): GR16 30/30 clean frames, Y16I
 5/5, LE payload on both, coexists with concurrent embedded-metadata
@@ -113,7 +113,7 @@ diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/medi
 index bcd612f..e0a73a7 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-@@ -175,6 +175,23 @@ static const struct tegra_video_format vi5_video_formats[] = {
+@@ -175,6 +175,24 @@ static const struct tegra_video_format vi5_video_formats[] = {
  	// R[7:3]R[3:0] | L[3:0]R[11:8] | L[11:8]L[7:4] | ALIGN[7:0]
  	TEGRA_VIDEO_FORMAT(RGB888, 24, RGB888_1X24, 4, 1, T_A8R8G8B8,
  				RGB888, Y12I, "Y12I 24"),
@@ -129,11 +129,12 @@ index bcd612f..e0a73a7 100644
 +				RAW16, SGRBG16, "GRBG16 16 LE",
 +				TEGRA_IMAGE_DT_YUV422_8,
 +				TEGRA_IMAGE_FORMAT_T_Y8_U8__Y8_V8, 1, 1, 1, 1),
-+	// Flat NV12 bytes over a RAW8 wire carrier: native match and byte
-+	// rule, one byte per wire pixel. Transport rows = H * 3/2.
++	// Flat NV12 bytes use the RAW8 byte rule. A descriptor-local RAW8
++	// override accepts both the generic RAW8 carrier and tunnel UD32.
++	// Transport rows = H * 3/2.
 +	TEGRA_VIDEO_FORMAT_OVERRIDE(RAW8, 8, RS_NV12_FLAT_1X8, 1, 1, T_R8,
 +				RAW8, NV12, "NV12 flat over RAW8",
-+				0, 0, 1, 1, 3, 2),
++				TEGRA_IMAGE_DT_RAW8, 0, 1, 1, 3, 2),
  
  };
  

--- a/nvidia-oot/max96724.c
+++ b/nvidia-oot/max96724.c
@@ -1030,6 +1030,23 @@ int max96724_get_available_pipe_id(struct device *dev, int vc_id)
 }
 EXPORT_SYMBOL(max96724_get_available_pipe_id);
 
+int max96724_get_multi_vc_pipe_id(struct device *dev, u32 vc_id)
+{
+	struct max96724 *priv = dev_get_drvdata(dev);
+
+	if (vc_id < 0 || vc_id >= 8)
+		return -EINVAL;
+
+	/* This driver exposes the single Link-A tunnel used by D5x. The tunnel
+	 * preserves every VC in one packet stream, so logical VCs share PIPE_X. */
+	mutex_lock(&priv->lock);
+	priv->pipe[MAX96724_PIPE_X].st_count++;
+	mutex_unlock(&priv->lock);
+
+	return MAX96724_PIPE_X;
+}
+EXPORT_SYMBOL(max96724_get_multi_vc_pipe_id);
+
 int max96724_release_pipe(struct device *dev, int pipe_id)
 {
 	struct max96724 *priv = dev_get_drvdata(dev);
@@ -1039,7 +1056,15 @@ int max96724_release_pipe(struct device *dev, int pipe_id)
 		return -EINVAL;
 
 	mutex_lock(&priv->lock);
-	priv->pipe[pipe_id].st_count = 0;
+	if (!priv->pipe[pipe_id].st_count) {
+		mutex_unlock(&priv->lock);
+		return -EINVAL;
+	}
+	priv->pipe[pipe_id].st_count--;
+	if (priv->pipe[pipe_id].st_count) {
+		mutex_unlock(&priv->lock);
+		return 0;
+	}
 	priv->retriggered_pipe_mask &= ~BIT(pipe_id);
 	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
 		if (priv->pipe[i].st_count)
@@ -1202,16 +1227,6 @@ void max96724_retrigger_datapath(struct device *dev)
 		msleep(20);
 	}
 
-	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
-		struct pipe_ctx *pipe = &priv->pipe[i];
-
-		if (!(retrigger_mask & BIT(i)) || !pipe->st_count ||
-		    !pipe->map_configured)
-			continue;
-		err |= __max96724_set_pipe(dev, i, pipe->dt_type,
-					   pipe->dt_type2, pipe->vc_id);
-	}
-
 	if (!err) {
 		if (full_retrigger)
 			err = max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR,
@@ -1263,7 +1278,7 @@ EXPORT_SYMBOL(max96724_init_settings);
 int max96724_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
 				   int ser_pipe_id, u32 link)
 {
-	/* In Tunnel Mode, pipe mapping is 1:1 (each camera → one pipe) */
+	/* Tunnel mode forwards the complete CSI packet stream unchanged. */
 	return 0;
 }
 EXPORT_SYMBOL(max96724_bind_ser_to_dser_pipe);
@@ -1271,11 +1286,7 @@ EXPORT_SYMBOL(max96724_bind_ser_to_dser_pipe);
 int max96724_set_pipe(struct device *dev, int pipe_id,
 		      u8 data_type1, u8 data_type2, u32 link, u32 vc_id)
 {
-	struct max96724 *priv = dev_get_drvdata(dev);
-	int err = 0;
-
-	if (pipe_id < 0 || pipe_id >= MAX96724_MAX_PIPES ||
-	    vc_id >= MAX96724_MAX_PIPES) {
+	if (pipe_id < 0 || pipe_id >= MAX96724_MAX_PIPES) {
 		dev_info(dev, "%s: input pipe_id: %d exceeds max96724 max pipes\n",
 			 __func__, pipe_id);
 		return -EINVAL;
@@ -1283,14 +1294,7 @@ int max96724_set_pipe(struct device *dev, int pipe_id,
 
 	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
 		__func__, pipe_id, data_type1, data_type2, vc_id);
-
-	mutex_lock(&priv->lock);
-
-	err = __max96724_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
-
-	mutex_unlock(&priv->lock);
-
-	return err;
+	return 0;
 }
 EXPORT_SYMBOL(max96724_set_pipe);
 

--- a/nvidia-oot/max96724.h
+++ b/nvidia-oot/max96724.h
@@ -41,6 +41,7 @@
  */
 
 int max96724_get_available_pipe_id(struct device *dev, int vc_id);
+int max96724_get_multi_vc_pipe_id(struct device *dev, u32 vc_id);
 int max96724_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
 		      u8 data_type2, u32 link, u32 vc_id);
 int max96724_release_pipe(struct device *dev, int pipe_id);


### PR DESCRIPTION
> **Reference design only — keep as Draft. Do not merge as the active baseline.**
>
> **All-UD32 tunnel contract reference rebased onto `dev@b4e5630` through #624; historical checked HEAD: `#599@6ca0568`.**

## Purpose

This stacked PR records the reference implementation for a uniform D585 tunnel contract in which flat NV12 and RGB/IR calibration payloads are transported over CSI-2 User Defined DT 0x32 (UD32).

It is intentionally separated from #624 so the exact `dev` synchronization remains independently reviewable, deployable, and revertible.

## Revision anchors

| Role | Revision |
| --- | --- |
| Rebase target | `dev@b4e5630` |
| Exact-dev integration layer | `#624@115cb5a` |
| Historical checked all-UD32 + VC4 head | `#599@6ca0568` |
| Current reference head | `#625@6091936` |

The historical checked HEAD is traceability evidence for the pre-rebase implementation. It is not presented as complete validation of the current reference head.

## Reference contract

| Path | Application ABI | Reference tunnel carrier |
| --- | --- | --- |
| RGB NV12 | `V4L2_PIX_FMT_NV12` | UD32 with descriptor-local RAW8 parsing |
| IR calibration | `V4L2_PIX_FMT_Y16I` | UD32 |
| RGB calibration unpacked | `V4L2_PIX_FMT_RW16` | UD32 |
| RGB calibration packed | `V4L2_PIX_FMT_GR0P` | UD32 |
| Dual-RGB reference | Separate left/right nodes | VC1 left plus VC4 right |

The VI parser override is descriptor configuration only. It does not add CPU-side frame conversion, copying, or software fan-out.

## Commits

- `65616d5` — `[D585][GMSL] Preserve tunnel transport contracts after dev sync`
- `6091936` — `[D585][GMSL] Restore NV12 UD32 parser override`

## Validation snapshot

- JetPack 6.2.2 full clean build and full rootfs deployment: **PASS**
- 2C Dual-RGB YUYV, two nodes, 121 frames each: **PASS**, zero video/metadata drops
- NV12 UD32 after the descriptor override, 1280x960: **PASS**, 60/60 good frames and zero drops
- `RW16`: **not advertised by the current stacked result; unresolved**
- `GR0P` and `Y16I`: **validation stopped by request; not claimed**

This PR is not E2E-complete for the full UD32 contract and must remain Draft. Historical results from #585, #592, and #599 are traceability evidence for their original heads only.

## Traceability

- #585 — D585 flat NV12 over User Defined carrier
- #592 — D585 RGB/IR calibration over User Defined carrier
- #599 — independent Dual-RGB VC1+VC4 reference and historical checked stack head
