### PR TITLE
[RSDEV-14097] Expose D585 GMSL gyro sensitivity

### DIFF
--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -2603,6 +2603,7 @@ enum ds5_sync_mode {
 #define DS5_CAMERA_CID_AE_MODE		(DS5_CAMERA_CID_BASE+35)
 #define D500_CAMERA_CID_DEVICE_MODE	(DS5_CAMERA_CID_BASE + 36)
 #define D500_CAMERA_CID_DUAL_RGB_AE_POLICY (DS5_CAMERA_CID_BASE + 37)
+#define D500_CAMERA_CID_GYRO_SENSITIVITY (DS5_CAMERA_CID_BASE + 38)
 
 enum d500_device_mode {
 	D500_DEVICE_MODE_3C = 0,
@@ -2616,8 +2617,17 @@ enum d500_2c_ae_mode {
 	D500_2C_AE_POLICY_HYBRID = 3,
 };
 
+enum d500_gyro_sensitivity {
+	D500_GYRO_SENSITIVITY_2000_DPS = 0,
+	D500_GYRO_SENSITIVITY_1000_DPS,
+	D500_GYRO_SENSITIVITY_500_DPS,
+	D500_GYRO_SENSITIVITY_250_DPS,
+	D500_GYRO_SENSITIVITY_125_DPS,
+};
+
 #define D500_DEVICE_MODE_XU_BASE		0x4528
 #define D500_DUAL_RGB_AE_XU_BASE	0x4530
+#define D500_GYRO_SENSITIVITY_XU_BASE	0x4538
 
 /* Auto-exposure algorithm types — mirrors FW ETAeType */
 enum ds5_ae_type {
@@ -3008,6 +3018,45 @@ static int d500_set_ae_policy(struct ds5 *state, u32 policy)
 		ret = -EBUSY;
 	if (!ret)
 		ret = ds5_raw_write(state, D500_DUAL_RGB_AE_XU_BASE,
+				    &value, sizeof(value));
+	mutex_unlock(&state->ds5_dev->lock);
+
+	return ret;
+}
+
+static int d500_get_gyro_sensitivity(struct ds5 *state, u32 *sensitivity)
+{
+	u8 value;
+	int ret;
+
+	if (!sensitivity)
+		return -EINVAL;
+
+	ret = ds5_raw_read(state, D500_GYRO_SENSITIVITY_XU_BASE,
+			   &value, sizeof(value));
+	if (ret)
+		return ret;
+	if (value > D500_GYRO_SENSITIVITY_125_DPS)
+		return -EBADMSG;
+
+	*sensitivity = value;
+	return 0;
+}
+
+static int d500_set_gyro_sensitivity(struct ds5 *state, u32 sensitivity)
+{
+	u8 value;
+	int ret;
+
+	if (sensitivity > D500_GYRO_SENSITIVITY_125_DPS)
+		return -EINVAL;
+	value = sensitivity;
+
+	mutex_lock(&state->ds5_dev->lock);
+	if (state->ds5_dev->imu_streaming)
+		ret = -EBUSY;
+	else
+		ret = ds5_raw_write(state, D500_GYRO_SENSITIVITY_XU_BASE,
 				    &value, sizeof(value));
 	mutex_unlock(&state->ds5_dev->lock);
 
@@ -3905,6 +3954,12 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 			    DS5_DEVICE_TYPE_D58X)
 			ret = d500_set_ae_policy(state, ctrl->val);
 		break;
+	case D500_CAMERA_CID_GYRO_SENSITIVITY:
+		if (state->is_imu &&
+		    READ_ONCE(state->ds5_dev->cached_device_type) ==
+			    DS5_DEVICE_TYPE_D58X)
+			ret = d500_set_gyro_sensitivity(state, ctrl->val);
+		break;
 	case DS5_CAMERA_CID_PWM:
 		if (state->is_depth)
 			ret = ds5_write(state, base | DS5_PWM_FREQUENCY, ctrl->val);
@@ -4399,6 +4454,17 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 				*ctrl->p_new.p_s32 = policy;
 		}
 		break;
+	case D500_CAMERA_CID_GYRO_SENSITIVITY:
+		if (state->is_imu && ctrl->p_new.p_s32 &&
+		    READ_ONCE(state->ds5_dev->cached_device_type) ==
+			    DS5_DEVICE_TYPE_D58X) {
+			u32 sensitivity;
+
+			ret = d500_get_gyro_sensitivity(state, &sensitivity);
+			if (!ret)
+				*ctrl->p_new.p_s32 = sensitivity;
+		}
+		break;
 	case DS5_CAMERA_CID_PWM:
 		if (state->is_depth)
 			ds5_read(state, base | DS5_PWM_FREQUENCY, ctrl->p_new.p_u16);
@@ -4784,6 +4850,26 @@ static const struct v4l2_ctrl_config ds5_ctrl_dual_rgb_ae_policy_d58x = {
 	.max = D500_2C_AE_POLICY_HYBRID,
 	.def = D500_2C_AE_POLICY_DEPTH_MASTER,
 	.qmenu = d58x_ae_policy_menu,
+	.flags = V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
+};
+
+static const char * const d500_gyro_sensitivity_menu[] = {
+	[D500_GYRO_SENSITIVITY_2000_DPS] = "61.0 mDeg/Sec",
+	[D500_GYRO_SENSITIVITY_1000_DPS] = "30.5 mDeg/Sec",
+	[D500_GYRO_SENSITIVITY_500_DPS] = "15.3 mDeg/Sec",
+	[D500_GYRO_SENSITIVITY_250_DPS] = "7.6 mDeg/Sec",
+	[D500_GYRO_SENSITIVITY_125_DPS] = "3.8 mDeg/Sec",
+};
+
+static const struct v4l2_ctrl_config ds5_ctrl_gyro_sensitivity_d58x = {
+	.ops = &ds5_ctrl_ops,
+	.id = D500_CAMERA_CID_GYRO_SENSITIVITY,
+	.name = "Gyro Sensitivity",
+	.type = V4L2_CTRL_TYPE_MENU,
+	.min = D500_GYRO_SENSITIVITY_2000_DPS,
+	.max = D500_GYRO_SENSITIVITY_125_DPS,
+	.def = D500_GYRO_SENSITIVITY_125_DPS,
+	.qmenu = d500_gyro_sensitivity_menu,
 	.flags = V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
 };
 
@@ -5861,8 +5947,13 @@ static int ds5_ctrl_init(struct ds5 *state, int sid)
 		v4l2_ctrl_new_custom(hdl, &ds5_ctrl_pwm, sensor);
 	}
 	// IMU custom
-	if (sid == IMU_SID)
+	if (sid == IMU_SID) {
 		ctrls->fw_version = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_fw_version, sensor);
+		if (is_d58x)
+			v4l2_ctrl_new_custom(hdl,
+					     &ds5_ctrl_gyro_sensitivity_d58x,
+					     sensor);
+	}
 
 	switch (sid) {
 	case DEPTH_SID:
@@ -6978,6 +7069,10 @@ static int ds5_mux_init(struct i2c_client *c, struct ds5 *state)
 	ds5_set_state_last_set(state);
 
 #ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+	if (state->is_imu)
+		v4l2_ctrl_add_handler(&state->ctrls.handler,
+				      &state->ctrls.handler_imu, NULL, true);
+
 	if (state->is_depth) {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 20, 0)
 		v4l2_ctrl_add_handler(&state->ctrls.handler,


### PR DESCRIPTION
## Summary
- expose a D58x IMU-only V4L2 gyro sensitivity menu at private CID +38
- perform live one-byte FW GET/SET at register 0x4538
- reject SET while IMU streaming and preserve other stream independence
- merge the IMU control handler into the Tegra capture handler

## Validation
- JP6.2.1 full Host module build passed
- strict checkpatch: 0 errors, 0 warnings
- Jetson 172 Tunnel mode: V4L2 values 0..4 passed; invalid value returned ERANGE; streaming SET returned EBUSY
- Jetson 205 Pixel mode: values 0..4, IMU stream cycles, and Viewer control passed
- cross-repository gyro contract test: 16/16 passed
- all ten Host build jobs passed

## Jira
RSDEV-14097

## Companion PRs
- IO: https://github.com/RealSenseAI-Internal/soc-rs-soc-io-drivers/pull/601
- Device Manager: https://github.com/RealSenseAI-Internal/soc-rs-soc-device-mgr/pull/511
- Apps (merged Tunnel implementation): https://github.com/RealSenseAI-Internal/soc-rs-hkr-apps/pull/322
- Apps (Pixel follow-up): https://github.com/RealSenseAI-Internal/soc-rs-hkr-apps/pull/327
- Tests (merged Tunnel contract): https://github.com/RealSenseAI-Internal/soc-rs-hkr-test/pull/402
- Tests (Pixel follow-up): https://github.com/RealSenseAI-Internal/soc-rs-hkr-test/pull/404
- Host: https://github.com/realsenseai/realsense_mipi_platform_driver/pull/633
- librealsense: https://github.com/realsenseai/librealsense/pull/15627