### PR TITLE
[MAX96712] Raise mixed-camera host CSI output to 2 Gbps/lane

### DIFF
--- a/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-16ch-cams-0-1-2-3-d5xx-3d4xx.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-16ch-cams-0-1-2-3-d5xx-3d4xx.dts
@@ -85,6 +85,10 @@
 	fragment@0 {
 		target-path = "/";
 		__overlay__ {
+			tegra-camera-platform {
+				max_lane_speed = <2000000>; /* Kbit/s per output lane */
+			};
+
 			tegra-capture-vi {
 				num-channels = <16>;
 				ports {
@@ -699,8 +703,11 @@
 								reg = <0x29>;
 								compatible = "maxim,max96712";
 								csi-mode = "2x4";
-								/* 4-lane CSI output towards the Jetson (1300 Mbps/lane). */
+								/* MAX96712-to-Jetson only; camera CSI and GMSL rates are unchanged. */
 								lane_cnt = <4>;
+								csi-lane-rate-mbps = <2000>;
+								/* Continuous output clock for periodic D-PHY deskew. */
+								force_clk0;
 								/* Enable all 4 links: 0 (d5xx) + 1,2,3 (d4xx). */
 								link-mask = <0xf>;
 								channel = "a";
@@ -784,7 +791,10 @@
 									tegra_sinterface = "serial_b";
 									mclk_khz = "24000";
 									pix_clk_hz = "74250000";
-									serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+									serdes_pix_clk_hz = "500000000"; /* 4 lanes x 2000 Mbps / 16 bpp */
+									discontinuous_clk = "no";
+									deskew_initial_enable = "true";
+									deskew_periodic_enable = "true";
 									line_length = "1280"; /* 2200 */
 									embedded_metadata_height = "0";
 								};
@@ -834,7 +844,10 @@
 									tegra_sinterface = "serial_b";
 									mclk_khz = "24000";
 									pix_clk_hz = "74250000";
-									serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+									serdes_pix_clk_hz = "500000000"; /* 4 lanes x 2000 Mbps / 16 bpp */
+									discontinuous_clk = "no";
+									deskew_initial_enable = "true";
+									deskew_periodic_enable = "true";
 									line_length = "1280"; /* 2200 */
 									embedded_metadata_height = "1";
 								};
@@ -883,7 +896,10 @@
 									tegra_sinterface = "serial_e";
 									mclk_khz = "24000";
 									pix_clk_hz = "74250000";
-									serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+									serdes_pix_clk_hz = "500000000"; /* 4 lanes x 2000 Mbps / 16 bpp */
+									discontinuous_clk = "no";
+									deskew_initial_enable = "true";
+									deskew_periodic_enable = "true";
 									line_length = "1280"; /* 2200 */
 									embedded_metadata_height = "1";
 								};
@@ -931,7 +947,10 @@
 									tegra_sinterface = "serial_a";
 									mclk_khz = "24000";
 									pix_clk_hz = "74250000";
-									serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+									serdes_pix_clk_hz = "500000000"; /* 4 lanes x 2000 Mbps / 16 bpp */
+									discontinuous_clk = "no";
+									deskew_initial_enable = "true";
+									deskew_periodic_enable = "true";
 									line_length = "1280"; /* 2200 */
 									embedded_metadata_height = "1";
 								};
@@ -982,7 +1001,10 @@
 									tegra_sinterface = "serial_b";
 									mclk_khz = "24000";
 									pix_clk_hz = "74250000";
-									serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+									serdes_pix_clk_hz = "500000000"; /* 4 lanes x 2000 Mbps / 16 bpp */
+									discontinuous_clk = "no";
+									deskew_initial_enable = "true";
+									deskew_periodic_enable = "true";
 									line_length = "1280"; /* 2200 */
 									embedded_metadata_height = "0";
 								};
@@ -1032,7 +1054,10 @@
 									tegra_sinterface = "serial_b";
 									mclk_khz = "24000";
 									pix_clk_hz = "74250000";
-									serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+									serdes_pix_clk_hz = "500000000"; /* 4 lanes x 2000 Mbps / 16 bpp */
+									discontinuous_clk = "no";
+									deskew_initial_enable = "true";
+									deskew_periodic_enable = "true";
 									line_length = "1280"; /* 2200 */
 									embedded_metadata_height = "1";
 								};
@@ -1081,7 +1106,10 @@
 									tegra_sinterface = "serial_e";
 									mclk_khz = "24000";
 									pix_clk_hz = "74250000";
-									serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+									serdes_pix_clk_hz = "500000000"; /* 4 lanes x 2000 Mbps / 16 bpp */
+									discontinuous_clk = "no";
+									deskew_initial_enable = "true";
+									deskew_periodic_enable = "true";
 									line_length = "1280"; /* 2200 */
 									embedded_metadata_height = "1";
 								};
@@ -1129,7 +1157,10 @@
 									tegra_sinterface = "serial_a";
 									mclk_khz = "24000";
 									pix_clk_hz = "74250000";
-									serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+									serdes_pix_clk_hz = "500000000"; /* 4 lanes x 2000 Mbps / 16 bpp */
+									discontinuous_clk = "no";
+									deskew_initial_enable = "true";
+									deskew_periodic_enable = "true";
 									line_length = "1280"; /* 2200 */
 									embedded_metadata_height = "1";
 								};
@@ -1180,7 +1211,10 @@
 									tegra_sinterface = "serial_b";
 									mclk_khz = "24000";
 									pix_clk_hz = "74250000";
-									serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+									serdes_pix_clk_hz = "500000000"; /* 4 lanes x 2000 Mbps / 16 bpp */
+									discontinuous_clk = "no";
+									deskew_initial_enable = "true";
+									deskew_periodic_enable = "true";
 									line_length = "1280"; /* 2200 */
 									embedded_metadata_height = "0";
 								};
@@ -1230,7 +1264,10 @@
 									tegra_sinterface = "serial_b";
 									mclk_khz = "24000";
 									pix_clk_hz = "74250000";
-									serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+									serdes_pix_clk_hz = "500000000"; /* 4 lanes x 2000 Mbps / 16 bpp */
+									discontinuous_clk = "no";
+									deskew_initial_enable = "true";
+									deskew_periodic_enable = "true";
 									line_length = "1280"; /* 2200 */
 									embedded_metadata_height = "1";
 								};
@@ -1279,7 +1316,10 @@
 									tegra_sinterface = "serial_e";
 									mclk_khz = "24000";
 									pix_clk_hz = "74250000";
-									serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+									serdes_pix_clk_hz = "500000000"; /* 4 lanes x 2000 Mbps / 16 bpp */
+									discontinuous_clk = "no";
+									deskew_initial_enable = "true";
+									deskew_periodic_enable = "true";
 									line_length = "1280"; /* 2200 */
 									embedded_metadata_height = "1";
 								};
@@ -1327,7 +1367,10 @@
 									tegra_sinterface = "serial_a";
 									mclk_khz = "24000";
 									pix_clk_hz = "74250000";
-									serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+									serdes_pix_clk_hz = "500000000"; /* 4 lanes x 2000 Mbps / 16 bpp */
+									discontinuous_clk = "no";
+									deskew_initial_enable = "true";
+									deskew_periodic_enable = "true";
 									line_length = "1280"; /* 2200 */
 									embedded_metadata_height = "1";
 								};
@@ -1378,7 +1421,10 @@
 									tegra_sinterface = "serial_b";
 									mclk_khz = "24000";
 									pix_clk_hz = "74250000";
-									serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+									serdes_pix_clk_hz = "500000000"; /* 4 lanes x 2000 Mbps / 16 bpp */
+									discontinuous_clk = "no";
+									deskew_initial_enable = "true";
+									deskew_periodic_enable = "true";
 									line_length = "1280"; /* 2200 */
 									embedded_metadata_height = "0";
 								};
@@ -1428,7 +1474,10 @@
 									tegra_sinterface = "serial_b";
 									mclk_khz = "24000";
 									pix_clk_hz = "74250000";
-									serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+									serdes_pix_clk_hz = "500000000"; /* 4 lanes x 2000 Mbps / 16 bpp */
+									discontinuous_clk = "no";
+									deskew_initial_enable = "true";
+									deskew_periodic_enable = "true";
 									line_length = "1280"; /* 2200 */
 									embedded_metadata_height = "1";
 								};
@@ -1477,7 +1526,10 @@
 									tegra_sinterface = "serial_e";
 									mclk_khz = "24000";
 									pix_clk_hz = "74250000";
-									serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+									serdes_pix_clk_hz = "500000000"; /* 4 lanes x 2000 Mbps / 16 bpp */
+									discontinuous_clk = "no";
+									deskew_initial_enable = "true";
+									deskew_periodic_enable = "true";
 									line_length = "1280"; /* 2200 */
 									embedded_metadata_height = "1";
 								};
@@ -1525,7 +1577,10 @@
 									tegra_sinterface = "serial_a";
 									mclk_khz = "24000";
 									pix_clk_hz = "74250000";
-									serdes_pix_clk_hz = "325000000"; /* 4 lanes x 1300 Mbps / 16 bpp */
+									serdes_pix_clk_hz = "500000000"; /* 4 lanes x 2000 Mbps / 16 bpp */
+									discontinuous_clk = "no";
+									deskew_initial_enable = "true";
+									deskew_periodic_enable = "true";
 									line_length = "1280"; /* 2200 */
 									embedded_metadata_height = "1";
 								};

--- a/nvidia-oot/6.0/0014-Configure-max96712-host-CSI-lane-rate.patch
+++ b/nvidia-oot/6.0/0014-Configure-max96712-host-CSI-lane-rate.patch
@@ -1,0 +1,138 @@
+Subject: [PATCH] Allow board-specific MAX96712 CSI output rates
+
+Select the deserializer-to-host lane rate independently of the camera
+input rate. Preserve legacy defaults when the DT property is absent.
+For an explicit rate above 1.5 Gbps/lane, arm automatic initial deskew
+and periodic deskew when the board enables a continuous clock.
+
+---
+diff --git a/drivers/media/i2c/max96712.c b/drivers/media/i2c/max96712.c
+--- a/drivers/media/i2c/max96712.c
++++ b/drivers/media/i2c/max96712.c
+@@ -53,6 +53,14 @@
+ #define MAX96712_BACKTOP25_PHY1_SW_OVRR_OFFS 0x5
+ #define MAX96712_BACKTOP25_2500Mbps 0x19
+ #define MAX96712_BACKTOP25_1300Mbps 0xd
++
++/* Deserializer-to-host D-PHY rate, independent of camera CSI/GMSL rates. */
++#define MAX96712_CSI_RATE_STEP_MBPS 100U
++#define MAX96712_CSI_RATE_MAX_MBPS 2500U
++#define MAX96712_CSI_DESKEW_THRESHOLD_MBPS 1500U
++#define MAX96712_DESKEW_INIT(phy) (0x0903 + (phy) * 0x40)
++#define MAX96712_DESKEW_PER(phy) (0x0904 + (phy) * 0x40)
++#define MAX96712_DESKEW_ENABLE BIT(7)
+ 
+ #define MAX96712_MIPI_TX_EXT0_ADDR 0x800
+ #define MAX96712_MIPI_TX_EXT1_ADDR 0x801
+@@ -184,6 +192,8 @@
+ 	u8 vc_remap[MAX96712_MAX_LINKS][MAX96712_MAX_SER_VCS];
+ 	bool force_clk0;
+ 	int lane_cnt;
++	u32 csi_lane_rate_mbps;
++	bool csi_lane_rate_override;
+ 	bool fangzhu_fg12_reverse_lane_polarity;
+ 	bool fangzhu_fg12_poc_enable;
+ };
+@@ -594,6 +604,26 @@
+ 			of_property_read_bool(np, "fangzhu,fg12-reverse-lane-polarity");
+ 		priv->fangzhu_fg12_poc_enable =
+ 			of_property_read_bool(np, "fangzhu,fg12-poc-enable");
++	}
++
++	/* Keep the existing defaults unless this board selects an output rate. */
++	priv->csi_lane_rate_mbps = MAX96712_CSI_RATE_STEP_MBPS *
++		((priv->lane_cnt == 4) ? MAX96712_BACKTOP25_1300Mbps :
++		 MAX96712_BACKTOP25_2500Mbps);
++	priv->csi_lane_rate_override =
++		np && of_find_property(np, "csi-lane-rate-mbps", NULL);
++	if (priv->csi_lane_rate_override) {
++		err = of_property_read_u32(np, "csi-lane-rate-mbps",
++					   &priv->csi_lane_rate_mbps);
++		if (err)
++			return err;
++		if (priv->csi_lane_rate_mbps < MAX96712_CSI_RATE_STEP_MBPS ||
++		    priv->csi_lane_rate_mbps > MAX96712_CSI_RATE_MAX_MBPS ||
++		    priv->csi_lane_rate_mbps % MAX96712_CSI_RATE_STEP_MBPS) {
++			dev_err(&client->dev,
++				"csi-lane-rate-mbps must be 100..2500 in 100 Mbps steps\n");
++			return -EINVAL;
++		}
+ 	}
+ 
+ 	err = max96712_parse_vc_remap(priv, np);
+@@ -1103,6 +1133,34 @@
+ 	return err;
+ }
+ 
++static int max96712_setup_output_deskew(struct max96712 *priv)
++{
++	u8 initial, periodic;
++	int phy, err;
++
++	/* Leave deskew settings on legacy boards unchanged. */
++	if (!priv->csi_lane_rate_override)
++		return 0;
++
++	initial = priv->csi_lane_rate_mbps > MAX96712_CSI_DESKEW_THRESHOLD_MBPS ?
++		MAX96712_DESKEW_ENABLE : 0;
++	/* Periodic calibration requires the clock lane to remain in HS mode. */
++	periodic = priv->force_clk0 ? initial : 0;
++	/* This driver routes port A through PHY0/PHY1; PHY2/PHY3 stay disabled. */
++	for (phy = 0; phy < 2; phy++) {
++		err = regmap_update_bits(priv->regmap, MAX96712_DESKEW_INIT(phy),
++					 MAX96712_DESKEW_ENABLE, initial);
++		if (err)
++			return err;
++		err = regmap_update_bits(priv->regmap, MAX96712_DESKEW_PER(phy),
++					 MAX96712_DESKEW_ENABLE, periodic);
++		if (err)
++			return err;
++	}
++
++	return 0;
++}
++
+ int max96712_init_settings(struct device *dev)
+ {
+ 	int err = 0;
+@@ -1117,8 +1175,7 @@
+ 		{MAX96712_VIDEO_PIPE_EN_ADDR, 0x00}, //0xF4, Disable all pipes for now
+ 	};
+ 
+-	/* 1300Mbps per lane for 4 lanes, 2500Mbps per lane for 2 lanes */
+-	uint8_t lane_rate = (priv->lane_cnt == 4) ? MAX96712_BACKTOP25_1300Mbps : MAX96712_BACKTOP25_2500Mbps;
++	uint8_t lane_rate = priv->csi_lane_rate_mbps / MAX96712_CSI_RATE_STEP_MBPS;
+ 
+ 	struct reg_pair map_phy_opt[] =
+ 	{
+@@ -1150,9 +1207,16 @@
+ 
+ 	mutex_lock(&priv->lock);
+ 
+-	err |= max96712_set_registers(priv, map_pipe_opt, ARRAY_SIZE(map_pipe_opt));
+-	err |= max96712_set_registers(priv, map_phy_opt, ARRAY_SIZE(map_phy_opt));
+-
++	err = max96712_set_registers(priv, map_pipe_opt, ARRAY_SIZE(map_pipe_opt));
++	if (err)
++		goto out_clear_mapping;
++	/* Arm calibration before the PHYs and CSI output are enabled. */
++	err = max96712_setup_output_deskew(priv);
++	if (err)
++		goto out_clear_mapping;
++	err = max96712_set_registers(priv, map_phy_opt, ARRAY_SIZE(map_phy_opt));
++
++out_clear_mapping:
+ 	/*
+ 	 * map_pipe_opt just disabled every video pipe (PIPE_EN = 0), so any
+ 	 * previously written multi-VC mapping is now void. Forget the
+@@ -1162,6 +1226,10 @@
+ 	 * left intact, matching how the dynamic allocation state persists here.
+ 	 */
+ 	memset(priv->multi_vc_configured, 0, sizeof(priv->multi_vc_configured));
++
++	if (!err)
++		dev_info(dev, "CSI output: %u Mbps/lane, %d lanes\n",
++			 priv->csi_lane_rate_mbps, priv->lane_cnt);
+ 
+ 	mutex_unlock(&priv->lock);
+ 

--- a/nvidia-oot/6.1/0014-Configure-max96712-host-CSI-lane-rate.patch
+++ b/nvidia-oot/6.1/0014-Configure-max96712-host-CSI-lane-rate.patch
@@ -1,0 +1,1 @@
+../6.0/0014-Configure-max96712-host-CSI-lane-rate.patch

--- a/nvidia-oot/6.2/0014-Configure-max96712-host-CSI-lane-rate.patch
+++ b/nvidia-oot/6.2/0014-Configure-max96712-host-CSI-lane-rate.patch
@@ -1,0 +1,1 @@
+../6.0/0014-Configure-max96712-host-CSI-lane-rate.patch


### PR DESCRIPTION
The FG12-16CH mixed-camera overlay currently aggregates one D585 and three D400 cameras onto a four-lane MAX96712 CSI output at 1.3 Gbps/lane. Raise this deserializer-to-host output to 2.0 Gbps/lane, increasing raw aggregate capacity from 5.2 to 8.0 Gbps to provide more headroom for overlapping camera bursts.

- Add a MAX96712 `csi-lane-rate-mbps` DT setting in the JetPack 6.x patch series, validated as 100–2500 Mbps in 100 Mbps steps. Boards without the property retain their existing 1.3 Gbps/4-lane or 2.5 Gbps/2-lane defaults.
- Select 2000 Mbps only in `tegra234-camera-d4xx-overlay-fg12-16ch-cams-0-1-2-3-d5xx-3d4xx.dts`. Set all 16 output modes to `serdes_pix_clk_hz = "500000000"` (4 × 2 Gbps / 16 bpp), and update `max_lane_speed`.
- Enable automatic initial D-PHY deskew on the active port-A PHYs for explicit rates above 1.5 Gbps/lane. Enable periodic deskew when the board selects a continuous clock; configure the mixed overlay and Host properties consistently. Calibration enable bits are programmed before enabling the PHYs/output, preserving the existing pattern-width and interval fields.
- Camera-to-serializer CSI rates, GMSL link rates, camera pixel clocks and `d4xx.c` are unchanged. The rate selection is applied again through the existing MAX96712 initialization path.

Validation:
- Checked patch application against the MAX96712 source produced by the existing patch series; verified shared patch paths for JP 6.0, 6.1, 6.2, 6.2.1 and 6.2.2.
- Checked all 16 mode clock/deskew settings, unchanged camera/GMSL-link configuration, and whitespace in the applied source and overlay.
- No compilation, DTB build, deployment or hardware tests were performed, as requested. The 2 Gbps output and deskew behavior still require on-board validation, including multi-camera streaming and repeated start/stop. This PR does not claim measured frame-loss improvements.
