### PR TITLE
[RSDEV-13487] Add 256x144 D58x depth and infrared profiles

### DIFF
--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -1661,6 +1661,7 @@ static const struct ds5_resolution d58x_depth_sizes[] = {
 	DS5_RES(640, 480, ds5_framerate_to_90)
 	DS5_RES(480, 270, ds5_framerate_to_90)
 	DS5_RES(424, 240, ds5_framerate_to_90)
+	DS5_RES(256, 144, ds5_framerate_to_90)
 };
 
 static const struct ds5_resolution d58x_y8_sizes[] = {
@@ -1671,6 +1672,7 @@ static const struct ds5_resolution d58x_y8_sizes[] = {
 	DS5_RES(640, 480, ds5_framerate_to_90)
 	DS5_RES(480, 270, ds5_framerate_to_90)
 	DS5_RES(424, 240, ds5_framerate_to_90)
+	DS5_RES(256, 144, ds5_framerate_to_90)
 };
 
 static const struct ds5_resolution d58x_calibration_sizes[] = {


### PR DESCRIPTION
D585 GMSL does not advertise 256x144 for depth and infrared, so RealSense Viewer cannot select that size. Add 256x144 to the D58x depth and IR profile tables using the existing 5/15/30/60/90 fps list. Both tables expose the same size so depth and IR can be selected together.

The camera firmware already has the depth/IR 256x144 path; this change exposes it through the host driver. RGB profile enumeration is unchanged.

Validation: JetPack 6.2 cross-compilation of d4xx.c passed. The final diff adds two profile entries. Hardware streaming validation of depth/IR 256x144 remains outstanding.
