### PR TITLE
[RSDEV-14516][Host][GMSL][D500][Fix] Pair embedded metadata per VI capture descriptor

### DIFF
--- a/kernel/nvidia/5.0.2/0001-Porting-driver-patches-to-jetpack-5.0.2.patch
+++ b/kernel/nvidia/5.0.2/0001-Porting-driver-patches-to-jetpack-5.0.2.patch
@@ -1,4 +1,4 @@
-From 9a8deb6e59925a02f2a6c4d7290ee2f160d5212a Mon Sep 17 00:00:00 2001
+From 0ae2028307cd304b258119e8dcf22efd715d96bd Mon Sep 17 00:00:00 2001
 From: Junze Wu <junze.wu@intel.com>
 Date: Tue, 30 Aug 2022 13:24:12 +0800
 Subject: [PATCH] Porting driver patches to jetpack 5.0.2
@@ -10,22 +10,22 @@ Signed-off-by: Junze Wu <junze.wu@intel.com>
  drivers/media/i2c/max9295.c                   | 389 ++++++++++++++++
  drivers/media/i2c/max9296.c                   | 399 ++++++++++++++++
  .../platform/tegra/camera/sensor_common.c     |   4 +
- .../media/platform/tegra/camera/vi/channel.c  | 429 +++++++++++++++++-
+ .../media/platform/tegra/camera/vi/channel.c  | 435 +++++++++++++++++-
  .../media/platform/tegra/camera/vi/graph.c    |  50 +-
  .../platform/tegra/camera/vi/mc_common.c      |  32 ++
  .../platform/tegra/camera/vi/vi4_formats.h    |  32 +-
- .../media/platform/tegra/camera/vi/vi5_fops.c | 136 +-
- .../platform/tegra/camera/vi/vi5_formats.h    |  28 -
+ .../media/platform/tegra/camera/vi/vi5_fops.c | 266 +++++++++--
+ .../platform/tegra/camera/vi/vi5_formats.h    |  30 +-
  .../tegra/camera/tegra_camera_platform.c      |   5 +
  include/media/gmsl-link.h                     |   7 +
  include/media/max9295.h                       |   2 +
  include/media/max9296.h                       |   3 +
- include/media/mc_common.h                     |  25 +
- include/media/tegra_camera_core.h             |  10 +-
- 17 files changed, 1534 insertions(+), 29 deletions(-)
+ include/media/mc_common.h                     |  26 ++
+ include/media/tegra_camera_core.h             |  12 +-
+ 17 files changed, 1643 insertions(+), 70 deletions(-)
 
 diff --git a/drivers/media/i2c/Kconfig b/drivers/media/i2c/Kconfig
-index 8362bc85b..90f5a90e6 100644
+index 8362bc8..873b62e 100644
 --- a/drivers/media/i2c/Kconfig
 +++ b/drivers/media/i2c/Kconfig
 @@ -184,6 +184,24 @@ config NV_VIDEO_AR0234
@@ -54,7 +54,7 @@ index 8362bc85b..90f5a90e6 100644
  
  endif
 diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
-index af6122bca..0784f0362 100644
+index af6122b..7be6d7e 100644
 --- a/drivers/media/i2c/Makefile
 +++ b/drivers/media/i2c/Makefile
 @@ -23,3 +23,6 @@ obj-$(CONFIG_I2C_IOEXPANDER_DESER_MAX9296) += max9296.o
@@ -65,7 +65,7 @@ index af6122bca..0784f0362 100644
 +obj-$(CONFIG_VIDEO_D4XX) += d4xx.o
 +obj-$(CONFIG_VIDEO_D4XX) += max96724.o
 diff --git a/drivers/media/i2c/max9295.c b/drivers/media/i2c/max9295.c
-index 110f861c3..03040ccb9 100644
+index 110f861..03040cc 100644
 --- a/drivers/media/i2c/max9295.c
 +++ b/drivers/media/i2c/max9295.c
 @@ -20,6 +20,8 @@
@@ -505,7 +505,7 @@ index 110f861c3..03040ccb9 100644
 +MODULE_VERSION(MAX9295_MODULE_VERSION);
  MODULE_LICENSE("GPL v2");
 diff --git a/drivers/media/i2c/max9296.c b/drivers/media/i2c/max9296.c
-index 20032619b..6ee2d9bc8 100644
+index 2003261..6ee2d9b 100644
 --- a/drivers/media/i2c/max9296.c
 +++ b/drivers/media/i2c/max9296.c
 @@ -104,6 +104,11 @@ struct pipe_ctx {
@@ -943,7 +943,7 @@ index 20032619b..6ee2d9bc8 100644
  		i2c_unregister_device(client);
  		client = NULL;
 diff --git a/drivers/media/platform/tegra/camera/sensor_common.c b/drivers/media/platform/tegra/camera/sensor_common.c
-index 69dbf2d96..21adc55ee 100644
+index 69dbf2d..21adc55 100644
 --- a/drivers/media/platform/tegra/camera/sensor_common.c
 +++ b/drivers/media/platform/tegra/camera/sensor_common.c
 @@ -265,6 +265,10 @@ static int extract_pixel_format(
@@ -958,7 +958,7 @@ index 69dbf2d96..21adc55ee 100644
  		pr_err("%s: Need to extend format%s\n", __func__, pixel_t);
  		return -EINVAL;
 diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
-index 11ee95f6e..7edef186a 100644
+index 11ee95f..0789c85 100644
 --- a/drivers/media/platform/tegra/camera/vi/channel.c
 +++ b/drivers/media/platform/tegra/camera/vi/channel.c
 @@ -40,6 +40,10 @@
@@ -1114,7 +1114,7 @@ index 11ee95f6e..7edef186a 100644
  };
  
  static int tegra_channel_close(struct file *fp);
-@@ -2406,6 +2499,331 @@ static int tegra_channel_csi_init(struct tegra_channel *chan)
+@@ -2406,6 +2499,334 @@ static int tegra_channel_csi_init(struct tegra_channel *chan)
  	return ret;
  }
  
@@ -1424,6 +1424,9 @@ index 11ee95f6e..7edef186a 100644
 +		dma_free_coherent(vi_unit_dev,
 +				chan->emb_buf_size,
 +				chan->emb_buf_addr, chan->emb_buf);
++		chan->emb_buf_addr = NULL;
++		chan->emb_buf = 0;
++		chan->emb_buf_stride = 0;
 +		chan->emb_buf_size = 0;
 +		vb2_queue_release(queue);
 +#if defined(CONFIG_VIDEOBUF2_DMA_CONTIG)
@@ -1446,9 +1449,13 @@ index 11ee95f6e..7edef186a 100644
  int tegra_channel_init_video(struct tegra_channel *chan)
  {
  	struct tegra_mc_vi *vi = chan->vi;
-@@ -2594,6 +3012,13 @@ int tegra_channel_cleanup(struct tegra_channel *chan)
+@@ -2593,7 +3014,17 @@ int tegra_channel_cleanup(struct tegra_channel *chan)
+ 		dma_free_coherent(vi_unit_dev,
  			chan->emb_buf_size,
  			chan->emb_buf_addr, chan->emb_buf);
++		chan->emb_buf_addr = NULL;
++		chan->emb_buf = 0;
++		chan->emb_buf_stride = 0;
  		chan->emb_buf_size = 0;
 +		vb2_queue_release(&chan->embedded.queue);
 +#if defined(CONFIG_VIDEOBUF2_DMA_CONTIG)
@@ -1461,7 +1468,7 @@ index 11ee95f6e..7edef186a 100644
  
  	tegra_channel_dealloc_buffer_queue(chan);
 diff --git a/drivers/media/platform/tegra/camera/vi/graph.c b/drivers/media/platform/tegra/camera/vi/graph.c
-index cb097442d..09cb88eaf 100644
+index cb09744..09cb88e 100644
 --- a/drivers/media/platform/tegra/camera/vi/graph.c
 +++ b/drivers/media/platform/tegra/camera/vi/graph.c
 @@ -373,9 +373,14 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
@@ -1554,7 +1561,7 @@ index cb097442d..09cb88eaf 100644
  		tegra_channel_cleanup_video(chan);
  		chan->link_status--;
 diff --git a/drivers/media/platform/tegra/camera/vi/mc_common.c b/drivers/media/platform/tegra/camera/vi/mc_common.c
-index bed3e92a3..54b60f3b7 100644
+index bed3e92..54b60f3 100644
 --- a/drivers/media/platform/tegra/camera/vi/mc_common.c
 +++ b/drivers/media/platform/tegra/camera/vi/mc_common.c
 @@ -24,6 +24,10 @@
@@ -1611,7 +1618,7 @@ index bed3e92a3..54b60f3b7 100644
  	for (i = 0; i < num_channels; i++) {
  		item = devm_kzalloc(vi->dev, sizeof(*item), GFP_KERNEL);
 diff --git a/drivers/media/platform/tegra/camera/vi/vi4_formats.h b/drivers/media/platform/tegra/camera/vi/vi4_formats.h
-index de33c42fb..02d63ab62 100644
+index de33c42..02d63ab 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi4_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi4_formats.h
 @@ -87,6 +87,9 @@ static const struct tegra_video_format vi4_video_formats[] = {
@@ -1676,10 +1683,27 @@ index de33c42fb..02d63ab62 100644
  
  #endif
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-index 69ebee6a8..6e08f65ea 100644
+index 69ebee6..5247855 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -270,7 +270,7 @@ static int tegra_channel_capture_setup(struct tegra_channel *chan, unsigned int
+@@ -15,6 +15,7 @@
+ #include <linux/nvhost.h>
+ #include <linux/semaphore.h>
+ #include <linux/version.h>
++#include <linux/overflow.h>
+ #include <media/tegra_camera_platform.h>
+ #include <media/mc_common.h>
+ #include <media/tegra-v4l2-camera.h>
+@@ -29,6 +30,8 @@
+ 
+ #define DEFAULT_FRAMERATE	30
+ #define BPP_MEM			2
++#define D4XX_META_BUFSIZE	255U
++#define D4XX_META_PAYLOAD	68U
+ #define VI_CSI_CLK_SCALE	110
+ #define PG_BITRATE		32
+ #define SLVSEC_STREAM_MAIN	0U
+@@ -270,7 +273,7 @@ static int tegra_channel_capture_setup(struct tegra_channel *chan, unsigned int
  
  	setup.queue_depth = chan->capture_queue_depth;
  
@@ -1688,7 +1712,24 @@ index 69ebee6a8..6e08f65ea 100644
  
  	chan->request[vi_port] = dma_alloc_coherent(chan->tegra_vi_channel[vi_port]->rtcpu_dev,
  					setup.queue_depth * setup.request_size,
-@@ -375,12 +375,45 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+@@ -355,12 +358,15 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	desc->ch_cfg.atomp.surface_stride[0] = bpl;
+ 
+ 	if (chan->embedded_data_height > 0) {
++		dma_addr_t emb_offset =
++			(dma_addr_t)descr_index * chan->emb_buf_stride;
++
+ 		desc->ch_cfg.embdata_enable = 1;
+ 		desc->ch_cfg.frame.embed_x = chan->embedded_data_width * BPP_MEM;
+ 		desc->ch_cfg.frame.embed_y = chan->embedded_data_height;
+ 
+ 		desc_memoryinfo->surface[VI_ATOMP_SURFACE_EMBEDDED].base_address
+-			= chan->emb_buf;
++			= chan->emb_buf + emb_offset;
+ 		desc_memoryinfo->surface[VI_ATOMP_SURFACE_EMBEDDED].size
+ 			= desc->ch_cfg.frame.embed_x * desc->ch_cfg.frame.embed_y;
+ 
+@@ -375,12 +381,45 @@ static void vi5_release_buffer(struct tegra_channel *chan,
  	struct tegra_channel_buffer *buf)
  {
  	struct vb2_v4l2_buffer *vbuf = &buf->buf;
@@ -1734,7 +1775,7 @@ index 69ebee6a8..6e08f65ea 100644
  }
  
  static void vi5_capture_enqueue(struct tegra_channel *chan,
-@@ -432,6 +465,88 @@ uncorr_err:
+@@ -432,6 +471,88 @@ uncorr_err:
  	spin_unlock_irqrestore(&chan->capture_state_lock, flags);
  }
  
@@ -1823,7 +1864,7 @@ index 69ebee6a8..6e08f65ea 100644
  static void vi5_capture_dequeue(struct tegra_channel *chan,
  	struct tegra_channel_buffer *buf)
  {
-@@ -476,15 +591,29 @@ static void vi5_capture_dequeue(struct tegra_channel *chan,
+@@ -476,15 +597,29 @@ static void vi5_capture_dequeue(struct tegra_channel *chan,
  			} else {
  				dev_warn(vi->dev,
  					"corr_err: discarding frame %d, flags: %d, "
@@ -1856,7 +1897,7 @@ index 69ebee6a8..6e08f65ea 100644
  			}
  		} else if (!vi_port) {
  			gang_prev_frame_id = descr->status.frame_id;
-@@ -529,7 +658,6 @@ static void vi5_capture_dequeue(struct tegra_channel *chan,
+@@ -529,7 +664,6 @@ static void vi5_capture_dequeue(struct tegra_channel *chan,
  	trace_tegra_channel_capture_frame("eof", &ts);
  #endif
  
@@ -1864,7 +1905,7 @@ index 69ebee6a8..6e08f65ea 100644
  	goto rel_buf;
  
  uncorr_err:
-@@ -632,6 +760,9 @@ static int tegra_channel_kthread_capture_enqueue(void *data)
+@@ -632,6 +766,9 @@ static int tegra_channel_kthread_capture_enqueue(void *data)
  		wait_event_interruptible(chan->start_wait,
  			(kthread_should_stop() || !list_empty(&chan->capture)));
  
@@ -1874,17 +1915,155 @@ index 69ebee6a8..6e08f65ea 100644
  		while (!(kthread_should_stop() || list_empty(&chan->capture))) {
  			spin_lock_irqsave(&chan->capture_state_lock, flags);
  			if ((chan->capture_state == CAPTURE_ERROR)
-@@ -823,6 +954,8 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+@@ -773,6 +910,75 @@ static void vi5_unit_get_device_handle(struct platform_device *pdev,
+ 		dev_err(&pdev->dev, "dev pointer is NULL\n");
+ }
+ 
++static int vi5_embedded_buffer_size(struct tegra_channel *chan,
++	unsigned int *stride, unsigned int *size)
++{
++	unsigned int payload_size;
++	unsigned int aligned_size;
++
++	if (!chan->capture_queue_depth)
++		return -EINVAL;
++
++	if (check_mul_overflow(chan->embedded_data_width,
++			chan->embedded_data_height, &payload_size) ||
++		check_mul_overflow(payload_size, (unsigned int)BPP_MEM,
++			&payload_size) ||
++		!payload_size ||
++		check_add_overflow(payload_size, (unsigned int)PAGE_SIZE - 1,
++			&aligned_size))
++		return -EOVERFLOW;
++
++	*stride = round_down(aligned_size, (unsigned int)PAGE_SIZE);
++	if (check_mul_overflow(*stride, chan->capture_queue_depth, size))
++		return -EOVERFLOW;
++
++	return 0;
++}
++
++static int vi5_channel_prepare_embedded_buffer(struct tegra_channel *chan)
++{
++	unsigned int emb_buf_stride;
++	unsigned int emb_buf_size;
++	struct device *vi_unit_dev;
++	dma_addr_t new_emb_buf;
++	void *new_emb_buf_addr;
++	int ret;
++
++	if (!chan->embedded_data_height) {
++		chan->emb_buf_stride = 0;
++		return 0;
++	}
++
++	ret = vi5_embedded_buffer_size(chan, &emb_buf_stride, &emb_buf_size);
++	if (ret)
++		return ret;
++	if (!chan->emb_buf_size) {
++		chan->emb_buf_addr = NULL;
++		chan->emb_buf = 0;
++		chan->emb_buf_stride = 0;
++	}
++
++	if (emb_buf_size > chan->emb_buf_size) {
++		vi5_unit_get_device_handle(chan->vi->ndev, chan->port[0],
++			&vi_unit_dev);
++		new_emb_buf_addr = dma_alloc_coherent(vi_unit_dev, emb_buf_size,
++			&new_emb_buf, GFP_KERNEL);
++		if (!new_emb_buf_addr)
++			return -ENOMEM;
++
++		if (chan->emb_buf_size > 0)
++			dma_free_coherent(vi_unit_dev, chan->emb_buf_size,
++				chan->emb_buf_addr, chan->emb_buf);
++
++		chan->emb_buf_addr = new_emb_buf_addr;
++		chan->emb_buf = new_emb_buf;
++		chan->emb_buf_size = emb_buf_size;
++	}
++
++	chan->emb_buf_stride = emb_buf_stride;
++	return 0;
++}
++
+ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ {
+ 	struct tegra_channel *chan = vb2_get_drv_priv(vq);
+@@ -785,7 +991,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 	struct device_node *node;
+ 	struct sensor_mode_properties *sensor_mode;
+ 	struct camera_common_data *s_data;
+-	unsigned int emb_buf_size = 0;
+ 
+ 	/* Skip in bypass mode */
+ 	if (!chan->bypass) {
+@@ -809,7 +1014,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 				if (s_data != NULL && node != NULL) {
+ 					int idx = s_data->mode_prop_idx;
+ 
+-					emb_buf_size = 0;
+ 					if (idx < s_data->sensor_props.\
+ 								num_modes) {
+ 						sensor_mode =
+@@ -823,46 +1027,16 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
  							sensor_mode->\
  							 image_properties.\
  						      embedded_metadata_height;
+-						/* rounding up to page size */
+-						emb_buf_size =
+-							round_up(chan->\
+-							embedded_data_width *
+-								chan->\
+-							embedded_data_height *
+-							BPP_MEM, PAGE_SIZE);
 +						if (chan->id != 0 && chan->id != 1)
 +							chan->embedded_data_height = 0;
- 						/* rounding up to page size */
- 						emb_buf_size =
- 							round_up(chan->\
+ 					}
+ 				}
+-				/* Allocate buffer for Embedded Data if need to*/
+-				if (emb_buf_size > chan->emb_buf_size) {
+-					struct device *vi_unit_dev;
+-
+-					vi5_unit_get_device_handle(\
+-						chan->vi->ndev, chan->port[0],\
+-						&vi_unit_dev);
+-				/*
+-				 * if old buffer is smaller than what we need,
+-				 * release the old buffer and re-allocate a
+-				 * bigger one below.
+-				 */
+-					if (chan->emb_buf_size > 0) {
+-						dma_free_coherent(vi_unit_dev,
+-							chan->emb_buf_size,
+-							chan->emb_buf_addr,
+-							chan->emb_buf);
+-						chan->emb_buf_size = 0;
+-					}
+-
+-					chan->emb_buf_addr =
+-						dma_alloc_coherent(vi_unit_dev,
+-							emb_buf_size,
+-						&chan->emb_buf, GFP_KERNEL);
+-					if (!chan->emb_buf_addr) {
+-						dev_err(&chan->video->dev,
+-							"Can't allocate memory"
+-							"for embedded data\n");
+-						goto err_setup;
+-					}
+-					chan->emb_buf_size = emb_buf_size;
++				ret = vi5_channel_prepare_embedded_buffer(chan);
++				if (ret) {
++					dev_err(&chan->video->dev,
++						"failed to prepare embedded buffer: %d\n",
++						ret);
++					goto err_setup;
+ 				}
+ 			}
+ 			ret = tegra_channel_capture_setup(chan, vi_port);
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-index 51cbbad5b..8c1a4f5bc 100644
+index 51cbbad..8c1a4f5 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 @@ -87,6 +87,8 @@ static const struct tegra_video_format vi5_video_formats[] = {
@@ -1947,7 +2126,7 @@ index 51cbbad5b..8c1a4f5bc 100644
  
  #endif
 diff --git a/drivers/video/tegra/camera/tegra_camera_platform.c b/drivers/video/tegra/camera/tegra_camera_platform.c
-index a322b1c19..ad48a7cfb 100644
+index a322b1c..ad48a7c 100644
 --- a/drivers/video/tegra/camera/tegra_camera_platform.c
 +++ b/drivers/video/tegra/camera/tegra_camera_platform.c
 @@ -1153,6 +1153,11 @@ int tegra_camera_update_clknbw(void *priv, bool stream_on)
@@ -1963,7 +2142,7 @@ index a322b1c19..ad48a7cfb 100644
  	if (!info)
  		return -EINVAL;
 diff --git a/include/media/gmsl-link.h b/include/media/gmsl-link.h
-index 1eab7bac9..9cfd907bd 100644
+index 1eab7ba..9cfd907 100644
 --- a/include/media/gmsl-link.h
 +++ b/include/media/gmsl-link.h
 @@ -56,6 +56,13 @@
@@ -1981,7 +2160,7 @@ index 1eab7bac9..9cfd907bd 100644
   * Maximum number of data streams (\ref gmsl_stream elements) in a GMSL link
   * (\ref gmsl_link_ctx).
 diff --git a/include/media/max9295.h b/include/media/max9295.h
-index cff6b867d..d25f43fc0 100644
+index cff6b86..d25f43f 100644
 --- a/include/media/max9295.h
 +++ b/include/media/max9295.h
 @@ -25,6 +25,7 @@
@@ -2001,7 +2180,7 @@ index cff6b867d..d25f43fc0 100644
  /**
   * @brief  Powers on a serializer device and performs the I2C overrides
 diff --git a/include/media/max9296.h b/include/media/max9296.h
-index 61435e263..69ada8a5e 100644
+index 61435e2..69ada8a 100644
 --- a/include/media/max9296.h
 +++ b/include/media/max9296.h
 @@ -25,6 +25,7 @@
@@ -2022,7 +2201,7 @@ index 61435e263..69ada8a5e 100644
   * Puts a deserializer device in single exclusive link mode, so link-specific
   * I2C overrides can be performed for sensor and serializer devices.
 diff --git a/include/media/mc_common.h b/include/media/mc_common.h
-index 9a9cba640..096c29a6c 100644
+index 9a9cba6..00b8ac1 100644
 --- a/include/media/mc_common.h
 +++ b/include/media/mc_common.h
 @@ -42,6 +42,7 @@
@@ -2061,7 +2240,15 @@ index 9a9cba640..096c29a6c 100644
  	DECLARE_BITMAP(fmts_bitmap, MAX_FORMAT_NUM);
  	atomic_t power_on_refcnt;
  	struct v4l2_fh *fh;
-@@ -308,6 +327,9 @@ struct tegra_mc_vi {
+@@ -267,6 +286,7 @@ struct tegra_channel {
+ 
+ 	dma_addr_t emb_buf;
+ 	void *emb_buf_addr;
++	unsigned int emb_buf_stride;
+ 	unsigned int emb_buf_size;
+ };
+ 
+@@ -308,6 +328,9 @@ struct tegra_mc_vi {
  	unsigned int num_channels;
  	unsigned int num_subdevs;
  
@@ -2071,7 +2258,7 @@ index 9a9cba640..096c29a6c 100644
  	struct tegra_csi_device *csi;
  	struct list_head vi_chans;
  	struct tegra_channel *tpg_start;
-@@ -412,7 +434,10 @@ struct tegra_channel_buffer *dequeue_inflight(struct tegra_channel *chan);
+@@ -412,7 +435,10 @@ struct tegra_channel_buffer *dequeue_inflight(struct tegra_channel *chan);
  int tegra_channel_set_power(struct tegra_channel *chan, bool on);
  
  int tegra_channel_init_video(struct tegra_channel *chan);
@@ -2083,7 +2270,7 @@ index 9a9cba640..096c29a6c 100644
  struct tegra_vi_fops {
  	int (*vi_power_on)(struct tegra_channel *chan);
 diff --git a/include/media/tegra_camera_core.h b/include/media/tegra_camera_core.h
-index 788cf77dc..1f57648f7 100644
+index 788cf77..67221b0 100644
 --- a/include/media/tegra_camera_core.h
 +++ b/include/media/tegra_camera_core.h
 @@ -23,7 +23,7 @@
@@ -2118,7 +2305,7 @@ index 788cf77dc..1f57648f7 100644
  };
  
  /* Supported CSI to VI Data Formats */
-@@ -66,6 +66,7 @@ enum tegra_vf_code {
+@@ -66,6 +75,7 @@ enum tegra_vf_code {
  	TEGRA_VF_RAW10,
  	TEGRA_VF_RAW12,
  	TEGRA_VF_RAW14,
@@ -2127,4 +2314,5 @@ index 788cf77dc..1f57648f7 100644
  	TEGRA_VF_RGB565,
  	TEGRA_VF_RGB555,
 -- 
-2.32.0
+2.34.1
+

--- a/kernel/nvidia/5.0.2/0004-Add-vi5_fops-cleanup-code-from-previous-unmerged-PR.patch
+++ b/kernel/nvidia/5.0.2/0004-Add-vi5_fops-cleanup-code-from-previous-unmerged-PR.patch
@@ -1,4 +1,4 @@
-From edcb7d4d704c111db14e8845a1669d962d5a4649 Mon Sep 17 00:00:00 2001
+From f4b8c8ceb6cf323aa2fa0089a6e4b3d9b117ea3f Mon Sep 17 00:00:00 2001
 From: Xin Zhang <xin.x.zhang@intel.com>
 Date: Fri, 11 Nov 2022 16:26:51 +0800
 Subject: [PATCH] Add vi5_fops cleanup code from previous unmerged PR
@@ -11,23 +11,27 @@ is not included.
 
 Signed-off-by: Xin Zhang <xin.x.zhang@intel.com>
 ---
- .../media/platform/tegra/camera/vi/vi5_fops.c | 69 ++++++++++---------
- 1 file changed, 35 insertions(+), 34 deletions(-)
+ .../media/platform/tegra/camera/vi/vi5_fops.c | 86 +++++++++++--------
+ 1 file changed, 52 insertions(+), 34 deletions(-)
 
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-index 6e08f65ea..af790b60d 100644
+index 5247855..84b3194 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -371,49 +371,52 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -377,49 +377,69 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  	chan->capture_descr_sequence += 1;
  }
  
 +static void vi5_release_metadata_buffer(struct tegra_channel *chan,
-+	struct vb2_v4l2_buffer *vbuf)
++	struct tegra_channel_buffer *buf)
 +{
 +	struct vb2_buffer *evb = NULL;
 +	struct vb2_v4l2_buffer *evbuf;
-+	void* frm_buffer;
++	struct vb2_v4l2_buffer *vbuf = &buf->buf;
++	void *frm_buffer;
++	void *metadata_addr;
++	unsigned int descr_index = buf->capture_descr_index[0];
++	unsigned int emb_offset;
 +
 +	spin_lock(&chan->embedded.spin_lock);
 +	if (0 < chan->embedded.num_buffers) {
@@ -44,13 +48,26 @@ index 6e08f65ea..af790b60d 100644
 +		return;
 +
 +	frm_buffer = vb2_plane_vaddr(evb, 0);
-+	if (!frm_buffer)
++	if (!frm_buffer) {
++		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
 +		return;
++	}
 +
-+	memcpy(frm_buffer, chan->emb_buf_addr, 255);
++	if (!chan->emb_buf_stride ||
++		chan->emb_buf_size < D4XX_META_BUFSIZE ||
++		descr_index >= chan->capture_queue_depth ||
++		check_mul_overflow(descr_index, chan->emb_buf_stride,
++			&emb_offset) ||
++		emb_offset > chan->emb_buf_size - D4XX_META_BUFSIZE) {
++		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
++		return;
++	}
++
++	metadata_addr = (u8 *)chan->emb_buf_addr + emb_offset;
++	memcpy(frm_buffer, metadata_addr, D4XX_META_BUFSIZE);
 +	evbuf = to_vb2_v4l2_buffer(evb);
 +	evbuf->sequence = vbuf->sequence;
-+	vb2_set_plane_payload(evb, 0, 68);
++	vb2_set_plane_payload(evb, 0, D4XX_META_PAYLOAD);
 +	evb->timestamp = vbuf->vb2_buf.timestamp;
 +	vb2_buffer_done(evb, VB2_BUF_STATE_DONE);
 +}
@@ -87,7 +104,9 @@ index 6e08f65ea..af790b60d 100644
 -			}
 -		}
 -	}
--
++	if (chan->embedded_data_height == 1 && buf->vb2_state == VB2_BUF_STATE_DONE)
++		vi5_release_metadata_buffer(chan, buf);
+ 
  	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);
 -	if (chan->embedded_data_height == 1 && evb) {
 -		evbuf = to_vb2_v4l2_buffer(evb);
@@ -97,21 +116,19 @@ index 6e08f65ea..af790b60d 100644
 -		evb->timestamp = vbuf->vb2_buf.timestamp;
 -		vb2_buffer_done(evb, buf->vb2_state);
 -	}
- 
-+	if (chan->embedded_data_height == 1 && buf->vb2_state == VB2_BUF_STATE_DONE)
-+		vi5_release_metadata_buffer(chan, vbuf);
+-
  }
  
  static void vi5_capture_enqueue(struct tegra_channel *chan,
-@@ -954,8 +957,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+@@ -1027,8 +1047,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
  							sensor_mode->\
  							 image_properties.\
  						      embedded_metadata_height;
 -						if (chan->id != 0 && chan->id != 1)
 -							chan->embedded_data_height = 0;
- 						/* rounding up to page size */
- 						emb_buf_size =
- 							round_up(chan->\
+ 					}
+ 				}
+ 				ret = vi5_channel_prepare_embedded_buffer(chan);
 -- 
-2.30.2
+2.34.1
 

--- a/kernel/nvidia/5.1.2/0001-Porting-driver-patches-to-jetpack-5.1.2.patch
+++ b/kernel/nvidia/5.1.2/0001-Porting-driver-patches-to-jetpack-5.1.2.patch
@@ -1,31 +1,31 @@
-From 1b06cf3323a3d7d1437071dc3789e9487b9b5733 Mon Sep 17 00:00:00 2001
+From 1bec22e5c4d45b326838d8fc2bf7083477e92f28 Mon Sep 17 00:00:00 2001
 From: Dmitry Perchanov <dmitry.perchanov@intel.com>
 Date: Wed, 18 Oct 2023 13:51:51 +0300
 Subject: [PATCH] Porting driver patches to jetpack 5.1.2
 
 Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
 ---
- drivers/media/i2c/Kconfig                     |  29 +
+ drivers/media/i2c/Kconfig                     |  29 ++
  drivers/media/i2c/Makefile                    |   3 +
- drivers/media/i2c/max9295.c                   | 145 ++++++-
- drivers/media/i2c/max9296.c                   | 189 ++++++++
+ drivers/media/i2c/max9295.c                   | 145 +++++-
+ drivers/media/i2c/max9296.c                   | 192 ++++++++
  .../platform/tegra/camera/sensor_common.c     |   4 +
- .../media/platform/tegra/camera/vi/channel.c  | 410 +++++++++++++++++-
+ .../media/platform/tegra/camera/vi/channel.c  | 416 +++++++++++++++++-
  .../media/platform/tegra/camera/vi/graph.c    |  48 +-
  .../platform/tegra/camera/vi/mc_common.c      |  32 ++
  .../platform/tegra/camera/vi/vi4_formats.h    |  32 +-
- .../media/platform/tegra/camera/vi/vi5_fops.c | 132 +-
- .../platform/tegra/camera/vi/vi5_formats.h    |  28 -
+ .../media/platform/tegra/camera/vi/vi5_fops.c | 279 ++++++++++--
+ .../platform/tegra/camera/vi/vi5_formats.h    |  30 +-
  .../tegra/camera/tegra_camera_platform.c      |   5 +
- include/media/gmsl-link.h                     |   4 ++
+ include/media/gmsl-link.h                     |   5 +
  include/media/max9295.h                       |   4 +
  include/media/max9296.h                       |   8 +
- include/media/mc_common.h                     |  23 +
- include/media/tegra_camera_core.h             |   8 +
- 17 files changed, 1066 insertions(+), 29 deletions(-)
+ include/media/mc_common.h                     |  24 +
+ include/media/tegra_camera_core.h             |  12 +-
+ 17 files changed, 1197 insertions(+), 71 deletions(-)
 
 diff --git a/drivers/media/i2c/Kconfig b/drivers/media/i2c/Kconfig
-index 5ec3c683c..7f288faf7 100644
+index 5ec3c683c..e3495a08b 100644
 --- a/drivers/media/i2c/Kconfig
 +++ b/drivers/media/i2c/Kconfig
 @@ -210,6 +210,35 @@ config NV_VIRTUAL_I2C_MUX
@@ -65,7 +65,7 @@ index 5ec3c683c..7f288faf7 100644
  
  endif
 diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
-index c4708d8c7..e11e8ad39 100644
+index c4708d8c7..e8f1ba94f 100644
 --- a/drivers/media/i2c/Makefile
 +++ b/drivers/media/i2c/Makefile
 @@ -27,3 +27,6 @@ obj-$(CONFIG_NV_VIDEO_HAWK_OWL) += nv_hawk_owl.o
@@ -76,7 +76,7 @@ index c4708d8c7..e11e8ad39 100644
 +obj-$(CONFIG_VIDEO_D4XX) += d4xx.o
 +obj-$(CONFIG_VIDEO_D4XX) += max96724.o
 diff --git a/drivers/media/i2c/max9295.c b/drivers/media/i2c/max9295.c
-index 110f861c3..6311d97d7 100644
+index 110f861c3..19026e8ca 100644
 --- a/drivers/media/i2c/max9295.c
 +++ b/drivers/media/i2c/max9295.c
 @@ -395,9 +395,9 @@ int max9295_reset_control(struct device *dev)
@@ -239,7 +239,7 @@ index 110f861c3..6311d97d7 100644
  				const struct i2c_device_id *id)
  {
 diff --git a/drivers/media/i2c/max9296.c b/drivers/media/i2c/max9296.c
-index 5f48c9b9f..316e687a1 100644
+index 5f48c9b9f..bc06fee82 100644
 --- a/drivers/media/i2c/max9296.c
 +++ b/drivers/media/i2c/max9296.c
 @@ -44,6 +44,8 @@
@@ -254,7 +254,7 @@ index 5f48c9b9f..316e687a1 100644
 @@ -260,6 +262,12 @@ void max9296_power_off(struct device *dev)
  	mutex_lock(&priv->lock);
  	priv->pw_ref--;
-
+ 
 +	if (priv->pw_ref < 0) {
 +		priv->pw_ref = 0;
 +		mutex_unlock(&priv->lock);
@@ -264,7 +264,7 @@ index 5f48c9b9f..316e687a1 100644
  	if (priv->pw_ref == 0) {
  		/* enter reset mode: XCLR */
  		usleep_range(1, 2);
-@@ -780,6 +785,190 @@ ret:
+@@ -780,6 +788,190 @@ ret:
  }
  EXPORT_SYMBOL(max9296_setup_streaming);
  
@@ -471,7 +471,7 @@ index d50b22e49..4d4ccc587 100644
  		pr_err("%s: Need to extend format%s\n", __func__, pixel_t);
  		return -EINVAL;
 diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
-index 03de76844..5801984aa 100644
+index 03de76844..9dc4dd267 100644
 --- a/drivers/media/platform/tegra/camera/vi/channel.c
 +++ b/drivers/media/platform/tegra/camera/vi/channel.c
 @@ -215,7 +215,12 @@ static void tegra_channel_fmt_align(struct tegra_channel *chan,
@@ -587,7 +587,7 @@ index 03de76844..5801984aa 100644
  };
  
  static int tegra_channel_close(struct file *fp);
-@@ -2429,6 +2503,331 @@ static int tegra_channel_csi_init(struct tegra_channel *chan)
+@@ -2429,6 +2503,334 @@ static int tegra_channel_csi_init(struct tegra_channel *chan)
  	return ret;
  }
  
@@ -897,6 +897,9 @@ index 03de76844..5801984aa 100644
 +		dma_free_coherent(vi_unit_dev,
 +				chan->emb_buf_size,
 +				chan->emb_buf_addr, chan->emb_buf);
++		chan->emb_buf_addr = NULL;
++		chan->emb_buf = 0;
++		chan->emb_buf_stride = 0;
 +		chan->emb_buf_size = 0;
 +		vb2_queue_release(queue);
 +#if defined(CONFIG_VIDEOBUF2_DMA_CONTIG)
@@ -919,9 +922,13 @@ index 03de76844..5801984aa 100644
  int tegra_channel_init_video(struct tegra_channel *chan)
  {
  	struct tegra_mc_vi *vi = chan->vi;
-@@ -2617,6 +3016,13 @@ int tegra_channel_cleanup(struct tegra_channel *chan)
+@@ -2616,7 +3018,17 @@ int tegra_channel_cleanup(struct tegra_channel *chan)
+ 		dma_free_coherent(vi_unit_dev,
  			chan->emb_buf_size,
  			chan->emb_buf_addr, chan->emb_buf);
++		chan->emb_buf_addr = NULL;
++		chan->emb_buf = 0;
++		chan->emb_buf_stride = 0;
  		chan->emb_buf_size = 0;
 +		vb2_queue_release(&chan->embedded.queue);
 +#if defined(CONFIG_VIDEOBUF2_DMA_CONTIG)
@@ -1145,19 +1152,57 @@ index de33c42fb..02d63ab62 100644
  
  #endif
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-index b54833d3f..042a80e51 100644
+index b54833d3f..98be1be4e 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -422,6 +422,39 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -18,6 +18,7 @@
+ #include <linux/errno.h>
+ #include <linux/semaphore.h>
+ #include <linux/version.h>
++#include <linux/overflow.h>
+ #include <media/tegra_camera_platform.h>
+ #include <media/mc_common.h>
+ #include <media/tegra-v4l2-camera.h>
+@@ -32,6 +33,8 @@
+ 
+ #define DEFAULT_FRAMERATE	30
+ #define BPP_MEM			2
++#define D4XX_META_BUFSIZE	255U
++#define D4XX_META_PAYLOAD	68U
+ #define VI_CSI_CLK_SCALE	110
+ #define PG_BITRATE		32
+ #define SLVSEC_STREAM_MAIN	0U
+@@ -406,12 +409,15 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	desc->ch_cfg.atomp.surface_stride[0] = bpl;
+ 
+ 	if (chan->embedded_data_height > 0) {
++		dma_addr_t emb_offset =
++			(dma_addr_t)descr_index * chan->emb_buf_stride;
++
+ 		desc->ch_cfg.embdata_enable = 1;
+ 		desc->ch_cfg.frame.embed_x = chan->embedded_data_width * BPP_MEM;
+ 		desc->ch_cfg.frame.embed_y = chan->embedded_data_height;
+ 
+ 		desc_memoryinfo->surface[VI_ATOMP_SURFACE_EMBEDDED].base_address
+-			= chan->emb_buf;
++			= chan->emb_buf + emb_offset;
+ 		desc_memoryinfo->surface[VI_ATOMP_SURFACE_EMBEDDED].size
+ 			= desc->ch_cfg.frame.embed_x * desc->ch_cfg.frame.embed_y;
+ 
+@@ -422,6 +428,56 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  	chan->capture_descr_sequence += 1;
  }
  
 +static void vi5_release_metadata_buffer(struct tegra_channel *chan,
-+	struct vb2_v4l2_buffer *vbuf)
++	struct tegra_channel_buffer *buf)
 +{
 +	struct vb2_buffer *evb = NULL;
 +	struct vb2_v4l2_buffer *evbuf;
-+	void* frm_buffer;
++	struct vb2_v4l2_buffer *vbuf = &buf->buf;
++	void *frm_buffer;
++	void *metadata_addr;
++	unsigned int descr_index = buf->capture_descr_index[0];
++	unsigned int emb_offset;
 +
 +	spin_lock(&chan->embedded.spin_lock);
 +	if (0 < chan->embedded.num_buffers) {
@@ -1174,13 +1219,26 @@ index b54833d3f..042a80e51 100644
 +		return;
 +
 +	frm_buffer = vb2_plane_vaddr(evb, 0);
-+	if (!frm_buffer)
++	if (!frm_buffer) {
++		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
 +		return;
++	}
 +
-+	memcpy(frm_buffer, chan->emb_buf_addr, 255);
++	if (!chan->emb_buf_stride ||
++		chan->emb_buf_size < D4XX_META_BUFSIZE ||
++		descr_index >= chan->capture_queue_depth ||
++		check_mul_overflow(descr_index, chan->emb_buf_stride,
++			&emb_offset) ||
++		emb_offset > chan->emb_buf_size - D4XX_META_BUFSIZE) {
++		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
++		return;
++	}
++
++	metadata_addr = (u8 *)chan->emb_buf_addr + emb_offset;
++	memcpy(frm_buffer, metadata_addr, D4XX_META_BUFSIZE);
 +	evbuf = to_vb2_v4l2_buffer(evb);
 +	evbuf->sequence = vbuf->sequence;
-+	vb2_set_plane_payload(evb, 0, 68);
++	vb2_set_plane_payload(evb, 0, D4XX_META_PAYLOAD);
 +	evb->timestamp = vbuf->vb2_buf.timestamp;
 +	vb2_buffer_done(evb, VB2_BUF_STATE_DONE);
 +}
@@ -1188,17 +1246,17 @@ index b54833d3f..042a80e51 100644
  static void vi5_release_buffer(struct tegra_channel *chan,
  	struct tegra_channel_buffer *buf)
  {
-@@ -432,6 +465,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+@@ -431,6 +487,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+ 	vbuf->field = V4L2_FIELD_NONE;
  	vb2_set_plane_payload(&vbuf->vb2_buf, 0, chan->format.sizeimage);
  
- 	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);
-+
 +	if (chan->embedded_data_height == 1 && buf->vb2_state == VB2_BUF_STATE_DONE)
-+		vi5_release_metadata_buffer(chan, vbuf);
++		vi5_release_metadata_buffer(chan, buf);
++
+ 	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);
  }
  
- static void vi5_capture_enqueue(struct tegra_channel *chan,
-@@ -483,6 +519,88 @@ uncorr_err:
+@@ -483,6 +542,88 @@ uncorr_err:
  	spin_unlock_irqrestore(&chan->capture_state_lock, flags);
  }
  
@@ -1287,7 +1345,7 @@ index b54833d3f..042a80e51 100644
  static void vi5_capture_dequeue(struct tegra_channel *chan,
  	struct tegra_channel_buffer *buf)
  {
-@@ -527,15 +645,29 @@ static void vi5_capture_dequeue(struct tegra_channel *chan,
+@@ -527,15 +668,29 @@ static void vi5_capture_dequeue(struct tegra_channel *chan,
  			} else {
  				dev_warn(vi->dev,
  					"corr_err: discarding frame %d, flags: %d, "
@@ -1320,7 +1378,7 @@ index b54833d3f..042a80e51 100644
  			}
  		} else if (!vi_port) {
  			gang_prev_frame_id = descr->status.frame_id;
-@@ -580,7 +712,6 @@ static void vi5_capture_dequeue(struct tegra_channel *chan,
+@@ -580,7 +735,6 @@ static void vi5_capture_dequeue(struct tegra_channel *chan,
  	trace_tegra_channel_capture_frame("eof", &ts);
  #endif
  
@@ -1328,6 +1386,151 @@ index b54833d3f..042a80e51 100644
  	goto rel_buf;
  
  uncorr_err:
+@@ -825,6 +979,75 @@ static void vi5_unit_get_device_handle(struct platform_device *pdev,
+ 		dev_err(&pdev->dev, "dev pointer is NULL\n");
+ }
+ 
++static int vi5_embedded_buffer_size(struct tegra_channel *chan,
++	unsigned int *stride, unsigned int *size)
++{
++	unsigned int payload_size;
++	unsigned int aligned_size;
++
++	if (!chan->capture_queue_depth)
++		return -EINVAL;
++
++	if (check_mul_overflow(chan->embedded_data_width,
++			chan->embedded_data_height, &payload_size) ||
++		check_mul_overflow(payload_size, (unsigned int)BPP_MEM,
++			&payload_size) ||
++		!payload_size ||
++		check_add_overflow(payload_size, (unsigned int)PAGE_SIZE - 1,
++			&aligned_size))
++		return -EOVERFLOW;
++
++	*stride = round_down(aligned_size, (unsigned int)PAGE_SIZE);
++	if (check_mul_overflow(*stride, chan->capture_queue_depth, size))
++		return -EOVERFLOW;
++
++	return 0;
++}
++
++static int vi5_channel_prepare_embedded_buffer(struct tegra_channel *chan)
++{
++	unsigned int emb_buf_stride;
++	unsigned int emb_buf_size;
++	struct device *vi_unit_dev;
++	dma_addr_t new_emb_buf;
++	void *new_emb_buf_addr;
++	int ret;
++
++	if (!chan->embedded_data_height) {
++		chan->emb_buf_stride = 0;
++		return 0;
++	}
++
++	ret = vi5_embedded_buffer_size(chan, &emb_buf_stride, &emb_buf_size);
++	if (ret)
++		return ret;
++	if (!chan->emb_buf_size) {
++		chan->emb_buf_addr = NULL;
++		chan->emb_buf = 0;
++		chan->emb_buf_stride = 0;
++	}
++
++	if (emb_buf_size > chan->emb_buf_size) {
++		vi5_unit_get_device_handle(chan->vi->ndev, chan->port[0],
++			&vi_unit_dev);
++		new_emb_buf_addr = dma_alloc_coherent(vi_unit_dev, emb_buf_size,
++			&new_emb_buf, GFP_KERNEL);
++		if (!new_emb_buf_addr)
++			return -ENOMEM;
++
++		if (chan->emb_buf_size > 0)
++			dma_free_coherent(vi_unit_dev, chan->emb_buf_size,
++				chan->emb_buf_addr, chan->emb_buf);
++
++		chan->emb_buf_addr = new_emb_buf_addr;
++		chan->emb_buf = new_emb_buf;
++		chan->emb_buf_size = emb_buf_size;
++	}
++
++	chan->emb_buf_stride = emb_buf_stride;
++	return 0;
++}
++
+ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ {
+ 	struct tegra_channel *chan = vb2_get_drv_priv(vq);
+@@ -837,7 +1060,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 	struct device_node *node;
+ 	struct sensor_mode_properties *sensor_mode;
+ 	struct camera_common_data *s_data;
+-	unsigned int emb_buf_size = 0;
+ 
+ 	/* Skip in bypass mode */
+ 	if (!chan->bypass) {
+@@ -860,7 +1082,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 				if (s_data != NULL && node != NULL) {
+ 					int idx = s_data->mode_prop_idx;
+ 
+-					emb_buf_size = 0;
+ 					if (idx < s_data->sensor_props.\
+ 								num_modes) {
+ 						sensor_mode =
+@@ -874,46 +1095,14 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 							sensor_mode->\
+ 							 image_properties.\
+ 						      embedded_metadata_height;
+-						/* rounding up to page size */
+-						emb_buf_size =
+-							round_up(chan->\
+-							embedded_data_width *
+-								chan->\
+-							embedded_data_height *
+-							BPP_MEM, PAGE_SIZE);
+ 					}
+ 				}
+-				/* Allocate buffer for Embedded Data if need to*/
+-				if (emb_buf_size > chan->emb_buf_size) {
+-					struct device *vi_unit_dev;
+-
+-					vi5_unit_get_device_handle(\
+-						chan->vi->ndev, chan->port[0],\
+-						&vi_unit_dev);
+-				/*
+-				 * if old buffer is smaller than what we need,
+-				 * release the old buffer and re-allocate a
+-				 * bigger one below.
+-				 */
+-					if (chan->emb_buf_size > 0) {
+-						dma_free_coherent(vi_unit_dev,
+-							chan->emb_buf_size,
+-							chan->emb_buf_addr,
+-							chan->emb_buf);
+-						chan->emb_buf_size = 0;
+-					}
+-
+-					chan->emb_buf_addr =
+-						dma_alloc_coherent(vi_unit_dev,
+-							emb_buf_size,
+-						&chan->emb_buf, GFP_KERNEL);
+-					if (!chan->emb_buf_addr) {
+-						dev_err(&chan->video->dev,
+-							"Can't allocate memory"
+-							"for embedded data\n");
+-						goto err_setup;
+-					}
+-					chan->emb_buf_size = emb_buf_size;
++				ret = vi5_channel_prepare_embedded_buffer(chan);
++				if (ret) {
++					dev_err(&chan->video->dev,
++						"failed to prepare embedded buffer: %d\n",
++						ret);
++					goto err_setup;
+ 				}
+ 			}
+ 			ret = tegra_channel_capture_setup(chan, vi_port);
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 index 7ee3a6223..0c6d0ae88 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
@@ -1408,7 +1611,7 @@ index 78ad66433..8795afe4e 100644
  	if (!info)
  		return -EINVAL;
 diff --git a/include/media/gmsl-link.h b/include/media/gmsl-link.h
-index 1eab7bac9..533f31eb8 100644
+index 1eab7bac9..0abe0996b 100644
 --- a/include/media/gmsl-link.h
 +++ b/include/media/gmsl-link.h
 @@ -53,6 +53,11 @@
@@ -1486,7 +1689,7 @@ index 61435e263..20f3a6657 100644
  
  #endif  /* __MAX9296_H__ */
 diff --git a/include/media/mc_common.h b/include/media/mc_common.h
-index 18328db1d..d0e908bf1 100644
+index 18328db1d..ccc9e5598 100644
 --- a/include/media/mc_common.h
 +++ b/include/media/mc_common.h
 @@ -42,6 +42,7 @@
@@ -1521,7 +1724,15 @@ index 18328db1d..d0e908bf1 100644
  	DECLARE_BITMAP(fmts_bitmap, MAX_FORMAT_NUM);
  	atomic_t power_on_refcnt;
  	struct v4l2_fh *fh;
-@@ -309,6 +327,9 @@ struct tegra_mc_vi {
+@@ -268,6 +286,7 @@ struct tegra_channel {
+ 
+ 	dma_addr_t emb_buf;
+ 	void *emb_buf_addr;
++	unsigned int emb_buf_stride;
+ 	unsigned int emb_buf_size;
+ };
+ 
+@@ -309,6 +328,9 @@ struct tegra_mc_vi {
  	unsigned int num_channels;
  	unsigned int num_subdevs;
  
@@ -1531,7 +1742,7 @@ index 18328db1d..d0e908bf1 100644
  	struct tegra_csi_device *csi;
  	struct list_head vi_chans;
  	struct tegra_channel *tpg_start;
-@@ -413,7 +434,9 @@ struct tegra_channel_buffer *dequeue_inflight(struct tegra_channel *chan);
+@@ -413,7 +435,9 @@ struct tegra_channel_buffer *dequeue_inflight(struct tegra_channel *chan);
  int tegra_channel_set_power(struct tegra_channel *chan, bool on);
  
  int tegra_channel_init_video(struct tegra_channel *chan);
@@ -1542,7 +1753,7 @@ index 18328db1d..d0e908bf1 100644
  struct tegra_vi_fops {
  	int (*vi_power_on)(struct tegra_channel *chan);
 diff --git a/include/media/tegra_camera_core.h b/include/media/tegra_camera_core.h
-index 788cf77dc..421c22491 100644
+index 788cf77dc..67221b0c6 100644
 --- a/include/media/tegra_camera_core.h
 +++ b/include/media/tegra_camera_core.h
 @@ -23,7 +23,7 @@
@@ -1577,7 +1788,7 @@ index 788cf77dc..421c22491 100644
  };
  
  /* Supported CSI to VI Data Formats */
-@@ -66,6 +66,7 @@ enum tegra_vf_code {
+@@ -66,6 +75,7 @@ enum tegra_vf_code {
  	TEGRA_VF_RAW10,
  	TEGRA_VF_RAW12,
  	TEGRA_VF_RAW14,
@@ -1587,3 +1798,4 @@ index 788cf77dc..421c22491 100644
  	TEGRA_VF_RGB555,
 -- 
 2.34.1
+

--- a/kernel/nvidia/5.1.6/0001-Porting-driver-patches-to-jetpack-5.1.2.patch
+++ b/kernel/nvidia/5.1.6/0001-Porting-driver-patches-to-jetpack-5.1.2.patch
@@ -1,31 +1,31 @@
-From 1b06cf3323a3d7d1437071dc3789e9487b9b5733 Mon Sep 17 00:00:00 2001
+From bdeb039ce28f4b3471e1c5d4f2d8a4650c969b15 Mon Sep 17 00:00:00 2001
 From: Dmitry Perchanov <dmitry.perchanov@intel.com>
 Date: Wed, 18 Oct 2023 13:51:51 +0300
 Subject: [PATCH] Porting driver patches to jetpack 5.1.2
 
 Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
 ---
- drivers/media/i2c/Kconfig                     |  29 +
+ drivers/media/i2c/Kconfig                     |  29 ++
  drivers/media/i2c/Makefile                    |   3 +
- drivers/media/i2c/max9295.c                   | 145 ++++++-
- drivers/media/i2c/max9296.c                   | 189 ++++++++
+ drivers/media/i2c/max9295.c                   | 145 +++++-
+ drivers/media/i2c/max9296.c                   | 192 ++++++++
  .../platform/tegra/camera/sensor_common.c     |   4 +
- .../media/platform/tegra/camera/vi/channel.c  | 410 +++++++++++++++++-
- .../media/platform/tegra/camera/vi/graph.c    |  48 +-
+ .../media/platform/tegra/camera/vi/channel.c  | 417 +++++++++++++++++-
+ .../media/platform/tegra/camera/vi/graph.c    |  50 ++-
  .../platform/tegra/camera/vi/mc_common.c      |  32 ++
  .../platform/tegra/camera/vi/vi4_formats.h    |  32 +-
- .../media/platform/tegra/camera/vi/vi5_fops.c | 132 +-
- .../platform/tegra/camera/vi/vi5_formats.h    |  28 -
+ .../media/platform/tegra/camera/vi/vi5_fops.c | 279 ++++++++++--
+ .../platform/tegra/camera/vi/vi5_formats.h    |  30 +-
  .../tegra/camera/tegra_camera_platform.c      |   5 +
- include/media/gmsl-link.h                     |   4 ++
+ include/media/gmsl-link.h                     |   5 +
  include/media/max9295.h                       |   4 +
  include/media/max9296.h                       |   8 +
- include/media/mc_common.h                     |  23 +
- include/media/tegra_camera_core.h             |   8 +
- 17 files changed, 1066 insertions(+), 29 deletions(-)
+ include/media/mc_common.h                     |  24 +
+ include/media/tegra_camera_core.h             |  12 +-
+ 17 files changed, 1201 insertions(+), 70 deletions(-)
 
 diff --git a/drivers/media/i2c/Kconfig b/drivers/media/i2c/Kconfig
-index 5ec3c683c..7f288faf7 100644
+index 5ec3c68..e3495a0 100644
 --- a/drivers/media/i2c/Kconfig
 +++ b/drivers/media/i2c/Kconfig
 @@ -210,6 +210,35 @@ config NV_VIRTUAL_I2C_MUX
@@ -65,7 +65,7 @@ index 5ec3c683c..7f288faf7 100644
  
  endif
 diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
-index c4708d8c7..e11e8ad39 100644
+index c4708d8..e8f1ba9 100644
 --- a/drivers/media/i2c/Makefile
 +++ b/drivers/media/i2c/Makefile
 @@ -27,3 +27,6 @@ obj-$(CONFIG_NV_VIDEO_HAWK_OWL) += nv_hawk_owl.o
@@ -76,7 +76,7 @@ index c4708d8c7..e11e8ad39 100644
 +obj-$(CONFIG_VIDEO_D4XX) += d4xx.o
 +obj-$(CONFIG_VIDEO_D4XX) += max96724.o
 diff --git a/drivers/media/i2c/max9295.c b/drivers/media/i2c/max9295.c
-index 110f861c3..6311d97d7 100644
+index 110f861..19026e8 100644
 --- a/drivers/media/i2c/max9295.c
 +++ b/drivers/media/i2c/max9295.c
 @@ -395,9 +395,9 @@ int max9295_reset_control(struct device *dev)
@@ -239,7 +239,7 @@ index 110f861c3..6311d97d7 100644
  				const struct i2c_device_id *id)
  {
 diff --git a/drivers/media/i2c/max9296.c b/drivers/media/i2c/max9296.c
-index 5f48c9b9f..316e687a1 100644
+index 5f48c9b..bc06fee 100644
 --- a/drivers/media/i2c/max9296.c
 +++ b/drivers/media/i2c/max9296.c
 @@ -44,6 +44,8 @@
@@ -254,7 +254,7 @@ index 5f48c9b9f..316e687a1 100644
 @@ -260,6 +262,12 @@ void max9296_power_off(struct device *dev)
  	mutex_lock(&priv->lock);
  	priv->pw_ref--;
-
+ 
 +	if (priv->pw_ref < 0) {
 +		priv->pw_ref = 0;
 +		mutex_unlock(&priv->lock);
@@ -264,7 +264,7 @@ index 5f48c9b9f..316e687a1 100644
  	if (priv->pw_ref == 0) {
  		/* enter reset mode: XCLR */
  		usleep_range(1, 2);
-@@ -780,6 +785,190 @@ ret:
+@@ -780,6 +788,190 @@ ret:
  }
  EXPORT_SYMBOL(max9296_setup_streaming);
  
@@ -456,10 +456,10 @@ index 5f48c9b9f..316e687a1 100644
  	{ .compatible = "maxim,max9296", },
  	{ },
 diff --git a/drivers/media/platform/tegra/camera/sensor_common.c b/drivers/media/platform/tegra/camera/sensor_common.c
-index d50b22e49..4d4ccc587 100644
+index 038c312..e7fc3d8 100644
 --- a/drivers/media/platform/tegra/camera/sensor_common.c
 +++ b/drivers/media/platform/tegra/camera/sensor_common.c
-@@ -273,6 +273,10 @@ static int extract_pixel_format(
+@@ -282,6 +282,10 @@ static int extract_pixel_format(
  		*format = V4L2_PIX_FMT_UYVY;
  	else if (strncmp(pixel_t, "yuv_vyuy16", size) == 0)
  		*format = V4L2_PIX_FMT_VYUY;
@@ -471,7 +471,7 @@ index d50b22e49..4d4ccc587 100644
  		pr_err("%s: Need to extend format%s\n", __func__, pixel_t);
  		return -EINVAL;
 diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
-index 03de76844..5801984aa 100644
+index 03de768..01f5bb3 100644
 --- a/drivers/media/platform/tegra/camera/vi/channel.c
 +++ b/drivers/media/platform/tegra/camera/vi/channel.c
 @@ -215,7 +215,13 @@ static void tegra_channel_fmt_align(struct tegra_channel *chan,
@@ -489,7 +489,7 @@ index 03de76844..5801984aa 100644
  
  	/* Clamp the requested bytes per line value. If the maximum bytes per
  	 * line value is zero, the module doesn't support user configurable line
-@@ -1044,7 +1049,8 @@ tegra_channel_querycap(struct file *file, void *fh, struct v4l2_capability *cap)
+@@ -1044,7 +1050,8 @@ tegra_channel_querycap(struct file *file, void *fh, struct v4l2_capability *cap)
  
  	cap->device_caps = V4L2_CAP_VIDEO_CAPTURE | V4L2_CAP_STREAMING;
  	cap->device_caps |= V4L2_CAP_EXT_PIX_FORMAT;
@@ -499,7 +499,7 @@ index 03de76844..5801984aa 100644
  
  	strlcpy(cap->driver, "tegra-video", sizeof(cap->driver));
  	strlcpy(cap->card, chan->video->name, sizeof(cap->card));
-@@ -2072,6 +2078,15 @@ __tegra_channel_try_format(struct tegra_channel *chan,
+@@ -2072,6 +2079,15 @@ __tegra_channel_try_format(struct tegra_channel *chan,
  	v4l2_fill_mbus_format(&fmt.format, pix, vfmt->code);
  
  	ret = v4l2_subdev_call(sd, pad, set_fmt, &cfg, &fmt);
@@ -515,7 +515,7 @@ index 03de76844..5801984aa 100644
  	if (ret == -ENOIOCTLCMD)
  		return -ENOTTY;
  
-@@ -2237,6 +2252,61 @@ static long tegra_channel_default_ioctl(struct file *file, void *fh,
+@@ -2237,6 +2253,61 @@ static long tegra_channel_default_ioctl(struct file *file, void *fh,
  	return ret;
  }
  
@@ -587,7 +587,7 @@ index 03de76844..5801984aa 100644
  };
  
  static int tegra_channel_close(struct file *fp);
-@@ -2429,6 +2503,332 @@ static int tegra_channel_csi_init(struct tegra_channel *chan)
+@@ -2429,6 +2503,335 @@ static int tegra_channel_csi_init(struct tegra_channel *chan)
  	return ret;
  }
  
@@ -898,6 +898,9 @@ index 03de76844..5801984aa 100644
 +		dma_free_coherent(vi_unit_dev,
 +				chan->emb_buf_size,
 +				chan->emb_buf_addr, chan->emb_buf);
++		chan->emb_buf_addr = NULL;
++		chan->emb_buf = 0;
++		chan->emb_buf_stride = 0;
 +		chan->emb_buf_size = 0;
 +		vb2_queue_release(queue);
 +#if defined(CONFIG_VIDEOBUF2_DMA_CONTIG)
@@ -920,9 +923,13 @@ index 03de76844..5801984aa 100644
  int tegra_channel_init_video(struct tegra_channel *chan)
  {
  	struct tegra_mc_vi *vi = chan->vi;
-@@ -2617,6 +3016,13 @@ int tegra_channel_cleanup(struct tegra_channel *chan)
+@@ -2616,7 +3019,17 @@ int tegra_channel_cleanup(struct tegra_channel *chan)
+ 		dma_free_coherent(vi_unit_dev,
  			chan->emb_buf_size,
  			chan->emb_buf_addr, chan->emb_buf);
++		chan->emb_buf_addr = NULL;
++		chan->emb_buf = 0;
++		chan->emb_buf_stride = 0;
  		chan->emb_buf_size = 0;
 +		vb2_queue_release(&chan->embedded.queue);
 +#if defined(CONFIG_VIDEOBUF2_DMA_CONTIG)
@@ -935,7 +942,7 @@ index 03de76844..5801984aa 100644
  
  	tegra_channel_dealloc_buffer_queue(chan);
 diff --git a/drivers/media/platform/tegra/camera/vi/graph.c b/drivers/media/platform/tegra/camera/vi/graph.c
-index cb097442d..5fd45cf10 100644
+index cb09744..f5bc795 100644
 --- a/drivers/media/platform/tegra/camera/vi/graph.c
 +++ b/drivers/media/platform/tegra/camera/vi/graph.c
 @@ -373,6 +373,12 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
@@ -951,7 +958,7 @@ index cb097442d..5fd45cf10 100644
  	int ret;
  
  	dev_dbg(chan->vi->dev, "notify complete, all subdevs registered\n");
-@@ -401,26 +406,61 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
+@@ -401,26 +407,61 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
  		if (entity->entity != NULL) {
  			ret = tegra_vi_graph_build_one(chan, entity);
  			if (ret < 0)
@@ -1017,7 +1024,7 @@ index cb097442d..5fd45cf10 100644
  	video_unregister_device(chan->video);
  register_device_error:
  	video_device_release(chan->video);
-@@ -482,6 +521,7 @@ static void tegra_vi_graph_notify_unbind(struct v4l2_async_notifier *notifier,
+@@ -482,6 +523,7 @@ static void tegra_vi_graph_notify_unbind(struct v4l2_async_notifier *notifier,
  
  	/* cleanup for complete */
  	if (chan->link_status) {
@@ -1026,7 +1033,7 @@ index cb097442d..5fd45cf10 100644
  		tegra_channel_cleanup_video(chan);
  		chan->link_status--;
 diff --git a/drivers/media/platform/tegra/camera/vi/mc_common.c b/drivers/media/platform/tegra/camera/vi/mc_common.c
-index bed3e92a3..54b60f3b7 100644
+index bed3e92..54b60f3 100644
 --- a/drivers/media/platform/tegra/camera/vi/mc_common.c
 +++ b/drivers/media/platform/tegra/camera/vi/mc_common.c
 @@ -24,6 +24,10 @@
@@ -1083,10 +1090,10 @@ index bed3e92a3..54b60f3b7 100644
  	for (i = 0; i < num_channels; i++) {
  		item = devm_kzalloc(vi->dev, sizeof(*item), GFP_KERNEL);
 diff --git a/drivers/media/platform/tegra/camera/vi/vi4_formats.h b/drivers/media/platform/tegra/camera/vi/vi4_formats.h
-index de33c42fb..02d63ab62 100644
+index daeaf45..e137c8c 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi4_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi4_formats.h
-@@ -87,6 +87,9 @@ static const struct tegra_video_format vi4_video_formats[] = {
+@@ -88,6 +88,9 @@ static const struct tegra_video_format vi4_video_formats[] = {
  	/* RAW 7: TODO */
  
  	/* RAW 8 */
@@ -1096,7 +1103,7 @@ index de33c42fb..02d63ab62 100644
  	TEGRA_VIDEO_FORMAT(RAW8, 8, SRGGB8_1X8, 1, 1, T_L8,
  				RAW8, SRGGB8, "RGRG.. GBGB.."),
  	TEGRA_VIDEO_FORMAT(RAW8, 8, SGRBG8_1X8, 1, 1, T_L8,
-@@ -117,22 +120,22 @@ static const struct tegra_video_format vi4_video_formats[] = {
+@@ -127,22 +130,22 @@ static const struct tegra_video_format vi4_video_formats[] = {
  				RAW14, SBGGR14, "BGBG.. GRGR.."),
  
  	/* RGB888 */
@@ -1127,7 +1134,7 @@ index de33c42fb..02d63ab62 100644
  	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
  				YUV422_8, UYVY, "YUV 4:2:2 UYVY"),
  	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_2X8, 2, 1, T_V8_Y8__U8_Y8,
-@@ -141,6 +144,19 @@ static const struct tegra_video_format vi4_video_formats[] = {
+@@ -151,6 +154,19 @@ static const struct tegra_video_format vi4_video_formats[] = {
  				YUV422_8, YUYV, "YUV 4:2:2 YUYV"),
  	TEGRA_VIDEO_FORMAT(YUV422, 16, YVYU8_2X8, 2, 1, T_Y8_V8__Y8_U8,
  				YUV422_8, YVYU, "YUV 4:2:2 YVYU"),
@@ -1148,19 +1155,57 @@ index de33c42fb..02d63ab62 100644
  
  #endif
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-index b54833d3f..042a80e51 100644
+index 467fbd3..5e662b1 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -422,6 +422,39 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -19,6 +19,7 @@
+ #include <linux/errno.h>
+ #include <linux/semaphore.h>
+ #include <linux/version.h>
++#include <linux/overflow.h>
+ #include <media/tegra_camera_platform.h>
+ #include <media/mc_common.h>
+ #include <media/tegra-v4l2-camera.h>
+@@ -33,6 +34,8 @@
+ 
+ #define DEFAULT_FRAMERATE	30
+ #define BPP_MEM			2
++#define D4XX_META_BUFSIZE	255U
++#define D4XX_META_PAYLOAD	68U
+ #define VI_CSI_CLK_SCALE	110
+ #define PG_BITRATE		32
+ #define SLVSEC_STREAM_MAIN	0U
+@@ -418,12 +421,15 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	desc->ch_cfg.atomp.surface_stride[0] = bpl;
+ 
+ 	if (chan->embedded_data_height > 0) {
++		dma_addr_t emb_offset =
++			(dma_addr_t)descr_index * chan->emb_buf_stride;
++
+ 		desc->ch_cfg.embdata_enable = 1;
+ 		desc->ch_cfg.frame.embed_x = chan->embedded_data_width * BPP_MEM;
+ 		desc->ch_cfg.frame.embed_y = chan->embedded_data_height;
+ 
+ 		desc_memoryinfo->surface[VI_ATOMP_SURFACE_EMBEDDED].base_address
+-			= chan->emb_buf;
++			= chan->emb_buf + emb_offset;
+ 		desc_memoryinfo->surface[VI_ATOMP_SURFACE_EMBEDDED].size
+ 			= desc->ch_cfg.frame.embed_x * desc->ch_cfg.frame.embed_y;
+ 
+@@ -434,6 +440,56 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  	chan->capture_descr_sequence += 1;
  }
  
 +static void vi5_release_metadata_buffer(struct tegra_channel *chan,
-+	struct vb2_v4l2_buffer *vbuf)
++	struct tegra_channel_buffer *buf)
 +{
 +	struct vb2_buffer *evb = NULL;
 +	struct vb2_v4l2_buffer *evbuf;
-+	void* frm_buffer;
++	struct vb2_v4l2_buffer *vbuf = &buf->buf;
++	void *frm_buffer;
++	void *metadata_addr;
++	unsigned int descr_index = buf->capture_descr_index[0];
++	unsigned int emb_offset;
 +
 +	spin_lock(&chan->embedded.spin_lock);
 +	if (0 < chan->embedded.num_buffers) {
@@ -1177,13 +1222,26 @@ index b54833d3f..042a80e51 100644
 +		return;
 +
 +	frm_buffer = vb2_plane_vaddr(evb, 0);
-+	if (!frm_buffer)
++	if (!frm_buffer) {
++		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
 +		return;
++	}
 +
-+	memcpy(frm_buffer, chan->emb_buf_addr, 255);
++	if (!chan->emb_buf_stride ||
++		chan->emb_buf_size < D4XX_META_BUFSIZE ||
++		descr_index >= chan->capture_queue_depth ||
++		check_mul_overflow(descr_index, chan->emb_buf_stride,
++			&emb_offset) ||
++		emb_offset > chan->emb_buf_size - D4XX_META_BUFSIZE) {
++		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
++		return;
++	}
++
++	metadata_addr = (u8 *)chan->emb_buf_addr + emb_offset;
++	memcpy(frm_buffer, metadata_addr, D4XX_META_BUFSIZE);
 +	evbuf = to_vb2_v4l2_buffer(evb);
 +	evbuf->sequence = vbuf->sequence;
-+	vb2_set_plane_payload(evb, 0, 68);
++	vb2_set_plane_payload(evb, 0, D4XX_META_PAYLOAD);
 +	evb->timestamp = vbuf->vb2_buf.timestamp;
 +	vb2_buffer_done(evb, VB2_BUF_STATE_DONE);
 +}
@@ -1191,17 +1249,17 @@ index b54833d3f..042a80e51 100644
  static void vi5_release_buffer(struct tegra_channel *chan,
  	struct tegra_channel_buffer *buf)
  {
-@@ -432,6 +465,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+@@ -443,6 +499,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+ 	vbuf->field = V4L2_FIELD_NONE;
  	vb2_set_plane_payload(&vbuf->vb2_buf, 0, chan->format.sizeimage);
  
- 	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);
-+
 +	if (chan->embedded_data_height == 1 && buf->vb2_state == VB2_BUF_STATE_DONE)
-+		vi5_release_metadata_buffer(chan, vbuf);
++		vi5_release_metadata_buffer(chan, buf);
++
+ 	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);
  }
  
- static void vi5_capture_enqueue(struct tegra_channel *chan,
-@@ -483,6 +519,89 @@ uncorr_err:
+@@ -495,6 +554,89 @@ uncorr_err:
  	spin_unlock_irqrestore(&chan->capture_state_lock, flags);
  }
  
@@ -1291,7 +1349,7 @@ index b54833d3f..042a80e51 100644
  static void vi5_capture_dequeue(struct tegra_channel *chan,
  	struct tegra_channel_buffer *buf)
  {
-@@ -527,10 +645,24 @@ static void vi5_capture_dequeue(struct tegra_channel *chan,
+@@ -549,10 +691,24 @@ static void vi5_capture_dequeue(struct tegra_channel *chan,
  			} else {
  				dev_warn(vi->dev,
  					"corr_err: discarding frame %d, flags: %d, "
@@ -1299,8 +1357,8 @@ index b54833d3f..042a80e51 100644
 +					"err_data %d, vc: %d\n",
  					descr->status.frame_id, descr->status.flags,
 -					descr->status.err_data);
-+					descr->status.err_data, chan->virtual_channel);
 -				frame_err = true;
++					descr->status.err_data, chan->virtual_channel);
 +				/* D457: err_data 131072 (20000h) & 512 (200h) leading to channel
 +				* timeout. This happens when first frame is corrupted - no md
 +				* and less lines than requested. Channel reset time is 6ms */
@@ -1319,11 +1377,156 @@ index b54833d3f..042a80e51 100644
  			}
  		} else if (!vi_port) {
  			gang_prev_frame_id = descr->status.frame_id;
+@@ -850,6 +1006,75 @@ static void vi5_unit_get_device_handle(struct platform_device *pdev,
+ 		dev_err(&pdev->dev, "dev pointer is NULL\n");
+ }
+ 
++static int vi5_embedded_buffer_size(struct tegra_channel *chan,
++	unsigned int *stride, unsigned int *size)
++{
++	unsigned int payload_size;
++	unsigned int aligned_size;
++
++	if (!chan->capture_queue_depth)
++		return -EINVAL;
++
++	if (check_mul_overflow(chan->embedded_data_width,
++			chan->embedded_data_height, &payload_size) ||
++		check_mul_overflow(payload_size, (unsigned int)BPP_MEM,
++			&payload_size) ||
++		!payload_size ||
++		check_add_overflow(payload_size, (unsigned int)PAGE_SIZE - 1,
++			&aligned_size))
++		return -EOVERFLOW;
++
++	*stride = round_down(aligned_size, (unsigned int)PAGE_SIZE);
++	if (check_mul_overflow(*stride, chan->capture_queue_depth, size))
++		return -EOVERFLOW;
++
++	return 0;
++}
++
++static int vi5_channel_prepare_embedded_buffer(struct tegra_channel *chan)
++{
++	unsigned int emb_buf_stride;
++	unsigned int emb_buf_size;
++	struct device *vi_unit_dev;
++	dma_addr_t new_emb_buf;
++	void *new_emb_buf_addr;
++	int ret;
++
++	if (!chan->embedded_data_height) {
++		chan->emb_buf_stride = 0;
++		return 0;
++	}
++
++	ret = vi5_embedded_buffer_size(chan, &emb_buf_stride, &emb_buf_size);
++	if (ret)
++		return ret;
++	if (!chan->emb_buf_size) {
++		chan->emb_buf_addr = NULL;
++		chan->emb_buf = 0;
++		chan->emb_buf_stride = 0;
++	}
++
++	if (emb_buf_size > chan->emb_buf_size) {
++		vi5_unit_get_device_handle(chan->vi->ndev, chan->port[0],
++			&vi_unit_dev);
++		new_emb_buf_addr = dma_alloc_coherent(vi_unit_dev, emb_buf_size,
++			&new_emb_buf, GFP_KERNEL);
++		if (!new_emb_buf_addr)
++			return -ENOMEM;
++
++		if (chan->emb_buf_size > 0)
++			dma_free_coherent(vi_unit_dev, chan->emb_buf_size,
++				chan->emb_buf_addr, chan->emb_buf);
++
++		chan->emb_buf_addr = new_emb_buf_addr;
++		chan->emb_buf = new_emb_buf;
++		chan->emb_buf_size = emb_buf_size;
++	}
++
++	chan->emb_buf_stride = emb_buf_stride;
++	return 0;
++}
++
+ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ {
+ 	struct tegra_channel *chan = vb2_get_drv_priv(vq);
+@@ -862,7 +1087,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 	struct device_node *node;
+ 	struct sensor_mode_properties *sensor_mode;
+ 	struct camera_common_data *s_data;
+-	unsigned int emb_buf_size = 0;
+ 
+ 	/* Skip in bypass mode */
+ 	if (!chan->bypass) {
+@@ -885,7 +1109,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 				if (s_data != NULL && node != NULL) {
+ 					int idx = s_data->mode_prop_idx;
+ 
+-					emb_buf_size = 0;
+ 					if (idx < s_data->sensor_props.\
+ 								num_modes) {
+ 						sensor_mode =
+@@ -899,46 +1122,14 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 							sensor_mode->\
+ 							 image_properties.\
+ 						      embedded_metadata_height;
+-						/* rounding up to page size */
+-						emb_buf_size =
+-							round_up(chan->\
+-							embedded_data_width *
+-								chan->\
+-							embedded_data_height *
+-							BPP_MEM, PAGE_SIZE);
+ 					}
+ 				}
+-				/* Allocate buffer for Embedded Data if need to*/
+-				if (emb_buf_size > chan->emb_buf_size) {
+-					struct device *vi_unit_dev;
+-
+-					vi5_unit_get_device_handle(\
+-						chan->vi->ndev, chan->port[0],\
+-						&vi_unit_dev);
+-				/*
+-				 * if old buffer is smaller than what we need,
+-				 * release the old buffer and re-allocate a
+-				 * bigger one below.
+-				 */
+-					if (chan->emb_buf_size > 0) {
+-						dma_free_coherent(vi_unit_dev,
+-							chan->emb_buf_size,
+-							chan->emb_buf_addr,
+-							chan->emb_buf);
+-						chan->emb_buf_size = 0;
+-					}
+-
+-					chan->emb_buf_addr =
+-						dma_alloc_coherent(vi_unit_dev,
+-							emb_buf_size,
+-						&chan->emb_buf, GFP_KERNEL);
+-					if (!chan->emb_buf_addr) {
+-						dev_err(&chan->video->dev,
+-							"Can't allocate memory"
+-							"for embedded data\n");
+-						goto err_setup;
+-					}
+-					chan->emb_buf_size = emb_buf_size;
++				ret = vi5_channel_prepare_embedded_buffer(chan);
++				if (ret) {
++					dev_err(&chan->video->dev,
++						"failed to prepare embedded buffer: %d\n",
++						ret);
++					goto err_setup;
+ 				}
+ 			}
+ 			ret = tegra_channel_capture_setup(chan, vi_port);
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-index 7ee3a6223..0c6d0ae88 100644
+index a2fefe0..3ebbc6d 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-@@ -87,6 +87,8 @@ static const struct tegra_video_format vi5_video_formats[] = {
+@@ -88,6 +88,8 @@ static const struct tegra_video_format vi5_video_formats[] = {
  	/* RAW 7: TODO */
  
  	/* RAW 8 */
@@ -1332,7 +1535,7 @@ index 7ee3a6223..0c6d0ae88 100644
  	TEGRA_VIDEO_FORMAT(RAW8, 8, SRGGB8_1X8, 1, 1, T_R8,
  				RAW8, SRGGB8, "RGRG.. GBGB.."),
  	TEGRA_VIDEO_FORMAT(RAW8, 8, SGRBG8_1X8, 1, 1, T_R8,
-@@ -117,22 +119,22 @@ static const struct tegra_video_format vi5_video_formats[] = {
+@@ -128,22 +130,22 @@ static const struct tegra_video_format vi5_video_formats[] = {
  				RAW12, SBGGR12, "BGBG.. GRGR.."),
  
  	/* RGB888 */
@@ -1363,7 +1566,7 @@ index 7ee3a6223..0c6d0ae88 100644
  	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
  				YUV422_8, UYVY, "YUV 4:2:2 UYVY"),
  	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_2X8, 2, 1, T_V8_Y8__U8_Y8,
-@@ -141,6 +143,18 @@ static const struct tegra_video_format vi5_video_formats[] = {
+@@ -152,6 +154,18 @@ static const struct tegra_video_format vi5_video_formats[] = {
  				YUV422_8, YUYV, "YUV 4:2:2 YUYV"),
  	TEGRA_VIDEO_FORMAT(YUV422, 16, YVYU8_2X8, 2, 1, T_Y8_V8__Y8_U8,
  				YUV422_8, YVYU, "YUV 4:2:2 YVYU"),
@@ -1383,7 +1586,7 @@ index 7ee3a6223..0c6d0ae88 100644
  
  #endif
 diff --git a/drivers/video/tegra/camera/tegra_camera_platform.c b/drivers/video/tegra/camera/tegra_camera_platform.c
-index 78ad66433..8795afe4e 100644
+index 78ad664..4c28294 100644
 --- a/drivers/video/tegra/camera/tegra_camera_platform.c
 +++ b/drivers/video/tegra/camera/tegra_camera_platform.c
 @@ -1162,6 +1162,11 @@ int tegra_camera_update_clknbw(void *priv, bool stream_on)
@@ -1399,7 +1602,7 @@ index 78ad66433..8795afe4e 100644
  	if (!info)
  		return -EINVAL;
 diff --git a/include/media/gmsl-link.h b/include/media/gmsl-link.h
-index 1eab7bac9..533f31eb8 100644
+index 1eab7ba..0abe099 100644
 --- a/include/media/gmsl-link.h
 +++ b/include/media/gmsl-link.h
 @@ -53,6 +53,11 @@
@@ -1415,7 +1618,7 @@ index 1eab7bac9..533f31eb8 100644
  #define GMSL_ST_ID_UNUSED 0xFF
  
 diff --git a/include/media/max9295.h b/include/media/max9295.h
-index cff6b867d..bea15c414 100644
+index cff6b86..bea15c4 100644
 --- a/include/media/max9295.h
 +++ b/include/media/max9295.h
 @@ -25,6 +25,7 @@
@@ -1444,7 +1647,7 @@ index cff6b867d..bea15c414 100644
  
  #endif  /* __MAX9295_H__ */
 diff --git a/include/media/max9296.h b/include/media/max9296.h
-index 61435e263..20f3a6657 100644
+index 61435e2..20f3a66 100644
 --- a/include/media/max9296.h
 +++ b/include/media/max9296.h
 @@ -25,6 +25,7 @@
@@ -1477,10 +1680,10 @@ index 61435e263..20f3a6657 100644
  
  #endif  /* __MAX9296_H__ */
 diff --git a/include/media/mc_common.h b/include/media/mc_common.h
-index 18328db1d..d0e908bf1 100644
+index 2ac69d0..f643168 100644
 --- a/include/media/mc_common.h
 +++ b/include/media/mc_common.h
-@@ -42,6 +42,7 @@
+@@ -43,6 +43,7 @@
  #define	ENABLE		1
  #define	DISABLE		0
  #define MAX_SYNCPT_PER_CHANNEL	3
@@ -1488,7 +1691,7 @@ index 18328db1d..d0e908bf1 100644
  
  #define CAPTURE_MIN_BUFFERS	1U
  #define CAPTURE_MAX_BUFFERS	240U
-@@ -231,6 +232,23 @@ struct tegra_channel {
+@@ -233,6 +234,23 @@ struct tegra_channel {
  	unsigned int embedded_data_width;
  	unsigned int embedded_data_height;
  
@@ -1512,7 +1715,15 @@ index 18328db1d..d0e908bf1 100644
  	DECLARE_BITMAP(fmts_bitmap, MAX_FORMAT_NUM);
  	atomic_t power_on_refcnt;
  	struct v4l2_fh *fh;
-@@ -309,6 +327,9 @@ struct tegra_mc_vi {
+@@ -271,6 +289,7 @@ struct tegra_channel {
+ 
+ 	dma_addr_t emb_buf;
+ 	void *emb_buf_addr;
++	unsigned int emb_buf_stride;
+ 	unsigned int emb_buf_size;
+ };
+ 
+@@ -312,6 +331,9 @@ struct tegra_mc_vi {
  	unsigned int num_channels;
  	unsigned int num_subdevs;
  
@@ -1522,7 +1733,7 @@ index 18328db1d..d0e908bf1 100644
  	struct tegra_csi_device *csi;
  	struct list_head vi_chans;
  	struct tegra_channel *tpg_start;
-@@ -413,7 +434,9 @@ struct tegra_channel_buffer *dequeue_inflight(struct tegra_channel *chan);
+@@ -416,7 +438,9 @@ struct tegra_channel_buffer *dequeue_inflight(struct tegra_channel *chan);
  int tegra_channel_set_power(struct tegra_channel *chan, bool on);
  
  int tegra_channel_init_video(struct tegra_channel *chan);
@@ -1533,7 +1744,7 @@ index 18328db1d..d0e908bf1 100644
  struct tegra_vi_fops {
  	int (*vi_power_on)(struct tegra_channel *chan);
 diff --git a/include/media/tegra_camera_core.h b/include/media/tegra_camera_core.h
-index 788cf77dc..421c22491 100644
+index 788cf77..67221b0 100644
 --- a/include/media/tegra_camera_core.h
 +++ b/include/media/tegra_camera_core.h
 @@ -23,7 +23,7 @@
@@ -1568,7 +1779,7 @@ index 788cf77dc..421c22491 100644
  };
  
  /* Supported CSI to VI Data Formats */
-@@ -66,6 +66,7 @@ enum tegra_vf_code {
+@@ -66,6 +75,7 @@ enum tegra_vf_code {
  	TEGRA_VF_RAW10,
  	TEGRA_VF_RAW12,
  	TEGRA_VF_RAW14,
@@ -1578,3 +1789,4 @@ index 788cf77dc..421c22491 100644
  	TEGRA_VF_RGB555,
 -- 
 2.34.1
+

--- a/nvidia-oot/6.0/0001-embedded-metadata-support-for-D4xx.patch
+++ b/nvidia-oot/6.0/0001-embedded-metadata-support-for-D4xx.patch
@@ -1,4 +1,4 @@
-From c241c00e72a918c37f1fa152ccbc9a95505f4e36 Mon Sep 17 00:00:00 2001
+From 2ee1c77861e29b67f973fb961ef90534313c0b31 Mon Sep 17 00:00:00 2001
 From: RealSense <support@realsenseai.com>
 Date: Tue, 9 Jun 2026 18:34:22 +0300
 Subject: [PATCH] embedded-metadata support for D4xx
@@ -11,20 +11,22 @@ vb2; real S_FMT/TRY_FMT; proper init error ladder) and review follow-ups:
  - D4XX_META_BUFSIZE/D4XX_META_PAYLOAD defines instead of 255/68 literals
  - shared tegra_metadata_fill_format() helper for G/S/TRY_FMT
  - drop stray double semicolon
+ - one page-aligned DMA slot per capture descriptor so in-flight frames do not
+   overwrite each other's embedded metadata
 ---
- drivers/media/i2c/Makefile                    |   6 +
+ drivers/media/i2c/Makefile                    |   5 +
  .../platform/tegra/camera/sensor_common.c     |   4 +
- .../media/platform/tegra/camera/vi/channel.c  | 437 +++++++++++++++++-
+ .../media/platform/tegra/camera/vi/channel.c  | 440 +++++++++++++++++-
  .../media/platform/tegra/camera/vi/graph.c    |  46 +-
  .../platform/tegra/camera/vi/mc_common.c      |  27 ++
- .../media/platform/tegra/camera/vi/vi5_fops.c |  29 +
- .../platform/tegra/camera/vi/vi5_formats.h    |  28 -
- include/media/mc_common.h                     |  30 ++
- include/media/tegra_camera_core.h             |  10 +-
- 9 files changed, 596 insertions(+), 19 deletions(-)
+ .../media/platform/tegra/camera/vi/vi5_fops.c | 188 ++++++--
+ .../platform/tegra/camera/vi/vi5_formats.h    |  30 +-
+ include/media/mc_common.h                     |  31 ++
+ include/media/tegra_camera_core.h             |  12 +-
+ 9 files changed, 723 insertions(+), 60 deletions(-)
 
 diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
-index 7c5913c6..396b9bc3 100644
+index 7c5913c..2c82b10 100644
 --- a/drivers/media/i2c/Makefile
 +++ b/drivers/media/i2c/Makefile
 @@ -5,6 +5,11 @@ subdir-ccflags-y += -Werror
@@ -40,7 +42,7 @@ index 7c5913c6..396b9bc3 100644
  obj-m += max96712.o
  
 diff --git a/drivers/media/platform/tegra/camera/sensor_common.c b/drivers/media/platform/tegra/camera/sensor_common.c
-index 92cc2fdf..69139eee 100644
+index 92cc2fd..69139ee 100644
 --- a/drivers/media/platform/tegra/camera/sensor_common.c
 +++ b/drivers/media/platform/tegra/camera/sensor_common.c
 @@ -267,6 +267,10 @@ static int extract_pixel_format(
@@ -55,7 +57,7 @@ index 92cc2fdf..69139eee 100644
  		pr_err("%s: Need to extend format%s\n", __func__, pixel_t);
  		return -EINVAL;
 diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
-index 91f8d5f8..5d216544 100644
+index 91f8d5f..c23ff91 100644
 --- a/drivers/media/platform/tegra/camera/vi/channel.c
 +++ b/drivers/media/platform/tegra/camera/vi/channel.c
 @@ -202,7 +202,12 @@ static void tegra_channel_fmt_align(struct tegra_channel *chan,
@@ -155,7 +157,7 @@ index 91f8d5f8..5d216544 100644
  };
  
  static int tegra_channel_close(struct file *fp);
-@@ -2470,6 +2535,359 @@ static int tegra_channel_csi_init(struct tegra_channel *chan)
+@@ -2470,6 +2535,362 @@ static int tegra_channel_csi_init(struct tegra_channel *chan)
  	return ret;
  }
  
@@ -480,6 +482,9 @@ index 91f8d5f8..5d216544 100644
 +		dma_free_coherent(vi_unit_dev,
 +				chan->emb_buf_size,
 +				chan->emb_buf_addr, chan->emb_buf);
++		chan->emb_buf_addr = NULL;
++		chan->emb_buf = 0;
++		chan->emb_buf_stride = 0;
 +		chan->emb_buf_size = 0;
 +	}
 +
@@ -515,7 +520,7 @@ index 91f8d5f8..5d216544 100644
  int tegra_channel_init_video(struct tegra_channel *chan)
  {
  	struct tegra_mc_vi *vi = chan->vi;
-@@ -2650,13 +3068,14 @@ int tegra_channel_cleanup(struct tegra_channel *chan)
+@@ -2650,13 +3071,14 @@ int tegra_channel_cleanup(struct tegra_channel *chan)
  {
  	struct device *vi_unit_dev = tegra_channel_get_vi_unit(chan);
  
@@ -538,7 +543,7 @@ index 91f8d5f8..5d216544 100644
  	tegra_channel_dealloc_buffer_queue(chan);
  
 diff --git a/drivers/media/platform/tegra/camera/vi/graph.c b/drivers/media/platform/tegra/camera/vi/graph.c
-index 7c2d05e7..7c81889c 100644
+index 7c2d05e..7c81889 100644
 --- a/drivers/media/platform/tegra/camera/vi/graph.c
 +++ b/drivers/media/platform/tegra/camera/vi/graph.c
 @@ -292,6 +292,11 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
@@ -618,7 +623,7 @@ index 7c2d05e7..7c81889c 100644
  		tegra_channel_cleanup_video(chan);
  		chan->link_status--;
 diff --git a/drivers/media/platform/tegra/camera/vi/mc_common.c b/drivers/media/platform/tegra/camera/vi/mc_common.c
-index ae6b4927..6288d712 100644
+index ae6b492..6288d71 100644
 --- a/drivers/media/platform/tegra/camera/vi/mc_common.c
 +++ b/drivers/media/platform/tegra/camera/vi/mc_common.c
 @@ -164,6 +164,10 @@ static int vi_parse_dt(struct tegra_mc_vi *vi, struct platform_device *dev)
@@ -663,19 +668,57 @@ index ae6b4927..6288d712 100644
  	if (ports == NULL)
  		ports = node;
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-index 7b16dcaf..cd58d4aa 100644
+index 7b16dca..329dc69 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -426,6 +426,39 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -10,6 +10,7 @@
+ #include <linux/fs.h>
+ #include <linux/kthread.h>
+ #include <linux/nvhost.h>
++#include <linux/overflow.h>
+ #include <linux/pm_runtime.h>
+ #include <linux/semaphore.h>
+ #include <linux/syscalls.h>
+@@ -70,6 +71,8 @@ static const struct capture_descriptor capture_template = {
+ 	},
+ };
+ 
++static int vi5_channel_prepare_embedded_buffer(struct tegra_channel *chan);
++
+ static void vi5_init_video_formats(struct tegra_channel *chan)
+ {
+ 	int i;
+@@ -409,12 +412,15 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	}
+ 
+ 	if (chan->embedded_data_height > 0) {
++		dma_addr_t emb_offset =
++			(dma_addr_t)descr_index * chan->emb_buf_stride;
++
+ 		desc->ch_cfg.embdata_enable = 1;
+ 		desc->ch_cfg.frame.embed_x = chan->embedded_data_width * BPP_MEM;
+ 		desc->ch_cfg.frame.embed_y = chan->embedded_data_height;
+ 
+ 		desc_memoryinfo->surface[VI_ATOMP_SURFACE_EMBEDDED].base_address
+-			= chan->emb_buf;
++			= chan->emb_buf + emb_offset;
+ 		desc_memoryinfo->surface[VI_ATOMP_SURFACE_EMBEDDED].size
+ 			= desc->ch_cfg.frame.embed_x * desc->ch_cfg.frame.embed_y;
+ 
+@@ -426,6 +432,56 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  		chan->capture_descr_sequence += 1;
  }
  
 +static void vi5_release_metadata_buffer(struct tegra_channel *chan,
-+	struct vb2_v4l2_buffer *vbuf)
++	struct tegra_channel_buffer *buf)
 +{
 +	struct vb2_buffer *evb = NULL;
 +	struct vb2_v4l2_buffer *evbuf;
-+	void* frm_buffer;
++	struct vb2_v4l2_buffer *vbuf = &buf->buf;
++	void *frm_buffer;
++	void *metadata_addr;
++	unsigned int descr_index = buf->capture_descr_index[0];
++	unsigned int emb_offset;
 +
 +	spin_lock(&chan->embedded.spin_lock);
 +	if (0 < chan->embedded.num_buffers) {
@@ -692,10 +735,23 @@ index 7b16dcaf..cd58d4aa 100644
 +		return;
 +
 +	frm_buffer = vb2_plane_vaddr(evb, 0);
-+	if (!frm_buffer)
++	if (!frm_buffer) {
++		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
 +		return;
++	}
 +
-+	memcpy(frm_buffer, chan->emb_buf_addr, D4XX_META_BUFSIZE);
++	if (!chan->emb_buf_stride ||
++		chan->emb_buf_size < D4XX_META_BUFSIZE ||
++		descr_index >= chan->capture_queue_depth ||
++		check_mul_overflow(descr_index, chan->emb_buf_stride,
++			&emb_offset) ||
++		emb_offset > chan->emb_buf_size - D4XX_META_BUFSIZE) {
++		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
++		return;
++	}
++
++	metadata_addr = (u8 *)chan->emb_buf_addr + emb_offset;
++	memcpy(frm_buffer, metadata_addr, D4XX_META_BUFSIZE);
 +	evbuf = to_vb2_v4l2_buffer(evb);
 +	evbuf->sequence = vbuf->sequence;
 +	vb2_set_plane_payload(evb, 0, D4XX_META_PAYLOAD);
@@ -706,18 +762,190 @@ index 7b16dcaf..cd58d4aa 100644
  static void vi5_release_buffer(struct tegra_channel *chan,
  	struct tegra_channel_buffer *buf)
  {
-@@ -436,6 +469,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+@@ -435,6 +491,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+ 	vbuf->field = V4L2_FIELD_NONE;
  	vb2_set_plane_payload(&vbuf->vb2_buf, 0, chan->format.sizeimage);
  
- 	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);
-+
 +	if (chan->embedded_data_height == 1 && buf->vb2_state == VB2_BUF_STATE_DONE)
-+		vi5_release_metadata_buffer(chan, vbuf);
++		vi5_release_metadata_buffer(chan, buf);
++
+ 	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);
  }
  
- static void vi5_capture_enqueue(struct tegra_channel *chan,
+@@ -636,6 +695,15 @@ static int vi5_channel_error_recover(struct tegra_channel *chan,
+ 			err = PTR_ERR(chan);
+ 			goto done;
+ 		}
++		err = vi5_channel_prepare_embedded_buffer(chan);
++		if (err) {
++			dev_err(&chan->video->dev,
++				"failed to restore embedded buffer: %d\n", err);
++			vi_channel_close_ex(chan->vi_channel_id[vi_port],
++				chan->tegra_vi_channel[vi_port]);
++			chan->tegra_vi_channel[vi_port] = NULL;
++			goto done;
++		}
+ 		err = tegra_channel_capture_setup(chan, vi_port);
+ 		if (err < 0)
+ 			goto done;
+@@ -807,6 +875,75 @@ static void vi5_unit_get_device_handle(struct platform_device *pdev,
+ 		dev_err(&pdev->dev, "dev pointer is NULL\n");
+ }
+ 
++static int vi5_embedded_buffer_size(struct tegra_channel *chan,
++	unsigned int *stride, unsigned int *size)
++{
++	unsigned int payload_size;
++	unsigned int aligned_size;
++
++	if (!chan->capture_queue_depth)
++		return -EINVAL;
++
++	if (check_mul_overflow(chan->embedded_data_width,
++			chan->embedded_data_height, &payload_size) ||
++		check_mul_overflow(payload_size, (unsigned int)BPP_MEM,
++			&payload_size) ||
++		!payload_size ||
++		check_add_overflow(payload_size, (unsigned int)PAGE_SIZE - 1,
++			&aligned_size))
++		return -EOVERFLOW;
++
++	*stride = round_down(aligned_size, (unsigned int)PAGE_SIZE);
++	if (check_mul_overflow(*stride, chan->capture_queue_depth, size))
++		return -EOVERFLOW;
++
++	return 0;
++}
++
++static int vi5_channel_prepare_embedded_buffer(struct tegra_channel *chan)
++{
++	unsigned int emb_buf_stride;
++	unsigned int emb_buf_size;
++	struct device *vi_unit_dev;
++	dma_addr_t new_emb_buf;
++	void *new_emb_buf_addr;
++	int ret;
++
++	if (!chan->embedded_data_height) {
++		chan->emb_buf_stride = 0;
++		return 0;
++	}
++
++	ret = vi5_embedded_buffer_size(chan, &emb_buf_stride, &emb_buf_size);
++	if (ret)
++		return ret;
++	if (!chan->emb_buf_size) {
++		chan->emb_buf_addr = NULL;
++		chan->emb_buf = 0;
++		chan->emb_buf_stride = 0;
++	}
++
++	if (emb_buf_size > chan->emb_buf_size) {
++		vi5_unit_get_device_handle(chan->vi->ndev, chan->port[0],
++			&vi_unit_dev);
++		new_emb_buf_addr = dma_alloc_coherent(vi_unit_dev, emb_buf_size,
++			&new_emb_buf, GFP_KERNEL);
++		if (!new_emb_buf_addr)
++			return -ENOMEM;
++
++		if (chan->emb_buf_size > 0)
++			dma_free_coherent(vi_unit_dev, chan->emb_buf_size,
++				chan->emb_buf_addr, chan->emb_buf);
++
++		chan->emb_buf_addr = new_emb_buf_addr;
++		chan->emb_buf = new_emb_buf;
++		chan->emb_buf_size = emb_buf_size;
++	}
++
++	chan->emb_buf_stride = emb_buf_stride;
++	return 0;
++}
++
+ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ {
+ 	struct tegra_channel *chan = vb2_get_drv_priv(vq);
+@@ -819,7 +956,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 	struct device_node *node;
+ 	struct sensor_mode_properties *sensor_mode;
+ 	struct camera_common_data *s_data;
+-	unsigned int emb_buf_size = 0;
+ 
+ 	/* Skip in bypass mode */
+ 	if (!chan->bypass) {
+@@ -842,7 +978,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 				if (s_data != NULL && node != NULL) {
+ 					int idx = s_data->mode_prop_idx;
+ 
+-					emb_buf_size = 0;
+ 					if (idx < s_data->sensor_props.\
+ 								num_modes) {
+ 						sensor_mode =
+@@ -856,46 +991,14 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 							sensor_mode->\
+ 							 image_properties.\
+ 						      embedded_metadata_height;
+-						/* rounding up to page size */
+-						emb_buf_size =
+-							round_up(chan->\
+-							embedded_data_width *
+-								chan->\
+-							embedded_data_height *
+-							BPP_MEM, PAGE_SIZE);
+ 					}
+ 				}
+-				/* Allocate buffer for Embedded Data if need to*/
+-				if (emb_buf_size > chan->emb_buf_size) {
+-					struct device *vi_unit_dev;
+-
+-					vi5_unit_get_device_handle(\
+-						chan->vi->ndev, chan->port[0],\
+-						&vi_unit_dev);
+-				/*
+-				 * if old buffer is smaller than what we need,
+-				 * release the old buffer and re-allocate a
+-				 * bigger one below.
+-				 */
+-					if (chan->emb_buf_size > 0) {
+-						dma_free_coherent(vi_unit_dev,
+-							chan->emb_buf_size,
+-							chan->emb_buf_addr,
+-							chan->emb_buf);
+-						chan->emb_buf_size = 0;
+-					}
+-
+-					chan->emb_buf_addr =
+-						dma_alloc_coherent(vi_unit_dev,
+-							emb_buf_size,
+-						&chan->emb_buf, GFP_KERNEL);
+-					if (!chan->emb_buf_addr) {
+-						dev_err(&chan->video->dev,
+-							"Can't allocate memory"
+-							"for embedded data\n");
+-						goto err_setup;
+-					}
+-					chan->emb_buf_size = emb_buf_size;
++				ret = vi5_channel_prepare_embedded_buffer(chan);
++				if (ret) {
++					dev_err(&chan->video->dev,
++						"failed to prepare embedded buffer: %d\n",
++						ret);
++					goto err_setup;
+ 				}
+ 			}
+ 			ret = tegra_channel_capture_setup(chan, vi_port);
+@@ -984,7 +1087,10 @@ static int vi5_channel_stop_streaming(struct vb2_queue *vq)
+ 										&vi_unit_dev);
+ 				dma_free_coherent(vi_unit_dev, chan->emb_buf_size,
+ 								chan->emb_buf_addr, chan->emb_buf);
++				chan->emb_buf_addr = NULL;
++				chan->emb_buf = 0;
+ 				chan->emb_buf_size = 0;
++				chan->emb_buf_stride = 0;
+ 			}
+ 
+ 			vi_channel_close_ex(chan->vi_channel_id[vi_port],
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-index 1d0c1133..1d375de5 100644
+index 1d0c113..1d375de 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 @@ -82,6 +82,8 @@ static const struct tegra_video_format vi5_video_formats[] = {
@@ -780,7 +1008,7 @@ index 1d0c1133..1d375de5 100644
  
  #endif
 diff --git a/include/media/mc_common.h b/include/media/mc_common.h
-index 0408ba67..e5a25062 100644
+index 0408ba6..c254aae 100644
 --- a/include/media/mc_common.h
 +++ b/include/media/mc_common.h
 @@ -224,6 +224,23 @@ struct tegra_channel {
@@ -807,7 +1035,15 @@ index 0408ba67..e5a25062 100644
  	DECLARE_BITMAP(fmts_bitmap, MAX_FORMAT_NUM);
  	atomic_t power_on_refcnt;
  	struct v4l2_fh *fh;
-@@ -304,6 +321,9 @@ struct tegra_mc_vi {
+@@ -263,6 +280,7 @@ struct tegra_channel {
+ 
+ 	dma_addr_t emb_buf;
+ 	void *emb_buf_addr;
++	unsigned int emb_buf_stride;
+ 	unsigned int emb_buf_size;
+ };
+ 
+@@ -304,6 +322,9 @@ struct tegra_mc_vi {
  	unsigned int num_channels;
  	unsigned int num_subdevs;
  
@@ -817,7 +1053,7 @@ index 0408ba67..e5a25062 100644
  	struct tegra_csi_device *csi;
  	struct list_head vi_chans;
  	struct tegra_channel *tpg_start;
-@@ -399,8 +419,18 @@ void enqueue_inflight(struct tegra_channel *chan,
+@@ -399,8 +420,18 @@ void enqueue_inflight(struct tegra_channel *chan,
  struct tegra_channel_buffer *dequeue_inflight(struct tegra_channel *chan);
  int tegra_channel_set_power(struct tegra_channel *chan, bool on);
  
@@ -837,7 +1073,7 @@ index 0408ba67..e5a25062 100644
  struct tegra_vi_fops {
  	int (*vi_power_on)(struct tegra_channel *chan);
 diff --git a/include/media/tegra_camera_core.h b/include/media/tegra_camera_core.h
-index e6d9a2b1..3b63f5bc 100644
+index e6d9a2b..a4c6978 100644
 --- a/include/media/tegra_camera_core.h
 +++ b/include/media/tegra_camera_core.h
 @@ -18,7 +18,7 @@
@@ -872,7 +1108,7 @@ index e6d9a2b1..3b63f5bc 100644
  };
  
  /* Supported CSI to VI Data Formats */
-@@ -61,6 +61,7 @@ enum tegra_vf_code {
+@@ -61,6 +70,7 @@ enum tegra_vf_code {
  	TEGRA_VF_RAW10,
  	TEGRA_VF_RAW12,
  	TEGRA_VF_RAW14,
@@ -880,3 +1116,5 @@ index e6d9a2b1..3b63f5bc 100644
  	TEGRA_VF_EMBEDDED8,
  	TEGRA_VF_RGB565,
  	TEGRA_VF_RGB555,
+-- 
+2.34.1

--- a/nvidia-oot/6.2/0001-embedded-metadata-support-for-D4xx.patch
+++ b/nvidia-oot/6.2/0001-embedded-metadata-support-for-D4xx.patch
@@ -1,4 +1,4 @@
-From a15670629db92f74e78075f65c1b92cac22f6c77 Mon Sep 17 00:00:00 2001
+From dfa92c568b7af74e97d662f6b9901a896c6cbc12 Mon Sep 17 00:00:00 2001
 From: RealSense <support@realsenseai.com>
 Date: Tue, 9 Jun 2026 18:32:40 +0300
 Subject: [PATCH] embedded-metadata support for D4xx
@@ -11,20 +11,22 @@ vb2; real S_FMT/TRY_FMT; proper init error ladder) and review follow-ups:
  - D4XX_META_BUFSIZE/D4XX_META_PAYLOAD defines instead of 255/68 literals
  - shared tegra_metadata_fill_format() helper for G/S/TRY_FMT
  - drop stray double semicolon
+ - one page-aligned DMA slot per capture descriptor so in-flight frames do not
+   overwrite each other's embedded metadata
 ---
- drivers/media/i2c/Makefile                    |   6 +
+ drivers/media/i2c/Makefile                    |   5 +
  .../platform/tegra/camera/sensor_common.c     |   4 +
- .../media/platform/tegra/camera/vi/channel.c  | 437 +++++++++++++++++-
+ .../media/platform/tegra/camera/vi/channel.c  | 440 +++++++++++++++++-
  .../media/platform/tegra/camera/vi/graph.c    |  46 +-
  .../platform/tegra/camera/vi/mc_common.c      |  27 ++
- .../media/platform/tegra/camera/vi/vi5_fops.c |  29 +
- .../platform/tegra/camera/vi/vi5_formats.h    |  28 -
- include/media/mc_common.h                     |  30 ++
- include/media/tegra_camera_core.h             |  10 +-
- 9 files changed, 596 insertions(+), 19 deletions(-)
+ .../media/platform/tegra/camera/vi/vi5_fops.c | 188 ++++++--
+ .../platform/tegra/camera/vi/vi5_formats.h    |  30 +-
+ include/media/mc_common.h                     |  31 ++
+ include/media/tegra_camera_core.h             |  12 +-
+ 9 files changed, 723 insertions(+), 60 deletions(-)
 
 diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
-index a85d6e88..b2849382 100644
+index a85d6e8..947e6e9 100644
 --- a/drivers/media/i2c/Makefile
 +++ b/drivers/media/i2c/Makefile
 @@ -5,6 +5,11 @@ subdir-ccflags-y += -Werror
@@ -40,7 +42,7 @@ index a85d6e88..b2849382 100644
  obj-m += max96712.o
  
 diff --git a/drivers/media/platform/tegra/camera/sensor_common.c b/drivers/media/platform/tegra/camera/sensor_common.c
-index 92cc2fdf..69139eee 100644
+index 92cc2fd..69139ee 100644
 --- a/drivers/media/platform/tegra/camera/sensor_common.c
 +++ b/drivers/media/platform/tegra/camera/sensor_common.c
 @@ -267,6 +267,10 @@ static int extract_pixel_format(
@@ -55,7 +57,7 @@ index 92cc2fdf..69139eee 100644
  		pr_err("%s: Need to extend format%s\n", __func__, pixel_t);
  		return -EINVAL;
 diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
-index 46ecdb17..ac5e0e9c 100644
+index 46ecdb1..3c704ba 100644
 --- a/drivers/media/platform/tegra/camera/vi/channel.c
 +++ b/drivers/media/platform/tegra/camera/vi/channel.c
 @@ -205,7 +205,12 @@ static void tegra_channel_fmt_align(struct tegra_channel *chan,
@@ -155,7 +157,7 @@ index 46ecdb17..ac5e0e9c 100644
  };
  
  static int tegra_channel_close(struct file *fp);
-@@ -2549,6 +2614,359 @@ static int tegra_channel_csi_init(struct tegra_channel *chan)
+@@ -2549,6 +2614,362 @@ static int tegra_channel_csi_init(struct tegra_channel *chan)
  	return ret;
  }
  
@@ -480,6 +482,9 @@ index 46ecdb17..ac5e0e9c 100644
 +		dma_free_coherent(vi_unit_dev,
 +				chan->emb_buf_size,
 +				chan->emb_buf_addr, chan->emb_buf);
++		chan->emb_buf_addr = NULL;
++		chan->emb_buf = 0;
++		chan->emb_buf_stride = 0;
 +		chan->emb_buf_size = 0;
 +	}
 +
@@ -515,7 +520,7 @@ index 46ecdb17..ac5e0e9c 100644
  int tegra_channel_init_video(struct tegra_channel *chan)
  {
  	struct tegra_mc_vi *vi = chan->vi;
-@@ -2729,13 +3147,14 @@ int tegra_channel_cleanup(struct tegra_channel *chan)
+@@ -2729,13 +3150,14 @@ int tegra_channel_cleanup(struct tegra_channel *chan)
  {
  	struct device *vi_unit_dev = tegra_channel_get_vi_unit(chan);
  
@@ -538,7 +543,7 @@ index 46ecdb17..ac5e0e9c 100644
  	tegra_channel_dealloc_buffer_queue(chan);
  
 diff --git a/drivers/media/platform/tegra/camera/vi/graph.c b/drivers/media/platform/tegra/camera/vi/graph.c
-index 7c2d05e7..7c81889c 100644
+index 7c2d05e..7c81889 100644
 --- a/drivers/media/platform/tegra/camera/vi/graph.c
 +++ b/drivers/media/platform/tegra/camera/vi/graph.c
 @@ -292,6 +292,11 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
@@ -618,7 +623,7 @@ index 7c2d05e7..7c81889c 100644
  		tegra_channel_cleanup_video(chan);
  		chan->link_status--;
 diff --git a/drivers/media/platform/tegra/camera/vi/mc_common.c b/drivers/media/platform/tegra/camera/vi/mc_common.c
-index ae6b4927..6288d712 100644
+index ae6b492..6288d71 100644
 --- a/drivers/media/platform/tegra/camera/vi/mc_common.c
 +++ b/drivers/media/platform/tegra/camera/vi/mc_common.c
 @@ -164,6 +164,10 @@ static int vi_parse_dt(struct tegra_mc_vi *vi, struct platform_device *dev)
@@ -663,19 +668,57 @@ index ae6b4927..6288d712 100644
  	if (ports == NULL)
  		ports = node;
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-index c6093a75..93a538e4 100644
+index c6093a7..c7c7454 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -445,6 +445,39 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -16,6 +16,7 @@
+ #include <linux/fs.h>
+ #include <linux/kthread.h>
+ #include <linux/nvhost.h>
++#include <linux/overflow.h>
+ #include <linux/pm_runtime.h>
+ #include <linux/semaphore.h>
+ #include <linux/syscalls.h>
+@@ -76,6 +77,8 @@ static const struct capture_descriptor capture_template = {
+ 	},
+ };
+ 
++static int vi5_channel_prepare_embedded_buffer(struct tegra_channel *chan);
++
+ static void vi5_init_video_formats(struct tegra_channel *chan)
+ {
+ 	int i;
+@@ -428,12 +431,15 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	}
+ 
+ 	if (chan->embedded_data_height > 0) {
++		dma_addr_t emb_offset =
++			(dma_addr_t)descr_index * chan->emb_buf_stride;
++
+ 		desc->ch_cfg.embdata_enable = 1;
+ 		desc->ch_cfg.frame.embed_x = chan->embedded_data_width * BPP_MEM;
+ 		desc->ch_cfg.frame.embed_y = chan->embedded_data_height;
+ 
+ 		desc_memoryinfo->surface[VI_ATOMP_SURFACE_EMBEDDED].base_address
+-			= chan->emb_buf;
++			= chan->emb_buf + emb_offset;
+ 		desc_memoryinfo->surface[VI_ATOMP_SURFACE_EMBEDDED].size
+ 			= desc->ch_cfg.frame.embed_x * desc->ch_cfg.frame.embed_y;
+ 
+@@ -445,6 +451,56 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  		chan->capture_descr_sequence += 1;
  }
  
 +static void vi5_release_metadata_buffer(struct tegra_channel *chan,
-+	struct vb2_v4l2_buffer *vbuf)
++	struct tegra_channel_buffer *buf)
 +{
 +	struct vb2_buffer *evb = NULL;
 +	struct vb2_v4l2_buffer *evbuf;
-+	void* frm_buffer;
++	struct vb2_v4l2_buffer *vbuf = &buf->buf;
++	void *frm_buffer;
++	void *metadata_addr;
++	unsigned int descr_index = buf->capture_descr_index[0];
++	unsigned int emb_offset;
 +
 +	spin_lock(&chan->embedded.spin_lock);
 +	if (0 < chan->embedded.num_buffers) {
@@ -692,10 +735,23 @@ index c6093a75..93a538e4 100644
 +		return;
 +
 +	frm_buffer = vb2_plane_vaddr(evb, 0);
-+	if (!frm_buffer)
++	if (!frm_buffer) {
++		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
 +		return;
++	}
 +
-+	memcpy(frm_buffer, chan->emb_buf_addr, D4XX_META_BUFSIZE);
++	if (!chan->emb_buf_stride ||
++		chan->emb_buf_size < D4XX_META_BUFSIZE ||
++		descr_index >= chan->capture_queue_depth ||
++		check_mul_overflow(descr_index, chan->emb_buf_stride,
++			&emb_offset) ||
++		emb_offset > chan->emb_buf_size - D4XX_META_BUFSIZE) {
++		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
++		return;
++	}
++
++	metadata_addr = (u8 *)chan->emb_buf_addr + emb_offset;
++	memcpy(frm_buffer, metadata_addr, D4XX_META_BUFSIZE);
 +	evbuf = to_vb2_v4l2_buffer(evb);
 +	evbuf->sequence = vbuf->sequence;
 +	vb2_set_plane_payload(evb, 0, D4XX_META_PAYLOAD);
@@ -706,18 +762,190 @@ index c6093a75..93a538e4 100644
  static void vi5_release_buffer(struct tegra_channel *chan,
  	struct tegra_channel_buffer *buf)
  {
-@@ -455,6 +488,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+@@ -454,6 +510,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+ 	vbuf->field = V4L2_FIELD_NONE;
  	vb2_set_plane_payload(&vbuf->vb2_buf, 0, chan->format.sizeimage);
  
- 	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);
-+
 +	if (chan->embedded_data_height == 1 && buf->vb2_state == VB2_BUF_STATE_DONE)
-+		vi5_release_metadata_buffer(chan, vbuf);
++		vi5_release_metadata_buffer(chan, buf);
++
+ 	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);
  }
  
- static void vi5_capture_enqueue(struct tegra_channel *chan,
+@@ -665,6 +724,15 @@ static int vi5_channel_error_recover(struct tegra_channel *chan,
+ 			err = PTR_ERR(chan);
+ 			goto done;
+ 		}
++		err = vi5_channel_prepare_embedded_buffer(chan);
++		if (err) {
++			dev_err(&chan->video->dev,
++				"failed to restore embedded buffer: %d\n", err);
++			vi_channel_close_ex(chan->vi_channel_id[vi_port],
++				chan->tegra_vi_channel[vi_port]);
++			chan->tegra_vi_channel[vi_port] = NULL;
++			goto done;
++		}
+ 		err = tegra_channel_capture_setup(chan, vi_port);
+ 		if (err < 0)
+ 			goto done;
+@@ -844,6 +912,75 @@ static void vi5_unit_get_device_handle(struct platform_device *pdev,
+ 		dev_err(&pdev->dev, "dev pointer is NULL\n");
+ }
+ 
++static int vi5_embedded_buffer_size(struct tegra_channel *chan,
++	unsigned int *stride, unsigned int *size)
++{
++	unsigned int payload_size;
++	unsigned int aligned_size;
++
++	if (!chan->capture_queue_depth)
++		return -EINVAL;
++
++	if (check_mul_overflow(chan->embedded_data_width,
++			chan->embedded_data_height, &payload_size) ||
++		check_mul_overflow(payload_size, (unsigned int)BPP_MEM,
++			&payload_size) ||
++		!payload_size ||
++		check_add_overflow(payload_size, (unsigned int)PAGE_SIZE - 1,
++			&aligned_size))
++		return -EOVERFLOW;
++
++	*stride = round_down(aligned_size, (unsigned int)PAGE_SIZE);
++	if (check_mul_overflow(*stride, chan->capture_queue_depth, size))
++		return -EOVERFLOW;
++
++	return 0;
++}
++
++static int vi5_channel_prepare_embedded_buffer(struct tegra_channel *chan)
++{
++	unsigned int emb_buf_stride;
++	unsigned int emb_buf_size;
++	struct device *vi_unit_dev;
++	dma_addr_t new_emb_buf;
++	void *new_emb_buf_addr;
++	int ret;
++
++	if (!chan->embedded_data_height) {
++		chan->emb_buf_stride = 0;
++		return 0;
++	}
++
++	ret = vi5_embedded_buffer_size(chan, &emb_buf_stride, &emb_buf_size);
++	if (ret)
++		return ret;
++	if (!chan->emb_buf_size) {
++		chan->emb_buf_addr = NULL;
++		chan->emb_buf = 0;
++		chan->emb_buf_stride = 0;
++	}
++
++	if (emb_buf_size > chan->emb_buf_size) {
++		vi5_unit_get_device_handle(chan->vi->ndev, chan->port[0],
++			&vi_unit_dev);
++		new_emb_buf_addr = dma_alloc_coherent(vi_unit_dev, emb_buf_size,
++			&new_emb_buf, GFP_KERNEL);
++		if (!new_emb_buf_addr)
++			return -ENOMEM;
++
++		if (chan->emb_buf_size > 0)
++			dma_free_coherent(vi_unit_dev, chan->emb_buf_size,
++				chan->emb_buf_addr, chan->emb_buf);
++
++		chan->emb_buf_addr = new_emb_buf_addr;
++		chan->emb_buf = new_emb_buf;
++		chan->emb_buf_size = emb_buf_size;
++	}
++
++	chan->emb_buf_stride = emb_buf_stride;
++	return 0;
++}
++
+ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ {
+ 	struct tegra_channel *chan = vb2_get_drv_priv(vq);
+@@ -856,7 +993,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 	struct device_node *node;
+ 	struct sensor_mode_properties *sensor_mode;
+ 	struct camera_common_data *s_data;
+-	unsigned int emb_buf_size = 0;
+ 
+ 	/* Skip in bypass mode */
+ 	if (!chan->bypass) {
+@@ -879,7 +1015,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 				if (s_data != NULL && node != NULL) {
+ 					int idx = s_data->mode_prop_idx;
+ 
+-					emb_buf_size = 0;
+ 					if (idx < s_data->sensor_props.\
+ 								num_modes) {
+ 						sensor_mode =
+@@ -893,46 +1028,14 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 							sensor_mode->\
+ 							 image_properties.\
+ 						      embedded_metadata_height;
+-						/* rounding up to page size */
+-						emb_buf_size =
+-							round_up(chan->\
+-							embedded_data_width *
+-								chan->\
+-							embedded_data_height *
+-							BPP_MEM, PAGE_SIZE);
+ 					}
+ 				}
+-				/* Allocate buffer for Embedded Data if need to*/
+-				if (emb_buf_size > chan->emb_buf_size) {
+-					struct device *vi_unit_dev;
+-
+-					vi5_unit_get_device_handle(\
+-						chan->vi->ndev, chan->port[0],\
+-						&vi_unit_dev);
+-				/*
+-				 * if old buffer is smaller than what we need,
+-				 * release the old buffer and re-allocate a
+-				 * bigger one below.
+-				 */
+-					if (chan->emb_buf_size > 0) {
+-						dma_free_coherent(vi_unit_dev,
+-							chan->emb_buf_size,
+-							chan->emb_buf_addr,
+-							chan->emb_buf);
+-						chan->emb_buf_size = 0;
+-					}
+-
+-					chan->emb_buf_addr =
+-						dma_alloc_coherent(vi_unit_dev,
+-							emb_buf_size,
+-						&chan->emb_buf, GFP_KERNEL);
+-					if (!chan->emb_buf_addr) {
+-						dev_err(&chan->video->dev,
+-							"Can't allocate memory"
+-							"for embedded data\n");
+-						goto err_setup;
+-					}
+-					chan->emb_buf_size = emb_buf_size;
++				ret = vi5_channel_prepare_embedded_buffer(chan);
++				if (ret) {
++					dev_err(&chan->video->dev,
++						"failed to prepare embedded buffer: %d\n",
++						ret);
++					goto err_setup;
+ 				}
+ 			}
+ 			ret = tegra_channel_capture_setup(chan, vi_port);
+@@ -1021,7 +1124,10 @@ static int vi5_channel_stop_streaming(struct vb2_queue *vq)
+ 										&vi_unit_dev);
+ 				dma_free_coherent(vi_unit_dev, chan->emb_buf_size,
+ 								chan->emb_buf_addr, chan->emb_buf);
++				chan->emb_buf_addr = NULL;
++				chan->emb_buf = 0;
+ 				chan->emb_buf_size = 0;
++				chan->emb_buf_stride = 0;
+ 			}
+ 
+ 			vi_channel_close_ex(chan->vi_channel_id[vi_port],
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-index 1d0c1133..1d375de5 100644
+index 1d0c113..1d375de 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 @@ -82,6 +82,8 @@ static const struct tegra_video_format vi5_video_formats[] = {
@@ -780,7 +1008,7 @@ index 1d0c1133..1d375de5 100644
  
  #endif
 diff --git a/include/media/mc_common.h b/include/media/mc_common.h
-index 607f1f5f..3ac7ef3b 100644
+index 607f1f5..cea3ca2 100644
 --- a/include/media/mc_common.h
 +++ b/include/media/mc_common.h
 @@ -238,6 +238,23 @@ struct tegra_channel {
@@ -807,7 +1035,15 @@ index 607f1f5f..3ac7ef3b 100644
  	DECLARE_BITMAP(fmts_bitmap, MAX_FORMAT_NUM);
  	atomic_t power_on_refcnt;
  	struct v4l2_fh *fh;
-@@ -319,6 +336,9 @@ struct tegra_mc_vi {
+@@ -278,6 +295,7 @@ struct tegra_channel {
+ 
+ 	dma_addr_t emb_buf;
+ 	void *emb_buf_addr;
++	unsigned int emb_buf_stride;
+ 	unsigned int emb_buf_size;
+ };
+ 
+@@ -319,6 +337,9 @@ struct tegra_mc_vi {
  	unsigned int num_channels;
  	unsigned int num_subdevs;
  
@@ -817,7 +1053,7 @@ index 607f1f5f..3ac7ef3b 100644
  	struct tegra_csi_device *csi;
  	struct list_head vi_chans;
  	struct tegra_channel *tpg_start;
-@@ -414,8 +434,18 @@ void enqueue_inflight(struct tegra_channel *chan,
+@@ -414,8 +435,18 @@ void enqueue_inflight(struct tegra_channel *chan,
  struct tegra_channel_buffer *dequeue_inflight(struct tegra_channel *chan);
  int tegra_channel_set_power(struct tegra_channel *chan, bool on);
  
@@ -837,7 +1073,7 @@ index 607f1f5f..3ac7ef3b 100644
  struct tegra_vi_fops {
  	int (*vi_power_on)(struct tegra_channel *chan);
 diff --git a/include/media/tegra_camera_core.h b/include/media/tegra_camera_core.h
-index e6d9a2b1..3b63f5bc 100644
+index e6d9a2b..a4c6978 100644
 --- a/include/media/tegra_camera_core.h
 +++ b/include/media/tegra_camera_core.h
 @@ -18,7 +18,7 @@
@@ -872,7 +1108,7 @@ index e6d9a2b1..3b63f5bc 100644
  };
  
  /* Supported CSI to VI Data Formats */
-@@ -61,6 +61,7 @@ enum tegra_vf_code {
+@@ -61,6 +70,7 @@ enum tegra_vf_code {
  	TEGRA_VF_RAW10,
  	TEGRA_VF_RAW12,
  	TEGRA_VF_RAW14,
@@ -880,3 +1116,5 @@ index e6d9a2b1..3b63f5bc 100644
  	TEGRA_VF_EMBEDDED8,
  	TEGRA_VF_RGB565,
  	TEGRA_VF_RGB555,
+-- 
+2.34.1

--- a/nvidia-oot/7.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/7.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -1,31 +1,35 @@
-From 1ce2b2e647c63724bfd1434f963eabbe4aa83941 Mon Sep 17 00:00:00 2001
+From d6e775bcd09291a45bd7f35d6d54c02a0fa3c32f Mon Sep 17 00:00:00 2001
 From: Dmitry Perchanov <dmitry.perchanov@intel.com>
 Date: Mon, 20 May 2024 18:08:02 +0300
 Subject: [PATCH] Porting nvidia driver patches to jetpack 6.0
 
+Allocate one page-aligned embedded-metadata DMA slot per VI capture descriptor.
+Descriptor setup and completion use the same slot so in-flight frames cannot
+overwrite each other's metadata.
+
 Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
 ---
- drivers/media/i2c/Makefile                    |   6 +
+ drivers/media/i2c/Makefile                    |   5 +
  drivers/media/i2c/max9295.c                   | 139 ++++++
- drivers/media/i2c/max9296.c                   | 190 +++++++++
+ drivers/media/i2c/max9296.c                   | 193 +++++++++
  .../platform/tegra/camera/sensor_common.c     |   4 +
- .../media/platform/tegra/camera/vi/channel.c  | 401 +++++++++++++++++-
+ .../media/platform/tegra/camera/vi/channel.c  | 408 +++++++++++++++++-
  .../media/platform/tegra/camera/vi/graph.c    |  38 +-
  .../platform/tegra/camera/vi/mc_common.c      |  27 ++
- .../media/platform/tegra/camera/vi/vi5_fops.c |  29 +
- .../platform/tegra/camera/vi/vi5_formats.h    |  28 -
- include/media/gmsl-link.h                     |   4 ++
+ .../media/platform/tegra/camera/vi/vi5_fops.c | 188 ++++++--
+ .../platform/tegra/camera/vi/vi5_formats.h    |  30 +-
+ include/media/gmsl-link.h                     |   5 +
  include/media/max9295.h                       |   4 +
  include/media/max9296.h                       |   8 +
- include/media/mc_common.h                     |  22 +
- include/media/tegra_camera_core.h             |   8 +
- 14 files changed, 895 insertions(+), 11 deletions(-)
+ include/media/mc_common.h                     |  23 +
+ include/media/tegra_camera_core.h             |  12 +-
+ 14 files changed, 1031 insertions(+), 53 deletions(-)
 
 diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
-index 7c5913c6..396b9bc3 100644
+index fdf09df..0e40687 100644
 --- a/drivers/media/i2c/Makefile
 +++ b/drivers/media/i2c/Makefile
-@@ -5,6 +5,11 @@ subdir-ccflags-y += -Werror
+@@ -17,6 +17,11 @@ subdir-ccflags-y += -Werror
  ifneq ($(NV_BUILD_SYSTEM_TYPE),embedded-linux)
  obj-m += max9295.o
  obj-m += max9296.o
@@ -38,7 +42,7 @@ index 7c5913c6..396b9bc3 100644
  obj-m += max96712.o
  
 diff --git a/drivers/media/i2c/max9295.c b/drivers/media/i2c/max9295.c
-index b363d5f6..e7c77845 100644
+index b363d5f..b2b3599 100644
 --- a/drivers/media/i2c/max9295.c
 +++ b/drivers/media/i2c/max9295.c
 @@ -465,6 +465,145 @@ static  struct regmap_config max9295_regmap_config = {
@@ -188,7 +192,7 @@ index b363d5f6..e7c77845 100644
  static int max9295_probe(struct i2c_client *client)
  #else
 diff --git a/drivers/media/i2c/max9296.c b/drivers/media/i2c/max9296.c
-index 1ceaf3cd..97559460 100644
+index 1ceaf3c..46516d6 100644
 --- a/drivers/media/i2c/max9296.c
 +++ b/drivers/media/i2c/max9296.c
 @@ -34,6 +34,8 @@
@@ -203,7 +207,7 @@ index 1ceaf3cd..97559460 100644
 @@ -250,6 +252,12 @@ void max9296_power_off(struct device *dev)
  	mutex_lock(&priv->lock);
  	priv->pw_ref--;
-
+ 
 +	if (priv->pw_ref < 0) {
 +		priv->pw_ref = 0;
 +		mutex_unlock(&priv->lock);
@@ -213,7 +217,7 @@ index 1ceaf3cd..97559460 100644
  	if (priv->pw_ref == 0) {
  		/* enter reset mode: XCLR */
  		usleep_range(1, 2);
-@@ -769,6 +774,191 @@ ret:
+@@ -769,6 +777,191 @@ ret:
  }
  EXPORT_SYMBOL(max9296_setup_streaming);
  
@@ -406,10 +410,10 @@ index 1ceaf3cd..97559460 100644
  	{ .compatible = "maxim,max9296", },
  	{ },
 diff --git a/drivers/media/platform/tegra/camera/sensor_common.c b/drivers/media/platform/tegra/camera/sensor_common.c
-index 92cc2fdf..69139eee 100644
+index 1de2ac3..f688610 100644
 --- a/drivers/media/platform/tegra/camera/sensor_common.c
 +++ b/drivers/media/platform/tegra/camera/sensor_common.c
-@@ -267,6 +267,10 @@ static int extract_pixel_format(
+@@ -306,6 +306,10 @@ static int extract_pixel_format(
  		*format = V4L2_PIX_FMT_UYVY;
  	else if (strncmp(pixel_t, "yuv_vyuy16", size) == 0)
  		*format = V4L2_PIX_FMT_VYUY;
@@ -421,10 +425,10 @@ index 92cc2fdf..69139eee 100644
  		pr_err("%s: Need to extend format%s\n", __func__, pixel_t);
  		return -EINVAL;
 diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
-index 91f8d5f8..d9be2677 100644
+index c5d149b..c01eeb2 100644
 --- a/drivers/media/platform/tegra/camera/vi/channel.c
 +++ b/drivers/media/platform/tegra/camera/vi/channel.c
-@@ -202,7 +202,12 @@ static void tegra_channel_fmt_align(struct tegra_channel *chan,
+@@ -231,7 +231,12 @@ static void tegra_channel_fmt_align(struct tegra_channel *chan,
  	 * different. Aligned width also may force a sensor mode change other
  	 * than the requested one
  	 */
@@ -438,7 +442,7 @@ index 91f8d5f8..d9be2677 100644
  
  	/* Clamp the requested bytes per line value. If the maximum bytes per
  	 * line value is zero, the module doesn't support user configurable line
-@@ -1027,7 +1032,8 @@ tegra_channel_querycap(struct file *file, void *fh, struct v4l2_capability *cap)
+@@ -1113,7 +1118,8 @@ tegra_channel_querycap(struct file *file, void *fh, struct v4l2_capability *cap)
  
  	cap->device_caps = V4L2_CAP_VIDEO_CAPTURE | V4L2_CAP_STREAMING;
  	cap->device_caps |= V4L2_CAP_EXT_PIX_FORMAT;
@@ -448,7 +452,7 @@ index 91f8d5f8..d9be2677 100644
  
  	len = strscpy(cap->driver, "tegra-video", sizeof(cap->driver));
  	if (len < 0)
-@@ -2224,6 +2230,66 @@ static long tegra_channel_default_ioctl(struct file *file, void *fh,
+@@ -2401,6 +2407,66 @@ static int tegra_channel_g_parm(struct file *file, void *fh,
  	return v4l2_g_parm_cap(chan->video, sd, a);
  }
  
@@ -515,7 +519,7 @@ index 91f8d5f8..d9be2677 100644
  static const struct v4l2_ioctl_ops tegra_channel_ioctl_ops = {
  	.vidioc_querycap		= tegra_channel_querycap,
  	.vidioc_enum_framesizes		= tegra_channel_enum_framesizes,
-@@ -2255,6 +2317,9 @@ static const struct v4l2_ioctl_ops tegra_channel_ioctl_ops = {
+@@ -2434,6 +2500,9 @@ static const struct v4l2_ioctl_ops tegra_channel_ioctl_ops = {
  	.vidioc_s_input			= tegra_channel_s_input,
  	.vidioc_log_status		= tegra_channel_log_status,
  	.vidioc_default			= tegra_channel_default_ioctl,
@@ -525,7 +529,7 @@ index 91f8d5f8..d9be2677 100644
  };
  
  static int tegra_channel_close(struct file *fp);
-@@ -2470,6 +2535,331 @@ static int tegra_channel_csi_init(struct tegra_channel *chan)
+@@ -2658,6 +2727,334 @@ static int tegra_channel_csi_init(struct tegra_channel *chan)
  	return ret;
  }
  
@@ -835,6 +839,9 @@ index 91f8d5f8..d9be2677 100644
 +		dma_free_coherent(vi_unit_dev,
 +				chan->emb_buf_size,
 +				chan->emb_buf_addr, chan->emb_buf);
++		chan->emb_buf_addr = NULL;
++		chan->emb_buf = 0;
++		chan->emb_buf_stride = 0;
 +		chan->emb_buf_size = 0;
 +		vb2_queue_release(queue);
 +#if defined(CONFIG_VIDEOBUF2_DMA_CONTIG)
@@ -857,7 +864,7 @@ index 91f8d5f8..d9be2677 100644
  int tegra_channel_init_video(struct tegra_channel *chan)
  {
  	struct tegra_mc_vi *vi = chan->vi;
-@@ -2656,6 +3046,13 @@ int tegra_channel_cleanup(struct tegra_channel *chan)
+@@ -2858,6 +3255,13 @@ int tegra_channel_cleanup(struct tegra_channel *chan)
  			chan->emb_buf_size,
  			chan->emb_buf_addr, chan->emb_buf);
  		chan->emb_buf_size = 0;
@@ -872,10 +879,10 @@ index 91f8d5f8..d9be2677 100644
  
  	tegra_channel_dealloc_buffer_queue(chan);
 diff --git a/drivers/media/platform/tegra/camera/vi/graph.c b/drivers/media/platform/tegra/camera/vi/graph.c
-index 7c2d05e7..5e25cf6a 100644
+index 097db3f..8e2a600 100644
 --- a/drivers/media/platform/tegra/camera/vi/graph.c
 +++ b/drivers/media/platform/tegra/camera/vi/graph.c
-@@ -292,6 +292,11 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
+@@ -291,6 +291,11 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
  	struct tegra_channel *chan =
  		container_of(notifier, struct tegra_channel, notifier);
  	struct tegra_vi_graph_entity *entity;
@@ -887,7 +894,7 @@ index 7c2d05e7..5e25cf6a 100644
  	int ret;
  
  	dev_dbg(chan->vi->dev, "notify complete, all subdevs registered\n");
-@@ -325,16 +330,46 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
+@@ -324,16 +329,46 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
  	if (ret < 0)
  		goto graph_error;
  
@@ -935,7 +942,7 @@ index 7c2d05e7..5e25cf6a 100644
  graph_error:
  	video_unregister_device(chan->video);
  register_device_error:
-@@ -398,6 +433,7 @@ static void tegra_vi_graph_notify_unbind(struct v4l2_async_notifier *notifier,
+@@ -397,6 +432,7 @@ static void tegra_vi_graph_notify_unbind(struct v4l2_async_notifier *notifier,
  
  	/* cleanup for complete */
  	if (chan->link_status) {
@@ -944,7 +951,7 @@ index 7c2d05e7..5e25cf6a 100644
  		tegra_channel_cleanup_video(chan);
  		chan->link_status--;
 diff --git a/drivers/media/platform/tegra/camera/vi/mc_common.c b/drivers/media/platform/tegra/camera/vi/mc_common.c
-index ae6b4927..6288d712 100644
+index ee1d6e2..a499d8d 100644
 --- a/drivers/media/platform/tegra/camera/vi/mc_common.c
 +++ b/drivers/media/platform/tegra/camera/vi/mc_common.c
 @@ -164,6 +164,10 @@ static int vi_parse_dt(struct tegra_mc_vi *vi, struct platform_device *dev)
@@ -989,19 +996,57 @@ index ae6b4927..6288d712 100644
  	if (ports == NULL)
  		ports = node;
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-index 7b16dcaf..487ae44b 100644
+index c68751f..b4b9d86 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -426,6 +426,39 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -7,6 +7,7 @@
+ #include <linux/fs.h>
+ #include <linux/kthread.h>
+ #include <linux/nvhost.h>
++#include <linux/overflow.h>
+ #include <linux/pm_runtime.h>
+ #include <linux/semaphore.h>
+ #include <linux/syscalls.h>
+@@ -67,6 +68,8 @@ static const struct capture_descriptor capture_template = {
+ 	},
+ };
+ 
++static int vi5_channel_prepare_embedded_buffer(struct tegra_channel *chan);
++
+ static void vi5_init_video_formats(struct tegra_channel *chan)
+ {
+ 	int i;
+@@ -442,12 +445,15 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	}
+ 
+ 	if (chan->embedded_data_height > 0) {
++		dma_addr_t emb_offset =
++			(dma_addr_t)descr_index * chan->emb_buf_stride;
++
+ 		desc->ch_cfg.embdata_enable = 1;
+ 		desc->ch_cfg.frame.embed_x = chan->embedded_data_width * BPP_MEM;
+ 		desc->ch_cfg.frame.embed_y = chan->embedded_data_height;
+ 
+ 		desc_memoryinfo->surface[VI_ATOMP_SURFACE_EMBEDDED].base_address
+-			= chan->emb_buf;
++			= chan->emb_buf + emb_offset;
+ 		desc_memoryinfo->surface[VI_ATOMP_SURFACE_EMBEDDED].size
+ 			= desc->ch_cfg.frame.embed_x * desc->ch_cfg.frame.embed_y;
+ 
+@@ -463,6 +469,56 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  		chan->capture_descr_sequence += 1;
  }
  
 +static void vi5_release_metadata_buffer(struct tegra_channel *chan,
-+	struct vb2_v4l2_buffer *vbuf)
++	struct tegra_channel_buffer *buf)
 +{
 +	struct vb2_buffer *evb = NULL;
 +	struct vb2_v4l2_buffer *evbuf;
-+	void* frm_buffer;
++	struct vb2_v4l2_buffer *vbuf = &buf->buf;
++	void *frm_buffer;
++	void *metadata_addr;
++	unsigned int descr_index = buf->capture_descr_index[0];
++	unsigned int emb_offset;
 +
 +	spin_lock(&chan->embedded.spin_lock);
 +	if (0 < chan->embedded.num_buffers) {
@@ -1018,10 +1063,23 @@ index 7b16dcaf..487ae44b 100644
 +		return;
 +
 +	frm_buffer = vb2_plane_vaddr(evb, 0);
-+	if (!frm_buffer)
++	if (!frm_buffer) {
++		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
 +		return;
++	}
 +
-+	memcpy(frm_buffer, chan->emb_buf_addr, 255);
++	if (!chan->emb_buf_stride ||
++		chan->emb_buf_size < 255 ||
++		descr_index >= chan->capture_queue_depth ||
++		check_mul_overflow(descr_index, chan->emb_buf_stride,
++			&emb_offset) ||
++		emb_offset > chan->emb_buf_size - 255) {
++		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
++		return;
++	}
++
++	metadata_addr = (u8 *)chan->emb_buf_addr + emb_offset;
++	memcpy(frm_buffer, metadata_addr, 255);
 +	evbuf = to_vb2_v4l2_buffer(evb);
 +	evbuf->sequence = vbuf->sequence;
 +	vb2_set_plane_payload(evb, 0, 68);
@@ -1032,21 +1090,193 @@ index 7b16dcaf..487ae44b 100644
  static void vi5_release_buffer(struct tegra_channel *chan,
  	struct tegra_channel_buffer *buf)
  {
-@@ -436,6 +469,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+@@ -477,6 +533,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+ 	vbuf->field = V4L2_FIELD_NONE;
  	vb2_set_plane_payload(&vbuf->vb2_buf, 0, chan->format.sizeimage);
  
- 	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);
-+
 +	if (chan->embedded_data_height == 1 && buf->vb2_state == VB2_BUF_STATE_DONE)
-+		vi5_release_metadata_buffer(chan, vbuf);
++		vi5_release_metadata_buffer(chan, buf);
++
+ 	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);
  }
  
- static void vi5_capture_enqueue(struct tegra_channel *chan,
+@@ -689,6 +748,15 @@ static int vi5_channel_error_recover(struct tegra_channel *chan,
+ 			err = PTR_ERR(chan);
+ 			goto done;
+ 		}
++		err = vi5_channel_prepare_embedded_buffer(chan);
++		if (err) {
++			dev_err(&chan->video->dev,
++				"failed to restore embedded buffer: %d\n", err);
++			vi_channel_close_ex(chan->vi_channel_id[vi_port],
++				chan->tegra_vi_channel[vi_port]);
++			chan->tegra_vi_channel[vi_port] = NULL;
++			goto done;
++		}
+ 		err = tegra_channel_capture_setup(chan, vi_port);
+ 		if (err < 0)
+ 			goto done;
+@@ -882,6 +950,75 @@ static void vi5_unit_get_device_handle(struct platform_device *pdev,
+ 		dev_err(&pdev->dev, "dev pointer is NULL\n");
+ }
+ 
++static int vi5_embedded_buffer_size(struct tegra_channel *chan,
++	unsigned int *stride, unsigned int *size)
++{
++	unsigned int payload_size;
++	unsigned int aligned_size;
++
++	if (!chan->capture_queue_depth)
++		return -EINVAL;
++
++	if (check_mul_overflow(chan->embedded_data_width,
++			chan->embedded_data_height, &payload_size) ||
++		check_mul_overflow(payload_size, (unsigned int)BPP_MEM,
++			&payload_size) ||
++		!payload_size ||
++		check_add_overflow(payload_size, (unsigned int)PAGE_SIZE - 1,
++			&aligned_size))
++		return -EOVERFLOW;
++
++	*stride = round_down(aligned_size, (unsigned int)PAGE_SIZE);
++	if (check_mul_overflow(*stride, chan->capture_queue_depth, size))
++		return -EOVERFLOW;
++
++	return 0;
++}
++
++static int vi5_channel_prepare_embedded_buffer(struct tegra_channel *chan)
++{
++	unsigned int emb_buf_stride;
++	unsigned int emb_buf_size;
++	struct device *vi_unit_dev;
++	dma_addr_t new_emb_buf;
++	void *new_emb_buf_addr;
++	int ret;
++
++	if (!chan->embedded_data_height) {
++		chan->emb_buf_stride = 0;
++		return 0;
++	}
++
++	ret = vi5_embedded_buffer_size(chan, &emb_buf_stride, &emb_buf_size);
++	if (ret)
++		return ret;
++	if (!chan->emb_buf_size) {
++		chan->emb_buf_addr = NULL;
++		chan->emb_buf = 0;
++		chan->emb_buf_stride = 0;
++	}
++
++	if (emb_buf_size > chan->emb_buf_size) {
++		vi5_unit_get_device_handle(chan->vi->ndev, chan->port[0],
++			&vi_unit_dev);
++		new_emb_buf_addr = dma_alloc_coherent(vi_unit_dev, emb_buf_size,
++			&new_emb_buf, GFP_KERNEL);
++		if (!new_emb_buf_addr)
++			return -ENOMEM;
++
++		if (chan->emb_buf_size > 0)
++			dma_free_coherent(vi_unit_dev, chan->emb_buf_size,
++				chan->emb_buf_addr, chan->emb_buf);
++
++		chan->emb_buf_addr = new_emb_buf_addr;
++		chan->emb_buf = new_emb_buf;
++		chan->emb_buf_size = emb_buf_size;
++	}
++
++	chan->emb_buf_stride = emb_buf_stride;
++	return 0;
++}
++
+ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ {
+ 	struct tegra_channel *chan = vb2_get_drv_priv(vq);
+@@ -894,7 +1031,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 	struct device_node *node;
+ 	struct sensor_mode_properties *sensor_mode;
+ 	struct camera_common_data *s_data;
+-	unsigned int emb_buf_size = 0;
+ 
+ 	/* Skip in bypass mode */
+ 	if (!chan->bypass) {
+@@ -917,7 +1053,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 				if (s_data != NULL && node != NULL) {
+ 					int idx = s_data->mode_prop_idx;
+ 
+-					emb_buf_size = 0;
+ 					if (idx < s_data->sensor_props.\
+ 								num_modes) {
+ 						sensor_mode =
+@@ -931,46 +1066,14 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 							sensor_mode->\
+ 							 image_properties.\
+ 						      embedded_metadata_height;
+-						/* rounding up to page size */
+-						emb_buf_size =
+-							round_up(chan->\
+-							embedded_data_width *
+-								chan->\
+-							embedded_data_height *
+-							BPP_MEM, PAGE_SIZE);
+ 					}
+ 				}
+-				/* Allocate buffer for Embedded Data if need to*/
+-				if (emb_buf_size > chan->emb_buf_size) {
+-					struct device *vi_unit_dev;
+-
+-					vi5_unit_get_device_handle(\
+-						chan->vi->ndev, chan->port[0],\
+-						&vi_unit_dev);
+-				/*
+-				 * if old buffer is smaller than what we need,
+-				 * release the old buffer and re-allocate a
+-				 * bigger one below.
+-				 */
+-					if (chan->emb_buf_size > 0) {
+-						dma_free_coherent(vi_unit_dev,
+-							chan->emb_buf_size,
+-							chan->emb_buf_addr,
+-							chan->emb_buf);
+-						chan->emb_buf_size = 0;
+-					}
+-
+-					chan->emb_buf_addr =
+-						dma_alloc_coherent(vi_unit_dev,
+-							emb_buf_size,
+-						&chan->emb_buf, GFP_KERNEL);
+-					if (!chan->emb_buf_addr) {
+-						dev_err(&chan->video->dev,
+-							"Can't allocate memory"
+-							"for embedded data\n");
+-						goto err_setup;
+-					}
+-					chan->emb_buf_size = emb_buf_size;
++				ret = vi5_channel_prepare_embedded_buffer(chan);
++				if (ret) {
++					dev_err(&chan->video->dev,
++						"failed to prepare embedded buffer: %d\n",
++						ret);
++					goto err_setup;
+ 				}
+ 			}
+ 			ret = tegra_channel_capture_setup(chan, vi_port);
+@@ -1060,7 +1163,10 @@ static int vi5_channel_stop_streaming(struct vb2_queue *vq)
+ 										&vi_unit_dev);
+ 				dma_free_coherent(vi_unit_dev, chan->emb_buf_size,
+ 								chan->emb_buf_addr, chan->emb_buf);
++				chan->emb_buf_addr = NULL;
++				chan->emb_buf = 0;
+ 				chan->emb_buf_size = 0;
++				chan->emb_buf_stride = 0;
+ 			}
+ 
+ 			vi_channel_close_ex(chan->vi_channel_id[vi_port],
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-index 1d0c1133..1d375de5 100644
+index 4baafc7..afa1a2c 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-@@ -82,6 +82,8 @@ static const struct tegra_video_format vi5_video_formats[] = {
+@@ -88,6 +88,8 @@ static const struct tegra_video_format vi5_video_formats[] = {
  	/* RAW 7: TODO */
  
  	/* RAW 8 */
@@ -1055,7 +1285,7 @@ index 1d0c1133..1d375de5 100644
  	TEGRA_VIDEO_FORMAT(RAW8, 8, SRGGB8_1X8, 1, 1, T_R8,
  				RAW8, SRGGB8, "RGRG.. GBGB.."),
  	TEGRA_VIDEO_FORMAT(RAW8, 8, SGRBG8_1X8, 1, 1, T_R8,
-@@ -112,22 +114,22 @@ static const struct tegra_video_format vi5_video_formats[] = {
+@@ -128,22 +130,22 @@ static const struct tegra_video_format vi5_video_formats[] = {
  				RAW12, SBGGR12, "BGBG.. GRGR.."),
  
  	/* RGB888 */
@@ -1086,7 +1316,7 @@ index 1d0c1133..1d375de5 100644
  	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
  				YUV422_8, UYVY, "YUV 4:2:2 UYVY"),
  	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_2X8, 2, 1, T_V8_Y8__U8_Y8,
-@@ -136,6 +138,18 @@ static const struct tegra_video_format vi5_video_formats[] = {
+@@ -152,6 +154,18 @@ static const struct tegra_video_format vi5_video_formats[] = {
  				YUV422_8, YUYV, "YUV 4:2:2 YUYV"),
  	TEGRA_VIDEO_FORMAT(YUV422, 16, YVYU8_2X8, 2, 1, T_Y8_V8__Y8_U8,
  				YUV422_8, YVYU, "YUV 4:2:2 YVYU"),
@@ -1106,7 +1336,7 @@ index 1d0c1133..1d375de5 100644
  
  #endif
 diff --git a/include/media/gmsl-link.h b/include/media/gmsl-link.h
-index ad902d0a..7dce2356 100644
+index ad902d0..cebeb37 100644
 --- a/include/media/gmsl-link.h
 +++ b/include/media/gmsl-link.h
 @@ -40,6 +40,11 @@
@@ -1122,7 +1352,7 @@ index ad902d0a..7dce2356 100644
  #define GMSL_ST_ID_UNUSED 0xFF
  
 diff --git a/include/media/max9295.h b/include/media/max9295.h
-index bf801aa2..c576e3e5 100644
+index bf801aa..c576e3e 100644
 --- a/include/media/max9295.h
 +++ b/include/media/max9295.h
 @@ -12,6 +12,7 @@
@@ -1151,7 +1381,7 @@ index bf801aa2..c576e3e5 100644
  
  #endif  /* __MAX9295_H__ */
 diff --git a/include/media/max9296.h b/include/media/max9296.h
-index 210dbc80..6b4c796e 100644
+index 210dbc8..6b4c796 100644
 --- a/include/media/max9296.h
 +++ b/include/media/max9296.h
 @@ -12,6 +12,7 @@
@@ -1184,10 +1414,10 @@ index 210dbc80..6b4c796e 100644
  
  #endif  /* __MAX9296_H__ */
 diff --git a/include/media/mc_common.h b/include/media/mc_common.h
-index 0408ba67..1252fb3f 100644
+index 607f1f5..7ad678d 100644
 --- a/include/media/mc_common.h
 +++ b/include/media/mc_common.h
-@@ -224,6 +224,23 @@ struct tegra_channel {
+@@ -238,6 +238,23 @@ struct tegra_channel {
  	unsigned int embedded_data_width;
  	unsigned int embedded_data_height;
  
@@ -1211,7 +1441,15 @@ index 0408ba67..1252fb3f 100644
  	DECLARE_BITMAP(fmts_bitmap, MAX_FORMAT_NUM);
  	atomic_t power_on_refcnt;
  	struct v4l2_fh *fh;
-@@ -304,6 +321,9 @@ struct tegra_mc_vi {
+@@ -278,6 +295,7 @@ struct tegra_channel {
+ 
+ 	dma_addr_t emb_buf;
+ 	void *emb_buf_addr;
++	unsigned int emb_buf_stride;
+ 	unsigned int emb_buf_size;
+ };
+ 
+@@ -319,6 +337,9 @@ struct tegra_mc_vi {
  	unsigned int num_channels;
  	unsigned int num_subdevs;
  
@@ -1221,7 +1459,7 @@ index 0408ba67..1252fb3f 100644
  	struct tegra_csi_device *csi;
  	struct list_head vi_chans;
  	struct tegra_channel *tpg_start;
-@@ -400,7 +420,9 @@ struct tegra_channel_buffer *dequeue_inflight(struct tegra_channel *chan);
+@@ -415,7 +436,9 @@ struct tegra_channel_buffer *dequeue_inflight(struct tegra_channel *chan);
  int tegra_channel_set_power(struct tegra_channel *chan, bool on);
  
  int tegra_channel_init_video(struct tegra_channel *chan);
@@ -1232,7 +1470,7 @@ index 0408ba67..1252fb3f 100644
  struct tegra_vi_fops {
  	int (*vi_power_on)(struct tegra_channel *chan);
 diff --git a/include/media/tegra_camera_core.h b/include/media/tegra_camera_core.h
-index e6d9a2b1..38634b77 100644
+index e6d9a2b..a4c6978 100644
 --- a/include/media/tegra_camera_core.h
 +++ b/include/media/tegra_camera_core.h
 @@ -18,7 +18,7 @@
@@ -1267,7 +1505,7 @@ index e6d9a2b1..38634b77 100644
  };
  
  /* Supported CSI to VI Data Formats */
-@@ -61,6 +61,7 @@ enum tegra_vf_code {
+@@ -61,6 +70,7 @@ enum tegra_vf_code {
  	TEGRA_VF_RAW10,
  	TEGRA_VF_RAW12,
  	TEGRA_VF_RAW14,

--- a/nvidia-oot/7.1/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/7.1/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -1,31 +1,35 @@
-From 1ce2b2e647c63724bfd1434f963eabbe4aa83941 Mon Sep 17 00:00:00 2001
+From 0c9ebb8cd406ec764ab44f6692c07596f1b7ba2b Mon Sep 17 00:00:00 2001
 From: Dmitry Perchanov <dmitry.perchanov@intel.com>
 Date: Mon, 20 May 2024 18:08:02 +0300
 Subject: [PATCH] Porting nvidia driver patches to jetpack 6.0
 
+Allocate one page-aligned embedded-metadata DMA slot per VI capture descriptor.
+Descriptor setup and completion use the same slot so in-flight frames cannot
+overwrite each other's metadata.
+
 Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
 ---
- drivers/media/i2c/Makefile                    |   6 +
+ drivers/media/i2c/Makefile                    |   5 +
  drivers/media/i2c/max9295.c                   | 139 ++++++
- drivers/media/i2c/max9296.c                   | 190 +++++++++
+ drivers/media/i2c/max9296.c                   | 193 +++++++++
  .../platform/tegra/camera/sensor_common.c     |   4 +
- .../media/platform/tegra/camera/vi/channel.c  | 401 +++++++++++++++++-
+ .../media/platform/tegra/camera/vi/channel.c  | 408 +++++++++++++++++-
  .../media/platform/tegra/camera/vi/graph.c    |  38 +-
  .../platform/tegra/camera/vi/mc_common.c      |  27 ++
- .../media/platform/tegra/camera/vi/vi5_fops.c |  29 +
- .../platform/tegra/camera/vi/vi5_formats.h    |  28 -
- include/media/gmsl-link.h                     |   4 ++
+ .../media/platform/tegra/camera/vi/vi5_fops.c | 188 ++++++--
+ .../platform/tegra/camera/vi/vi5_formats.h    |  30 +-
+ include/media/gmsl-link.h                     |   5 +
  include/media/max9295.h                       |   4 +
  include/media/max9296.h                       |   8 +
- include/media/mc_common.h                     |  22 +
- include/media/tegra_camera_core.h             |   8 +
- 14 files changed, 895 insertions(+), 11 deletions(-)
+ include/media/mc_common.h                     |  23 +
+ include/media/tegra_camera_core.h             |  10 +-
+ 14 files changed, 1029 insertions(+), 53 deletions(-)
 
 diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
-index 7c5913c6..396b9bc3 100644
+index 3b3a3c1..293b9cf 100644
 --- a/drivers/media/i2c/Makefile
 +++ b/drivers/media/i2c/Makefile
-@@ -5,6 +5,11 @@ subdir-ccflags-y += -Werror
+@@ -17,6 +17,11 @@ subdir-ccflags-y += -Werror
  ifneq ($(NV_BUILD_SYSTEM_TYPE),embedded-linux)
  obj-m += max9295.o
  obj-m += max9296.o
@@ -38,7 +42,7 @@ index 7c5913c6..396b9bc3 100644
  obj-m += max96712.o
  
 diff --git a/drivers/media/i2c/max9295.c b/drivers/media/i2c/max9295.c
-index b363d5f6..e7c77845 100644
+index b363d5f..b2b3599 100644
 --- a/drivers/media/i2c/max9295.c
 +++ b/drivers/media/i2c/max9295.c
 @@ -465,6 +465,145 @@ static  struct regmap_config max9295_regmap_config = {
@@ -188,7 +192,7 @@ index b363d5f6..e7c77845 100644
  static int max9295_probe(struct i2c_client *client)
  #else
 diff --git a/drivers/media/i2c/max9296.c b/drivers/media/i2c/max9296.c
-index 1ceaf3cd..97559460 100644
+index 1ceaf3c..46516d6 100644
 --- a/drivers/media/i2c/max9296.c
 +++ b/drivers/media/i2c/max9296.c
 @@ -34,6 +34,8 @@
@@ -203,7 +207,7 @@ index 1ceaf3cd..97559460 100644
 @@ -250,6 +252,12 @@ void max9296_power_off(struct device *dev)
  	mutex_lock(&priv->lock);
  	priv->pw_ref--;
-
+ 
 +	if (priv->pw_ref < 0) {
 +		priv->pw_ref = 0;
 +		mutex_unlock(&priv->lock);
@@ -213,7 +217,7 @@ index 1ceaf3cd..97559460 100644
  	if (priv->pw_ref == 0) {
  		/* enter reset mode: XCLR */
  		usleep_range(1, 2);
-@@ -769,6 +774,191 @@ ret:
+@@ -769,6 +777,191 @@ ret:
  }
  EXPORT_SYMBOL(max9296_setup_streaming);
  
@@ -406,10 +410,10 @@ index 1ceaf3cd..97559460 100644
  	{ .compatible = "maxim,max9296", },
  	{ },
 diff --git a/drivers/media/platform/tegra/camera/sensor_common.c b/drivers/media/platform/tegra/camera/sensor_common.c
-index 92cc2fdf..69139eee 100644
+index f31bba7..9812286 100644
 --- a/drivers/media/platform/tegra/camera/sensor_common.c
 +++ b/drivers/media/platform/tegra/camera/sensor_common.c
-@@ -267,6 +267,10 @@ static int extract_pixel_format(
+@@ -357,6 +357,10 @@ static int extract_pixel_format(
  		*format = V4L2_PIX_FMT_UYVY;
  	else if (strncmp(pixel_t, "yuv_vyuy16", size) == 0)
  		*format = V4L2_PIX_FMT_VYUY;
@@ -421,10 +425,10 @@ index 92cc2fdf..69139eee 100644
  		pr_err("%s: Need to extend format%s\n", __func__, pixel_t);
  		return -EINVAL;
 diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
-index 91f8d5f8..d9be2677 100644
+index 5febe52..19b9bc4 100644
 --- a/drivers/media/platform/tegra/camera/vi/channel.c
 +++ b/drivers/media/platform/tegra/camera/vi/channel.c
-@@ -202,7 +202,12 @@ static void tegra_channel_fmt_align(struct tegra_channel *chan,
+@@ -231,7 +231,12 @@ static void tegra_channel_fmt_align(struct tegra_channel *chan,
  	 * different. Aligned width also may force a sensor mode change other
  	 * than the requested one
  	 */
@@ -438,7 +442,7 @@ index 91f8d5f8..d9be2677 100644
  
  	/* Clamp the requested bytes per line value. If the maximum bytes per
  	 * line value is zero, the module doesn't support user configurable line
-@@ -1027,7 +1032,8 @@ tegra_channel_querycap(struct file *file, void *fh, struct v4l2_capability *cap)
+@@ -1122,7 +1127,8 @@ tegra_channel_querycap(struct file *file, void *fh, struct v4l2_capability *cap)
  
  	cap->device_caps = V4L2_CAP_VIDEO_CAPTURE | V4L2_CAP_STREAMING;
  	cap->device_caps |= V4L2_CAP_EXT_PIX_FORMAT;
@@ -448,7 +452,7 @@ index 91f8d5f8..d9be2677 100644
  
  	len = strscpy(cap->driver, "tegra-video", sizeof(cap->driver));
  	if (len < 0)
-@@ -2224,6 +2230,66 @@ static long tegra_channel_default_ioctl(struct file *file, void *fh,
+@@ -2417,6 +2423,66 @@ static int tegra_channel_g_parm(struct file *file, void *fh,
  	return v4l2_g_parm_cap(chan->video, sd, a);
  }
  
@@ -515,7 +519,7 @@ index 91f8d5f8..d9be2677 100644
  static const struct v4l2_ioctl_ops tegra_channel_ioctl_ops = {
  	.vidioc_querycap		= tegra_channel_querycap,
  	.vidioc_enum_framesizes		= tegra_channel_enum_framesizes,
-@@ -2255,6 +2317,9 @@ static const struct v4l2_ioctl_ops tegra_channel_ioctl_ops = {
+@@ -2450,6 +2516,9 @@ static const struct v4l2_ioctl_ops tegra_channel_ioctl_ops = {
  	.vidioc_s_input			= tegra_channel_s_input,
  	.vidioc_log_status		= tegra_channel_log_status,
  	.vidioc_default			= tegra_channel_default_ioctl,
@@ -525,7 +529,7 @@ index 91f8d5f8..d9be2677 100644
  };
  
  static int tegra_channel_close(struct file *fp);
-@@ -2470,6 +2535,331 @@ static int tegra_channel_csi_init(struct tegra_channel *chan)
+@@ -2674,6 +2743,334 @@ static int tegra_channel_csi_init(struct tegra_channel *chan)
  	return ret;
  }
  
@@ -835,6 +839,9 @@ index 91f8d5f8..d9be2677 100644
 +		dma_free_coherent(vi_unit_dev,
 +				chan->emb_buf_size,
 +				chan->emb_buf_addr, chan->emb_buf);
++		chan->emb_buf_addr = NULL;
++		chan->emb_buf = 0;
++		chan->emb_buf_stride = 0;
 +		chan->emb_buf_size = 0;
 +		vb2_queue_release(queue);
 +#if defined(CONFIG_VIDEOBUF2_DMA_CONTIG)
@@ -857,7 +864,7 @@ index 91f8d5f8..d9be2677 100644
  int tegra_channel_init_video(struct tegra_channel *chan)
  {
  	struct tegra_mc_vi *vi = chan->vi;
-@@ -2656,6 +3046,13 @@ int tegra_channel_cleanup(struct tegra_channel *chan)
+@@ -2874,6 +3271,13 @@ int tegra_channel_cleanup(struct tegra_channel *chan)
  			chan->emb_buf_size,
  			chan->emb_buf_addr, chan->emb_buf);
  		chan->emb_buf_size = 0;
@@ -872,10 +879,10 @@ index 91f8d5f8..d9be2677 100644
  
  	tegra_channel_dealloc_buffer_queue(chan);
 diff --git a/drivers/media/platform/tegra/camera/vi/graph.c b/drivers/media/platform/tegra/camera/vi/graph.c
-index 7c2d05e7..5e25cf6a 100644
+index 097db3f..8e2a600 100644
 --- a/drivers/media/platform/tegra/camera/vi/graph.c
 +++ b/drivers/media/platform/tegra/camera/vi/graph.c
-@@ -292,6 +292,11 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
+@@ -291,6 +291,11 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
  	struct tegra_channel *chan =
  		container_of(notifier, struct tegra_channel, notifier);
  	struct tegra_vi_graph_entity *entity;
@@ -887,7 +894,7 @@ index 7c2d05e7..5e25cf6a 100644
  	int ret;
  
  	dev_dbg(chan->vi->dev, "notify complete, all subdevs registered\n");
-@@ -325,16 +330,46 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
+@@ -324,16 +329,46 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
  	if (ret < 0)
  		goto graph_error;
  
@@ -935,7 +942,7 @@ index 7c2d05e7..5e25cf6a 100644
  graph_error:
  	video_unregister_device(chan->video);
  register_device_error:
-@@ -398,6 +433,7 @@ static void tegra_vi_graph_notify_unbind(struct v4l2_async_notifier *notifier,
+@@ -397,6 +432,7 @@ static void tegra_vi_graph_notify_unbind(struct v4l2_async_notifier *notifier,
  
  	/* cleanup for complete */
  	if (chan->link_status) {
@@ -944,7 +951,7 @@ index 7c2d05e7..5e25cf6a 100644
  		tegra_channel_cleanup_video(chan);
  		chan->link_status--;
 diff --git a/drivers/media/platform/tegra/camera/vi/mc_common.c b/drivers/media/platform/tegra/camera/vi/mc_common.c
-index ae6b4927..6288d712 100644
+index ee1d6e2..a499d8d 100644
 --- a/drivers/media/platform/tegra/camera/vi/mc_common.c
 +++ b/drivers/media/platform/tegra/camera/vi/mc_common.c
 @@ -164,6 +164,10 @@ static int vi_parse_dt(struct tegra_mc_vi *vi, struct platform_device *dev)
@@ -989,19 +996,57 @@ index ae6b4927..6288d712 100644
  	if (ports == NULL)
  		ports = node;
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-index 7b16dcaf..487ae44b 100644
+index 0535607..c858d91 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -426,6 +426,39 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -7,6 +7,7 @@
+ #include <linux/fs.h>
+ #include <linux/kthread.h>
+ #include <linux/nvhost.h>
++#include <linux/overflow.h>
+ #include <linux/pm_runtime.h>
+ #include <linux/semaphore.h>
+ #include <linux/syscalls.h>
+@@ -67,6 +68,8 @@ static const struct capture_descriptor capture_template = {
+ 	},
+ };
+ 
++static int vi5_channel_prepare_embedded_buffer(struct tegra_channel *chan);
++
+ static void vi5_init_video_formats(struct tegra_channel *chan)
+ {
+ 	int i;
+@@ -442,12 +445,15 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	}
+ 
+ 	if (chan->embedded_data_height > 0) {
++		dma_addr_t emb_offset =
++			(dma_addr_t)descr_index * chan->emb_buf_stride;
++
+ 		desc->ch_cfg.embdata_enable = 1;
+ 		desc->ch_cfg.frame.embed_x = chan->embedded_data_width * BPP_MEM;
+ 		desc->ch_cfg.frame.embed_y = chan->embedded_data_height;
+ 
+ 		desc_memoryinfo->surface[VI_ATOMP_SURFACE_EMBEDDED].base_address
+-			= chan->emb_buf;
++			= chan->emb_buf + emb_offset;
+ 		desc_memoryinfo->surface[VI_ATOMP_SURFACE_EMBEDDED].size
+ 			= desc->ch_cfg.frame.embed_x * desc->ch_cfg.frame.embed_y;
+ 
+@@ -463,6 +469,56 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  		chan->capture_descr_sequence += 1;
  }
  
 +static void vi5_release_metadata_buffer(struct tegra_channel *chan,
-+	struct vb2_v4l2_buffer *vbuf)
++	struct tegra_channel_buffer *buf)
 +{
 +	struct vb2_buffer *evb = NULL;
 +	struct vb2_v4l2_buffer *evbuf;
-+	void* frm_buffer;
++	struct vb2_v4l2_buffer *vbuf = &buf->buf;
++	void *frm_buffer;
++	void *metadata_addr;
++	unsigned int descr_index = buf->capture_descr_index[0];
++	unsigned int emb_offset;
 +
 +	spin_lock(&chan->embedded.spin_lock);
 +	if (0 < chan->embedded.num_buffers) {
@@ -1018,10 +1063,23 @@ index 7b16dcaf..487ae44b 100644
 +		return;
 +
 +	frm_buffer = vb2_plane_vaddr(evb, 0);
-+	if (!frm_buffer)
++	if (!frm_buffer) {
++		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
 +		return;
++	}
 +
-+	memcpy(frm_buffer, chan->emb_buf_addr, 255);
++	if (!chan->emb_buf_stride ||
++		chan->emb_buf_size < 255 ||
++		descr_index >= chan->capture_queue_depth ||
++		check_mul_overflow(descr_index, chan->emb_buf_stride,
++			&emb_offset) ||
++		emb_offset > chan->emb_buf_size - 255) {
++		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
++		return;
++	}
++
++	metadata_addr = (u8 *)chan->emb_buf_addr + emb_offset;
++	memcpy(frm_buffer, metadata_addr, 255);
 +	evbuf = to_vb2_v4l2_buffer(evb);
 +	evbuf->sequence = vbuf->sequence;
 +	vb2_set_plane_payload(evb, 0, 255);
@@ -1032,21 +1090,193 @@ index 7b16dcaf..487ae44b 100644
  static void vi5_release_buffer(struct tegra_channel *chan,
  	struct tegra_channel_buffer *buf)
  {
-@@ -436,6 +469,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+@@ -477,6 +533,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+ 	vbuf->field = V4L2_FIELD_NONE;
  	vb2_set_plane_payload(&vbuf->vb2_buf, 0, chan->format.sizeimage);
  
- 	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);
-+
 +	if (chan->embedded_data_height == 1 && buf->vb2_state == VB2_BUF_STATE_DONE)
-+		vi5_release_metadata_buffer(chan, vbuf);
++		vi5_release_metadata_buffer(chan, buf);
++
+ 	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);
  }
  
- static void vi5_capture_enqueue(struct tegra_channel *chan,
+@@ -718,6 +777,15 @@ static int vi5_channel_error_recover(struct tegra_channel *chan,
+ 			err = PTR_ERR(chan);
+ 			goto done;
+ 		}
++		err = vi5_channel_prepare_embedded_buffer(chan);
++		if (err) {
++			dev_err(&chan->video->dev,
++				"failed to restore embedded buffer: %d\n", err);
++			vi_channel_close_ex(chan->vi_channel_id[vi_port],
++				chan->tegra_vi_channel[vi_port]);
++			chan->tegra_vi_channel[vi_port] = NULL;
++			goto done;
++		}
+ 		err = tegra_channel_capture_setup(chan, vi_port);
+ 		if (err < 0)
+ 			goto done;
+@@ -911,6 +979,75 @@ static void vi5_unit_get_device_handle(struct platform_device *pdev,
+ 		dev_err(&pdev->dev, "dev pointer is NULL\n");
+ }
+ 
++static int vi5_embedded_buffer_size(struct tegra_channel *chan,
++	unsigned int *stride, unsigned int *size)
++{
++	unsigned int payload_size;
++	unsigned int aligned_size;
++
++	if (!chan->capture_queue_depth)
++		return -EINVAL;
++
++	if (check_mul_overflow(chan->embedded_data_width,
++			chan->embedded_data_height, &payload_size) ||
++		check_mul_overflow(payload_size, (unsigned int)BPP_MEM,
++			&payload_size) ||
++		!payload_size ||
++		check_add_overflow(payload_size, (unsigned int)PAGE_SIZE - 1,
++			&aligned_size))
++		return -EOVERFLOW;
++
++	*stride = round_down(aligned_size, (unsigned int)PAGE_SIZE);
++	if (check_mul_overflow(*stride, chan->capture_queue_depth, size))
++		return -EOVERFLOW;
++
++	return 0;
++}
++
++static int vi5_channel_prepare_embedded_buffer(struct tegra_channel *chan)
++{
++	unsigned int emb_buf_stride;
++	unsigned int emb_buf_size;
++	struct device *vi_unit_dev;
++	dma_addr_t new_emb_buf;
++	void *new_emb_buf_addr;
++	int ret;
++
++	if (!chan->embedded_data_height) {
++		chan->emb_buf_stride = 0;
++		return 0;
++	}
++
++	ret = vi5_embedded_buffer_size(chan, &emb_buf_stride, &emb_buf_size);
++	if (ret)
++		return ret;
++	if (!chan->emb_buf_size) {
++		chan->emb_buf_addr = NULL;
++		chan->emb_buf = 0;
++		chan->emb_buf_stride = 0;
++	}
++
++	if (emb_buf_size > chan->emb_buf_size) {
++		vi5_unit_get_device_handle(chan->vi->ndev, chan->port[0],
++			&vi_unit_dev);
++		new_emb_buf_addr = dma_alloc_coherent(vi_unit_dev, emb_buf_size,
++			&new_emb_buf, GFP_KERNEL);
++		if (!new_emb_buf_addr)
++			return -ENOMEM;
++
++		if (chan->emb_buf_size > 0)
++			dma_free_coherent(vi_unit_dev, chan->emb_buf_size,
++				chan->emb_buf_addr, chan->emb_buf);
++
++		chan->emb_buf_addr = new_emb_buf_addr;
++		chan->emb_buf = new_emb_buf;
++		chan->emb_buf_size = emb_buf_size;
++	}
++
++	chan->emb_buf_stride = emb_buf_stride;
++	return 0;
++}
++
+ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ {
+ 	struct tegra_channel *chan = vb2_get_drv_priv(vq);
+@@ -923,7 +1060,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 	struct device_node *node;
+ 	struct sensor_mode_properties *sensor_mode;
+ 	struct camera_common_data *s_data;
+-	unsigned int emb_buf_size = 0;
+ 
+ 	/* Skip in bypass mode */
+ 	if (!chan->bypass) {
+@@ -946,7 +1082,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 				if (s_data != NULL && node != NULL) {
+ 					int idx = s_data->mode_prop_idx;
+ 
+-					emb_buf_size = 0;
+ 					if (idx < s_data->sensor_props.\
+ 								num_modes) {
+ 						sensor_mode =
+@@ -960,46 +1095,14 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 							sensor_mode->\
+ 							 image_properties.\
+ 						      embedded_metadata_height;
+-						/* rounding up to page size */
+-						emb_buf_size =
+-							round_up(chan->\
+-							embedded_data_width *
+-								chan->\
+-							embedded_data_height *
+-							BPP_MEM, PAGE_SIZE);
+ 					}
+ 				}
+-				/* Allocate buffer for Embedded Data if need to*/
+-				if (emb_buf_size > chan->emb_buf_size) {
+-					struct device *vi_unit_dev;
+-
+-					vi5_unit_get_device_handle(\
+-						chan->vi->ndev, chan->port[0],\
+-						&vi_unit_dev);
+-				/*
+-				 * if old buffer is smaller than what we need,
+-				 * release the old buffer and re-allocate a
+-				 * bigger one below.
+-				 */
+-					if (chan->emb_buf_size > 0) {
+-						dma_free_coherent(vi_unit_dev,
+-							chan->emb_buf_size,
+-							chan->emb_buf_addr,
+-							chan->emb_buf);
+-						chan->emb_buf_size = 0;
+-					}
+-
+-					chan->emb_buf_addr =
+-						dma_alloc_coherent(vi_unit_dev,
+-							emb_buf_size,
+-						&chan->emb_buf, GFP_KERNEL);
+-					if (!chan->emb_buf_addr) {
+-						dev_err(&chan->video->dev,
+-							"Can't allocate memory"
+-							"for embedded data\n");
+-						goto err_setup;
+-					}
+-					chan->emb_buf_size = emb_buf_size;
++				ret = vi5_channel_prepare_embedded_buffer(chan);
++				if (ret) {
++					dev_err(&chan->video->dev,
++						"failed to prepare embedded buffer: %d\n",
++						ret);
++					goto err_setup;
+ 				}
+ 			}
+ 			ret = tegra_channel_capture_setup(chan, vi_port);
+@@ -1089,7 +1192,10 @@ static int vi5_channel_stop_streaming(struct vb2_queue *vq)
+ 										&vi_unit_dev);
+ 				dma_free_coherent(vi_unit_dev, chan->emb_buf_size,
+ 								chan->emb_buf_addr, chan->emb_buf);
++				chan->emb_buf_addr = NULL;
++				chan->emb_buf = 0;
+ 				chan->emb_buf_size = 0;
++				chan->emb_buf_stride = 0;
+ 			}
+ 
+ 			vi_channel_close_ex(chan->vi_channel_id[vi_port],
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-index 1d0c1133..1d375de5 100644
+index d040393..bd22b58 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-@@ -82,6 +82,8 @@ static const struct tegra_video_format vi5_video_formats[] = {
+@@ -88,6 +88,8 @@ static const struct tegra_video_format vi5_video_formats[] = {
  	/* RAW 7: TODO */
  
  	/* RAW 8 */
@@ -1055,7 +1285,7 @@ index 1d0c1133..1d375de5 100644
  	TEGRA_VIDEO_FORMAT(RAW8, 8, SRGGB8_1X8, 1, 1, T_R8,
  				RAW8, SRGGB8, "RGRG.. GBGB.."),
  	TEGRA_VIDEO_FORMAT(RAW8, 8, SGRBG8_1X8, 1, 1, T_R8,
-@@ -112,22 +114,22 @@ static const struct tegra_video_format vi5_video_formats[] = {
+@@ -138,22 +140,22 @@ static const struct tegra_video_format vi5_video_formats[] = {
  				RAW16, SBGGR16, "BGBG.. GRGR.."),
  
  	/* RGB888 */
@@ -1086,7 +1316,7 @@ index 1d0c1133..1d375de5 100644
  	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
  				YUV422_8, UYVY, "YUV 4:2:2 UYVY"),
  	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_2X8, 2, 1, T_V8_Y8__U8_Y8,
-@@ -136,6 +138,18 @@ static const struct tegra_video_format vi5_video_formats[] = {
+@@ -162,6 +164,18 @@ static const struct tegra_video_format vi5_video_formats[] = {
  				YUV422_8, YUYV, "YUV 4:2:2 YUYV"),
  	TEGRA_VIDEO_FORMAT(YUV422, 16, YVYU8_2X8, 2, 1, T_Y8_V8__Y8_U8,
  				YUV422_8, YVYU, "YUV 4:2:2 YVYU"),
@@ -1106,7 +1336,7 @@ index 1d0c1133..1d375de5 100644
  
  #endif
 diff --git a/include/media/gmsl-link.h b/include/media/gmsl-link.h
-index ad902d0a..7dce2356 100644
+index ad902d0..cebeb37 100644
 --- a/include/media/gmsl-link.h
 +++ b/include/media/gmsl-link.h
 @@ -40,6 +40,11 @@
@@ -1122,7 +1352,7 @@ index ad902d0a..7dce2356 100644
  #define GMSL_ST_ID_UNUSED 0xFF
  
 diff --git a/include/media/max9295.h b/include/media/max9295.h
-index bf801aa2..c576e3e5 100644
+index bf801aa..c576e3e 100644
 --- a/include/media/max9295.h
 +++ b/include/media/max9295.h
 @@ -12,6 +12,7 @@
@@ -1151,7 +1381,7 @@ index bf801aa2..c576e3e5 100644
  
  #endif  /* __MAX9295_H__ */
 diff --git a/include/media/max9296.h b/include/media/max9296.h
-index 210dbc80..6b4c796e 100644
+index 210dbc8..6b4c796 100644
 --- a/include/media/max9296.h
 +++ b/include/media/max9296.h
 @@ -12,6 +12,7 @@
@@ -1184,10 +1414,10 @@ index 210dbc80..6b4c796e 100644
  
  #endif  /* __MAX9296_H__ */
 diff --git a/include/media/mc_common.h b/include/media/mc_common.h
-index 0408ba67..1252fb3f 100644
+index 607f1f5..7ad678d 100644
 --- a/include/media/mc_common.h
 +++ b/include/media/mc_common.h
-@@ -224,6 +224,23 @@ struct tegra_channel {
+@@ -238,6 +238,23 @@ struct tegra_channel {
  	unsigned int embedded_data_width;
  	unsigned int embedded_data_height;
  
@@ -1211,7 +1441,15 @@ index 0408ba67..1252fb3f 100644
  	DECLARE_BITMAP(fmts_bitmap, MAX_FORMAT_NUM);
  	atomic_t power_on_refcnt;
  	struct v4l2_fh *fh;
-@@ -304,6 +321,9 @@ struct tegra_mc_vi {
+@@ -278,6 +295,7 @@ struct tegra_channel {
+ 
+ 	dma_addr_t emb_buf;
+ 	void *emb_buf_addr;
++	unsigned int emb_buf_stride;
+ 	unsigned int emb_buf_size;
+ };
+ 
+@@ -319,6 +337,9 @@ struct tegra_mc_vi {
  	unsigned int num_channels;
  	unsigned int num_subdevs;
  
@@ -1221,7 +1459,7 @@ index 0408ba67..1252fb3f 100644
  	struct tegra_csi_device *csi;
  	struct list_head vi_chans;
  	struct tegra_channel *tpg_start;
-@@ -400,7 +420,9 @@ struct tegra_channel_buffer *dequeue_inflight(struct tegra_channel *chan);
+@@ -415,7 +436,9 @@ struct tegra_channel_buffer *dequeue_inflight(struct tegra_channel *chan);
  int tegra_channel_set_power(struct tegra_channel *chan, bool on);
  
  int tegra_channel_init_video(struct tegra_channel *chan);
@@ -1232,10 +1470,10 @@ index 0408ba67..1252fb3f 100644
  struct tegra_vi_fops {
  	int (*vi_power_on)(struct tegra_channel *chan);
 diff --git a/include/media/tegra_camera_core.h b/include/media/tegra_camera_core.h
-index e6d9a2b1..38634b77 100644
+index be84820..0e8acb1 100644
 --- a/include/media/tegra_camera_core.h
 +++ b/include/media/tegra_camera_core.h
-@@ -18,7 +18,7 @@
+@@ -30,7 +30,7 @@
  /* Width alignment */
  #define TEGRA_WIDTH_ALIGNMENT	1
  /* Stride alignment */
@@ -1244,7 +1482,7 @@ index e6d9a2b1..38634b77 100644
  /* Height alignment */
  #define TEGRA_HEIGHT_ALIGNMENT	1
  /* Size alignment */
-@@ -32,6 +32,8 @@
+@@ -44,6 +44,8 @@
  #define TEGRA_IMAGE_FORMAT_DEF	32
  
  enum tegra_image_dt {
@@ -1253,7 +1491,7 @@ index e6d9a2b1..38634b77 100644
  	TEGRA_IMAGE_DT_YUV420_8 = 24,
  	TEGRA_IMAGE_DT_YUV420_10,
  
-@@ -51,6 +53,12 @@ enum tegra_image_dt {
+@@ -64,6 +66,12 @@ enum tegra_image_dt {
  	TEGRA_IMAGE_DT_RAW12,
  	TEGRA_IMAGE_DT_RAW14,
  	TEGRA_IMAGE_DT_RAW16,

--- a/nvidia-oot/7.2/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/7.2/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -1,5 +1,5 @@
 diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
-index fdf09df6..b1042aa3 100644
+index fdf09df61137d7bb2c76c59fbabf597d655037d1..0e40687893598cd928c0fad034658ea39d7e692a 100644
 --- a/drivers/media/i2c/Makefile
 +++ b/drivers/media/i2c/Makefile
 @@ -17,6 +17,11 @@ subdir-ccflags-y += -Werror
@@ -13,9 +13,9 @@ index fdf09df6..b1042aa3 100644
 +obj-m += max96724.o
  ifndef CONFIG_TEGRA_SYSTEM_TYPE_ACK
  obj-m += max96712.o
-
+ 
 diff --git a/drivers/media/i2c/max9295.c b/drivers/media/i2c/max9295.c
-index b363d5f6..e7c77845 100644
+index b363d5f67926b9affeab4b2b917e2f7e127b322b..b2b3599c2e8b23e57829b76d9ef4d0062a831ff1 100644
 --- a/drivers/media/i2c/max9295.c
 +++ b/drivers/media/i2c/max9295.c
 @@ -465,6 +465,145 @@ static  struct regmap_config max9295_regmap_config = {
@@ -165,7 +165,7 @@ index b363d5f6..e7c77845 100644
  static int max9295_probe(struct i2c_client *client)
  #else
 diff --git a/drivers/media/i2c/max9296.c b/drivers/media/i2c/max9296.c
-index 1ceaf3cd..46516d63 100644
+index 1ceaf3cd5cb1d3915905744700f6831b5fc83f84..46516d63c506d3b126141cb8576d39bd499199f1 100644
 --- a/drivers/media/i2c/max9296.c
 +++ b/drivers/media/i2c/max9296.c
 @@ -34,6 +34,8 @@
@@ -383,7 +383,7 @@ index 1ceaf3cd..46516d63 100644
  	{ .compatible = "maxim,max9296", },
  	{ },
 diff --git a/drivers/media/platform/tegra/camera/sensor_common.c b/drivers/media/platform/tegra/camera/sensor_common.c
-index 3d86b3df..66227cc5 100644
+index 3d86b3dfc986a334650081da919d22af81b9e70b..66227cc5bf6e0c8508f5cb98c1e0b75ba3e083a7 100644
 --- a/drivers/media/platform/tegra/camera/sensor_common.c
 +++ b/drivers/media/platform/tegra/camera/sensor_common.c
 @@ -341,6 +341,10 @@ static int extract_pixel_format(
@@ -398,7 +398,7 @@ index 3d86b3df..66227cc5 100644
  		pr_err("%s: Need to extend format%s\n", __func__, pixel_t);
  		return -EINVAL;
 diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
-index 33700bb3..22a810d2 100644
+index 33700bb3247aefe991636d3de8de43d583bf046f..26d19f578bbea4bc5ca2a3214b422e9853c2085c 100644
 --- a/drivers/media/platform/tegra/camera/vi/channel.c
 +++ b/drivers/media/platform/tegra/camera/vi/channel.c
 @@ -231,7 +231,12 @@ static void tegra_channel_fmt_align(struct tegra_channel *chan,
@@ -502,7 +502,7 @@ index 33700bb3..22a810d2 100644
  };
  
  static int tegra_channel_close(struct file *fp);
-@@ -2678,6 +2747,331 @@ static int tegra_channel_csi_init(struct tegra_channel *chan)
+@@ -2678,6 +2747,334 @@ static int tegra_channel_csi_init(struct tegra_channel *chan)
  	return ret;
  }
  
@@ -812,6 +812,9 @@ index 33700bb3..22a810d2 100644
 +		dma_free_coherent(vi_unit_dev,
 +				chan->emb_buf_size,
 +				chan->emb_buf_addr, chan->emb_buf);
++		chan->emb_buf_addr = NULL;
++		chan->emb_buf = 0;
++		chan->emb_buf_stride = 0;
 +		chan->emb_buf_size = 0;
 +		vb2_queue_release(queue);
 +#if defined(CONFIG_VIDEOBUF2_DMA_CONTIG)
@@ -834,7 +837,7 @@ index 33700bb3..22a810d2 100644
  int tegra_channel_init_video(struct tegra_channel *chan)
  {
  	struct tegra_mc_vi *vi = chan->vi;
-@@ -2878,6 +3272,13 @@ int tegra_channel_cleanup(struct tegra_channel *chan)
+@@ -2878,6 +3275,13 @@ int tegra_channel_cleanup(struct tegra_channel *chan)
  			chan->emb_buf_size,
  			chan->emb_buf_addr, chan->emb_buf);
  		chan->emb_buf_size = 0;
@@ -849,7 +852,7 @@ index 33700bb3..22a810d2 100644
  
  	tegra_channel_dealloc_buffer_queue(chan);
 diff --git a/drivers/media/platform/tegra/camera/vi/graph.c b/drivers/media/platform/tegra/camera/vi/graph.c
-index 097db3f7..8e2a600f 100644
+index 097db3f747c31b46faa7d446b6e1f42e0e6466a6..8e2a600f31c233eedcc4cc9ae0dab908ca0fd826 100644
 --- a/drivers/media/platform/tegra/camera/vi/graph.c
 +++ b/drivers/media/platform/tegra/camera/vi/graph.c
 @@ -291,6 +291,11 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
@@ -921,7 +924,7 @@ index 097db3f7..8e2a600f 100644
  		tegra_channel_cleanup_video(chan);
  		chan->link_status--;
 diff --git a/drivers/media/platform/tegra/camera/vi/mc_common.c b/drivers/media/platform/tegra/camera/vi/mc_common.c
-index ee1d6e26..a499d8d1 100644
+index ee1d6e26daea11406638213ff79cd66e735e651b..a499d8d11013a1d1eaad1e36af071ec721c83ef5 100644
 --- a/drivers/media/platform/tegra/camera/vi/mc_common.c
 +++ b/drivers/media/platform/tegra/camera/vi/mc_common.c
 @@ -164,6 +164,10 @@ static int vi_parse_dt(struct tegra_mc_vi *vi, struct platform_device *dev)
@@ -966,19 +969,57 @@ index ee1d6e26..a499d8d1 100644
  	if (ports == NULL)
  		ports = node;
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-index 69d76521..e23df865 100644
+index 69d76521b28f0c5b07ddbd7ac867c35c5cc0204c..a4ced49a7e06bfce89759abf93be4433e0409fa0 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -463,6 +463,39 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -7,6 +7,7 @@
+ #include <linux/fs.h>
+ #include <linux/kthread.h>
+ #include <linux/nvhost.h>
++#include <linux/overflow.h>
+ #include <linux/pm_runtime.h>
+ #include <linux/semaphore.h>
+ #include <linux/syscalls.h>
+@@ -67,6 +68,8 @@ static const struct capture_descriptor capture_template = {
+ 	},
+ };
+ 
++static int vi5_channel_prepare_embedded_buffer(struct tegra_channel *chan);
++
+ static void vi5_init_video_formats(struct tegra_channel *chan)
+ {
+ 	int i;
+@@ -442,12 +445,15 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	}
+ 
+ 	if (chan->embedded_data_height > 0) {
++		dma_addr_t emb_offset =
++			(dma_addr_t)descr_index * chan->emb_buf_stride;
++
+ 		desc->ch_cfg.embdata_enable = 1;
+ 		desc->ch_cfg.frame.embed_x = chan->embedded_data_width * BPP_MEM;
+ 		desc->ch_cfg.frame.embed_y = chan->embedded_data_height;
+ 
+ 		desc_memoryinfo->surface[VI_ATOMP_SURFACE_EMBEDDED].base_address
+-			= chan->emb_buf;
++			= chan->emb_buf + emb_offset;
+ 		desc_memoryinfo->surface[VI_ATOMP_SURFACE_EMBEDDED].size
+ 			= desc->ch_cfg.frame.embed_x * desc->ch_cfg.frame.embed_y;
+ 
+@@ -463,6 +469,56 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  		chan->capture_descr_sequence += 1;
  }
  
 +static void vi5_release_metadata_buffer(struct tegra_channel *chan,
-+	struct vb2_v4l2_buffer *vbuf)
++	struct tegra_channel_buffer *buf)
 +{
 +	struct vb2_buffer *evb = NULL;
 +	struct vb2_v4l2_buffer *evbuf;
-+	void* frm_buffer;
++	struct vb2_v4l2_buffer *vbuf = &buf->buf;
++	void *frm_buffer;
++	void *metadata_addr;
++	unsigned int descr_index = buf->capture_descr_index[0];
++	unsigned int emb_offset;
 +
 +	spin_lock(&chan->embedded.spin_lock);
 +	if (0 < chan->embedded.num_buffers) {
@@ -995,10 +1036,23 @@ index 69d76521..e23df865 100644
 +		return;
 +
 +	frm_buffer = vb2_plane_vaddr(evb, 0);
-+	if (!frm_buffer)
++	if (!frm_buffer) {
++		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
 +		return;
++	}
 +
-+	memcpy(frm_buffer, chan->emb_buf_addr, 255);
++	if (!chan->emb_buf_stride ||
++		chan->emb_buf_size < 255 ||
++		descr_index >= chan->capture_queue_depth ||
++		check_mul_overflow(descr_index, chan->emb_buf_stride,
++			&emb_offset) ||
++		emb_offset > chan->emb_buf_size - 255) {
++		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
++		return;
++	}
++
++	metadata_addr = (u8 *)chan->emb_buf_addr + emb_offset;
++	memcpy(frm_buffer, metadata_addr, 255);
 +	evbuf = to_vb2_v4l2_buffer(evb);
 +	evbuf->sequence = vbuf->sequence;
 +	vb2_set_plane_payload(evb, 0, 255);
@@ -1009,18 +1063,190 @@ index 69d76521..e23df865 100644
  static void vi5_release_buffer(struct tegra_channel *chan,
  	struct tegra_channel_buffer *buf)
  {
-@@ -478,6 +511,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+@@ -477,6 +533,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+ 	vbuf->field = V4L2_FIELD_NONE;
  	vb2_set_plane_payload(&vbuf->vb2_buf, 0, chan->format.sizeimage);
  
- 	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);
-+
 +	if (chan->embedded_data_height == 1 && buf->vb2_state == VB2_BUF_STATE_DONE)
-+		vi5_release_metadata_buffer(chan, vbuf);
++		vi5_release_metadata_buffer(chan, buf);
++
+ 	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);
  }
  
- static void vi5_capture_enqueue(struct tegra_channel *chan,
+@@ -718,6 +777,15 @@ static int vi5_channel_error_recover(struct tegra_channel *chan,
+ 			err = PTR_ERR(chan);
+ 			goto done;
+ 		}
++		err = vi5_channel_prepare_embedded_buffer(chan);
++		if (err) {
++			dev_err(&chan->video->dev,
++				"failed to restore embedded buffer: %d\n", err);
++			vi_channel_close_ex(chan->vi_channel_id[vi_port],
++				chan->tegra_vi_channel[vi_port]);
++			chan->tegra_vi_channel[vi_port] = NULL;
++			goto done;
++		}
+ 		err = tegra_channel_capture_setup(chan, vi_port);
+ 		if (err < 0)
+ 			goto done;
+@@ -911,6 +979,75 @@ static void vi5_unit_get_device_handle(struct platform_device *pdev,
+ 		dev_err(&pdev->dev, "dev pointer is NULL\n");
+ }
+ 
++static int vi5_embedded_buffer_size(struct tegra_channel *chan,
++	unsigned int *stride, unsigned int *size)
++{
++	unsigned int payload_size;
++	unsigned int aligned_size;
++
++	if (!chan->capture_queue_depth)
++		return -EINVAL;
++
++	if (check_mul_overflow(chan->embedded_data_width,
++			chan->embedded_data_height, &payload_size) ||
++		check_mul_overflow(payload_size, (unsigned int)BPP_MEM,
++			&payload_size) ||
++		!payload_size ||
++		check_add_overflow(payload_size, (unsigned int)PAGE_SIZE - 1,
++			&aligned_size))
++		return -EOVERFLOW;
++
++	*stride = round_down(aligned_size, (unsigned int)PAGE_SIZE);
++	if (check_mul_overflow(*stride, chan->capture_queue_depth, size))
++		return -EOVERFLOW;
++
++	return 0;
++}
++
++static int vi5_channel_prepare_embedded_buffer(struct tegra_channel *chan)
++{
++	unsigned int emb_buf_stride;
++	unsigned int emb_buf_size;
++	struct device *vi_unit_dev;
++	dma_addr_t new_emb_buf;
++	void *new_emb_buf_addr;
++	int ret;
++
++	if (!chan->embedded_data_height) {
++		chan->emb_buf_stride = 0;
++		return 0;
++	}
++
++	ret = vi5_embedded_buffer_size(chan, &emb_buf_stride, &emb_buf_size);
++	if (ret)
++		return ret;
++	if (!chan->emb_buf_size) {
++		chan->emb_buf_addr = NULL;
++		chan->emb_buf = 0;
++		chan->emb_buf_stride = 0;
++	}
++
++	if (emb_buf_size > chan->emb_buf_size) {
++		vi5_unit_get_device_handle(chan->vi->ndev, chan->port[0],
++			&vi_unit_dev);
++		new_emb_buf_addr = dma_alloc_coherent(vi_unit_dev, emb_buf_size,
++			&new_emb_buf, GFP_KERNEL);
++		if (!new_emb_buf_addr)
++			return -ENOMEM;
++
++		if (chan->emb_buf_size > 0)
++			dma_free_coherent(vi_unit_dev, chan->emb_buf_size,
++				chan->emb_buf_addr, chan->emb_buf);
++
++		chan->emb_buf_addr = new_emb_buf_addr;
++		chan->emb_buf = new_emb_buf;
++		chan->emb_buf_size = emb_buf_size;
++	}
++
++	chan->emb_buf_stride = emb_buf_stride;
++	return 0;
++}
++
+ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ {
+ 	struct tegra_channel *chan = vb2_get_drv_priv(vq);
+@@ -923,7 +1060,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 	struct device_node *node;
+ 	struct sensor_mode_properties *sensor_mode;
+ 	struct camera_common_data *s_data;
+-	unsigned int emb_buf_size = 0;
+ 
+ 	/* Skip in bypass mode */
+ 	if (!chan->bypass) {
+@@ -946,7 +1082,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 				if (s_data != NULL && node != NULL) {
+ 					int idx = s_data->mode_prop_idx;
+ 
+-					emb_buf_size = 0;
+ 					if (idx < s_data->sensor_props.\
+ 								num_modes) {
+ 						sensor_mode =
+@@ -960,46 +1095,14 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 							sensor_mode->\
+ 							 image_properties.\
+ 						      embedded_metadata_height;
+-						/* rounding up to page size */
+-						emb_buf_size =
+-							round_up(chan->\
+-							embedded_data_width *
+-								chan->\
+-							embedded_data_height *
+-							BPP_MEM, PAGE_SIZE);
+ 					}
+ 				}
+-				/* Allocate buffer for Embedded Data if need to*/
+-				if (emb_buf_size > chan->emb_buf_size) {
+-					struct device *vi_unit_dev;
+-
+-					vi5_unit_get_device_handle(\
+-						chan->vi->ndev, chan->port[0],\
+-						&vi_unit_dev);
+-				/*
+-				 * if old buffer is smaller than what we need,
+-				 * release the old buffer and re-allocate a
+-				 * bigger one below.
+-				 */
+-					if (chan->emb_buf_size > 0) {
+-						dma_free_coherent(vi_unit_dev,
+-							chan->emb_buf_size,
+-							chan->emb_buf_addr,
+-							chan->emb_buf);
+-						chan->emb_buf_size = 0;
+-					}
+-
+-					chan->emb_buf_addr =
+-						dma_alloc_coherent(vi_unit_dev,
+-							emb_buf_size,
+-						&chan->emb_buf, GFP_KERNEL);
+-					if (!chan->emb_buf_addr) {
+-						dev_err(&chan->video->dev,
+-							"Can't allocate memory"
+-							"for embedded data\n");
+-						goto err_setup;
+-					}
+-					chan->emb_buf_size = emb_buf_size;
++				ret = vi5_channel_prepare_embedded_buffer(chan);
++				if (ret) {
++					dev_err(&chan->video->dev,
++						"failed to prepare embedded buffer: %d\n",
++						ret);
++					goto err_setup;
+ 				}
+ 			}
+ 			ret = tegra_channel_capture_setup(chan, vi_port);
+@@ -1089,7 +1192,10 @@ static int vi5_channel_stop_streaming(struct vb2_queue *vq)
+ 										&vi_unit_dev);
+ 				dma_free_coherent(vi_unit_dev, chan->emb_buf_size,
+ 								chan->emb_buf_addr, chan->emb_buf);
++				chan->emb_buf_addr = NULL;
++				chan->emb_buf = 0;
+ 				chan->emb_buf_size = 0;
++				chan->emb_buf_stride = 0;
+ 			}
+ 
+ 			vi_channel_close_ex(chan->vi_channel_id[vi_port],
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-index d0403936..c04ca61f 100644
+index d0403936b50ab7faf5426e63865332577cc6044a..c04ca61f927caba63fab1f00d99c06cc6f527772 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 @@ -88,6 +88,8 @@ static const struct tegra_video_format vi5_video_formats[] = {
@@ -1083,7 +1309,7 @@ index d0403936..c04ca61f 100644
  
  #endif
 diff --git a/include/media/gmsl-link.h b/include/media/gmsl-link.h
-index ad902d0a..7dce2356 100644
+index ad902d0a70ce93a59e776d8ac108b4fe5908841d..cebeb37e6b31bd4784da9c147be03d6930112395 100644
 --- a/include/media/gmsl-link.h
 +++ b/include/media/gmsl-link.h
 @@ -40,6 +40,11 @@
@@ -1099,7 +1325,7 @@ index ad902d0a..7dce2356 100644
  #define GMSL_ST_ID_UNUSED 0xFF
  
 diff --git a/include/media/max9295.h b/include/media/max9295.h
-index bf801aa2..c576e3e5 100644
+index bf801aa244f3ca46a577ea23cfa43b4f40e5cbb3..c576e3e5de3535014e4b674ab390fa681e2949d7 100644
 --- a/include/media/max9295.h
 +++ b/include/media/max9295.h
 @@ -12,6 +12,7 @@
@@ -1128,7 +1354,7 @@ index bf801aa2..c576e3e5 100644
  
  #endif  /* __MAX9295_H__ */
 diff --git a/include/media/max9296.h b/include/media/max9296.h
-index 210dbc80..6b4c796e 100644
+index 210dbc80a9c8bc4e9b1a25f6d79d5e2ad634b0d8..6b4c796e67eed83b94f875ea64b71b7f0b7649f2 100644
 --- a/include/media/max9296.h
 +++ b/include/media/max9296.h
 @@ -12,6 +12,7 @@
@@ -1161,7 +1387,7 @@ index 210dbc80..6b4c796e 100644
  
  #endif  /* __MAX9296_H__ */
 diff --git a/include/media/mc_common.h b/include/media/mc_common.h
-index e74971f5..15ab0084 100644
+index e74971f55565039894c5f30326afcc20fe5cc0b8..d908237fe91c8841a393644eabc38ae13f49cf33 100644
 --- a/include/media/mc_common.h
 +++ b/include/media/mc_common.h
 @@ -224,6 +224,23 @@ struct tegra_channel {
@@ -1188,7 +1414,15 @@ index e74971f5..15ab0084 100644
  	DECLARE_BITMAP(fmts_bitmap, MAX_FORMAT_NUM);
  	atomic_t power_on_refcnt;
  	struct v4l2_fh *fh;
-@@ -305,6 +322,9 @@ struct tegra_mc_vi {
+@@ -264,6 +281,7 @@ struct tegra_channel {
+ 
+ 	dma_addr_t emb_buf;
+ 	void *emb_buf_addr;
++	unsigned int emb_buf_stride;
+ 	unsigned int emb_buf_size;
+ };
+ 
+@@ -305,6 +323,9 @@ struct tegra_mc_vi {
  	unsigned int num_channels;
  	unsigned int num_subdevs;
  
@@ -1198,7 +1432,7 @@ index e74971f5..15ab0084 100644
  	struct tegra_csi_device *csi;
  	struct list_head vi_chans;
  	struct tegra_channel *tpg_start;
-@@ -401,7 +421,9 @@ struct tegra_channel_buffer *dequeue_inflight(struct tegra_channel *chan);
+@@ -401,7 +422,9 @@ struct tegra_channel_buffer *dequeue_inflight(struct tegra_channel *chan);
  int tegra_channel_set_power(struct tegra_channel *chan, bool on);
  
  int tegra_channel_init_video(struct tegra_channel *chan);
@@ -1209,7 +1443,7 @@ index e74971f5..15ab0084 100644
  struct tegra_vi_fops {
  	int (*vi_power_on)(struct tegra_channel *chan);
 diff --git a/include/media/tegra_camera_core.h b/include/media/tegra_camera_core.h
-index be84820c..0e8acb1f 100644
+index be84820ccd125fe4f7191c9c3b11ed2c94ac2415..0e8acb1f33c003df03d313b84d87d2e9af314964 100644
 --- a/include/media/tegra_camera_core.h
 +++ b/include/media/tegra_camera_core.h
 @@ -30,7 +30,7 @@


### PR DESCRIPTION
## Summary

Fix embedded-metadata ownership in the NVIDIA VI5 capture path.

The existing path gives queued video buffers independent pixel DMA addresses, but programs multiple in-flight capture descriptors with one shared embedded-metadata DMA address. A later descriptor can therefore overwrite metadata before an earlier descriptor releases it to userspace.

This change:

- allocates one page-aligned embedded-metadata slot per capture descriptor;
- programs and releases the slot using the same `capture_descr_index`;
- validates the complete allocation geometry with checked arithmetic;
- replaces an existing allocation transactionally and returns real STREAMON errors;
- prepares valid metadata storage before descriptor setup;
- clears the complete DMA state during normal stop and final cleanup.

The correction is folded into the existing embedded-metadata carrier patches so that metadata support is introduced with correct per-descriptor ownership from the start. JP5 support is included following review feedback.

## Scope

This PR intentionally contains:

- no `d4xx.c` changes;
- no new stream ID, register, or V4L2 control;
- no kernel-side Left/Right demux;
- no pixel-frame copy;
- no metadata size-contract change.

The userspace V4L2 ABI is unchanged. Userspace continues to associate video and metadata by sequence and may interpret the metadata payload, including source identity, without kernel-side source parsing.

## Why the carrier diff is larger than the runtime change

This repository stores NVIDIA source changes inside patch files. Folding the correction into an existing carrier changes its hunks and context, so GitHub's patch-of-patch diff is larger than the runtime source delta.

The layout follows the repository's existing patch organization:

- JP5.0.2 keeps its historical split: allocation and descriptor ownership are in `0001`, while release-by-descriptor is adapted in the existing `0004` helper patch;
- JP5.1.2 and JP5.1.6 carry the complete change in their existing `0001` patches;
- JP6.0 owns one `0001` body and JP6.1 links to it;
- JP6.2 has an independent `0001`; repository aliases cover JP6.2.1 and JP6.2.2;
- JP7.0, JP7.1, and JP7.2 retain their existing independent `0001` files.

No new tail repair patch is introduced. Carrier-link cleanup and the separate JP7 metadata-size contract remain outside this PR.

After application, the ownership change is confined to `channel.c`, `vi5_fops.c`, and `mc_common.h`:

| Change | Why it is required |
|---|---|
| Descriptor-indexed DMA address and release lookup | Prevent two in-flight descriptors from owning the same metadata bytes |
| Checked stride and pool-size calculation | Prevent zero-depth and integer-overflow configurations from producing an invalid DMA allocation |
| Transactional pool replacement | Preserve the valid old allocation if a larger replacement cannot be allocated |
| Shared prepare helper | Ensure descriptors receive valid slot geometry while reusing a valid pool when possible |
| Complete state reset on stop/cleanup | Prevent a freed address, handle, or stride from being reused by a later lifecycle |

These checks close one metadata-buffer ownership lifecycle. They do not add routing, product selection, frame-format handling, or pixel processing.

## Root cause and reproduced failure

On the unmodified shared-slot path, a sustained D500 2C one-node RGB Calib `1600x1300@25` run produced 3,443 video buffers and 3,443 sequence-paired metadata buffers, but all metadata payloads were attributed to one source and 1,721 source counters/timestamps were repeated. Correct V4L2 sequence values did not protect the payload because the shared DMA memory had already been overwritten.

The smaller `1280x960` NV12 case did not reproduce the issue. That is a timing result, not evidence that sharing one in-flight metadata address is safe.

Issue details: https://rsjira.realsenseai.com/browse/RSDEV-14516

## Verification

The branch is one commit on current `dev@d5b77a61931a915d254069aae43ca11435b27154`.

Local validation for the added JP5 scope:

- the complete patch series applies to pristine JP5.0.2, JP5.1.2, and JP5.1.6 source baselines;
- full repository builds pass for JP5.0.2, JP5.1.2, and JP5.1.6;
- the JP6.0, JP6.2, JP7.0, JP7.1, and JP7.2 carrier files are byte-identical to the previously reviewed PR head.

The existing JP6.2.2 hardware results remain applicable because the JP6/JP7 implementation was not changed by this update:

- D500 2C RGB Calib `1600x1300@25`: 2,000/2,000 exact video/metadata joins; MC1/MC3 = 1,000/1,000 at 25 FPS per source; zero drop, source, pairing, reuse, or ordering error.
- The immediately following 2C Depth + IR + Dual-RGB + IMU reopen passed: RGB 1,204 exact joins; MC1/MC3 = 602/602 at 30 FPS per source; all stream integrity counters were zero.
- D500 2C RGB-only NV12 `1280x960@60`: 2,405 exact joins; MC1/MC3 = 1,203/1,202 at about 60 FPS per source, about 120 FPS aggregate; all integrity counters were zero.
- D500 3C Depth + IR + RGB + IMU `1280x960@30`: passed 600-frame-class capture for each video stream with exact metadata pairing and zero integrity errors.
- D500 3C RGB-only NV12 and YUYV `1280x960@60`, plus RGB Calib `1600x1300@25`: all passed the requested frame count, FPS, and metadata checks.

One 2C calibration stop observed an HKR-side tail statistic of `req/done=1002/1001`. It remained non-gating: normal close completed and the immediate full-stream reopen passed without stale registration, zero-frame capture, leak, assertion, or new VI error. The acceptance gate is lifecycle reusability and data integrity, not equality of a diagnostic counter at the stop instant.

Companion HKR and validation PRs:

- https://github.com/RealSenseAI-Internal/soc-rs-hkr-trunk/pull/135
- https://github.com/RealSenseAI-Internal/soc-rs-soc-device-mgr/pull/475
- https://github.com/RealSenseAI-Internal/soc-rs-hkr-apps/pull/297
- https://github.com/RealSenseAI-Internal/soc-rs-soc-io-drivers/pull/556
- https://github.com/RealSenseAI-Internal/soc-rs-hkr-test/pull/376
