### PR TITLE
[D500][GMSL][Fix] Support variable metadata payload sizes

### DIFF
--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -32,6 +32,7 @@
 #include <linux/videodev2.h>
 #include <linux/version.h>
 #include <linux/mutex.h>
+#include <asm/unaligned.h>
 #include <media/media-entity.h>
 #include <media/v4l2-ctrls.h>
 #include <media/v4l2-device.h>
@@ -3595,6 +3596,59 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 }
 
 static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on);
+
+#if defined(CONFIG_TEGRA_CAMERA_PLATFORM) && \
+	defined(TEGRA_HAS_EMBEDDED_METADATA_OPS)
+#define D500_CSI_METADATA_UVC_HEADER_SIZE	12U
+#define D500_CSI_METADATA_UVC_INFO_BASE		0x8eU
+#define D500_CSI_METADATA_UVC_FID_MASK		0x01U
+#define D500_CSI_METADATA_BLOCK_HEADER_SIZE	8U
+#define D500_CSI_METADATA_CAPTURE_TIMING_ID	0x80000001U
+#define D500_CSI_METADATA_MAX_SIZE		0xffU
+
+/*
+ * D500 sends its UVC metadata header and payload unchanged over CSI.  Byte 0
+ * carries the frame's actual length, which differs between sensor streams.
+ * Validate the transport framing here; semantic parsing stays in userspace.
+ */
+static size_t d500_csi_metadata_bytesused(const u8 *data,
+					  size_t captured_size)
+{
+	u32 first_block_size;
+	size_t bytesused;
+
+	if (!data || captured_size < D500_CSI_METADATA_UVC_HEADER_SIZE +
+				      D500_CSI_METADATA_BLOCK_HEADER_SIZE)
+		return 0;
+
+	bytesused = data[0];
+	if (bytesused < D500_CSI_METADATA_UVC_HEADER_SIZE +
+			D500_CSI_METADATA_BLOCK_HEADER_SIZE ||
+	    bytesused > captured_size)
+		return 0;
+
+	if ((data[1] & ~D500_CSI_METADATA_UVC_FID_MASK) !=
+	    D500_CSI_METADATA_UVC_INFO_BASE)
+		return 0;
+
+	if (get_unaligned_le32(data + D500_CSI_METADATA_UVC_HEADER_SIZE) !=
+	    D500_CSI_METADATA_CAPTURE_TIMING_ID)
+		return 0;
+
+	first_block_size = get_unaligned_le32(data +
+		D500_CSI_METADATA_UVC_HEADER_SIZE + sizeof(u32));
+	if (first_block_size < D500_CSI_METADATA_BLOCK_HEADER_SIZE ||
+	    D500_CSI_METADATA_UVC_HEADER_SIZE + first_block_size > bytesused)
+		return 0;
+
+	return bytesused;
+}
+
+static const struct tegra_embedded_metadata_ops d500_csi_metadata_ops = {
+	.max_buffer_size = D500_CSI_METADATA_MAX_SIZE,
+	.get_bytesused = d500_csi_metadata_bytesused,
+};
+#endif
 
 static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 {
@@ -7204,6 +7258,11 @@ static int ds5_mux_init(struct i2c_client *c, struct ds5 *state)
 		state->mux.last_set = &state->imu.sensor;
 
 	state->mux.sd.dev = &c->dev;
+#if defined(CONFIG_TEGRA_CAMERA_PLATFORM) && \
+	defined(TEGRA_HAS_EMBEDDED_METADATA_OPS)
+	if (ds5_is_d58x(state))
+		state->mux.sd.embedded_metadata_ops = &d500_csi_metadata_ops;
+#endif
 	ret = camera_common_initialize(&state->mux.sd, "d4xx");
 	if (ret) {
 		dev_err(&c->dev, "Failed to initialize d4xx.\n");

--- a/nvidia-oot/6.2/0001-embedded-metadata-support-for-D4xx.patch
+++ b/nvidia-oot/6.2/0001-embedded-metadata-support-for-D4xx.patch
@@ -1,32 +1,24 @@
-From dfa92c568b7af74e97d662f6b9901a896c6cbc12 Mon Sep 17 00:00:00 2001
+From 9b565de4b5ae5e9dfa7185207684cf035ad86d25 Mon Sep 17 00:00:00 2001
 From: RealSense <support@realsenseai.com>
 Date: Tue, 9 Jun 2026 18:32:40 +0300
 Subject: [PATCH] embedded-metadata support for D4xx
 
-Embedded-metadata capture support in the Tegra VI/camera stack plus D4XX build
-wiring. Includes upstream-review blocker fixes (single-owner idempotent embedded
-teardown; NULL-guard/cleanup on graph error paths; ring-full buffers returned to
-vb2; real S_FMT/TRY_FMT; proper init error ladder) and review follow-ups:
- - free emb_buf independent of embedded.video (decouple lifetimes)
- - D4XX_META_BUFSIZE/D4XX_META_PAYLOAD defines instead of 255/68 literals
- - shared tegra_metadata_fill_format() helper for G/S/TRY_FMT
- - drop stray double semicolon
- - one page-aligned DMA slot per capture descriptor so in-flight frames do not
-   overwrite each other's embedded metadata
+Allocate one metadata DMA slot per capture descriptor and expose a per-sensor hook for queue capacity and validated per-frame payload length.
 ---
  drivers/media/i2c/Makefile                    |   5 +
  .../platform/tegra/camera/sensor_common.c     |   4 +
- .../media/platform/tegra/camera/vi/channel.c  | 440 +++++++++++++++++-
- .../media/platform/tegra/camera/vi/graph.c    |  46 +-
+ .../media/platform/tegra/camera/vi/channel.c  | 452 +++++++++++++++++-
+ .../media/platform/tegra/camera/vi/graph.c    |  47 +-
  .../platform/tegra/camera/vi/mc_common.c      |  27 ++
- .../media/platform/tegra/camera/vi/vi5_fops.c | 188 ++++++--
+ .../media/platform/tegra/camera/vi/vi5_fops.c | 222 +++++++--
  .../platform/tegra/camera/vi/vi5_formats.h    |  30 +-
- include/media/mc_common.h                     |  31 ++
+ include/media/camera_common.h                 |   8 +
+ include/media/mc_common.h                     |  34 ++
  include/media/tegra_camera_core.h             |  12 +-
- 9 files changed, 723 insertions(+), 60 deletions(-)
+ 10 files changed, 781 insertions(+), 60 deletions(-)
 
 diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
-index a85d6e8..947e6e9 100644
+index a85d6e88..947e6e94 100644
 --- a/drivers/media/i2c/Makefile
 +++ b/drivers/media/i2c/Makefile
 @@ -5,6 +5,11 @@ subdir-ccflags-y += -Werror
@@ -42,10 +34,10 @@ index a85d6e8..947e6e9 100644
  obj-m += max96712.o
  
 diff --git a/drivers/media/platform/tegra/camera/sensor_common.c b/drivers/media/platform/tegra/camera/sensor_common.c
-index 92cc2fd..69139ee 100644
+index 501a230d..71382088 100644
 --- a/drivers/media/platform/tegra/camera/sensor_common.c
 +++ b/drivers/media/platform/tegra/camera/sensor_common.c
-@@ -267,6 +267,10 @@ static int extract_pixel_format(
+@@ -296,6 +296,10 @@ static int extract_pixel_format(
  		*format = V4L2_PIX_FMT_UYVY;
  	else if (strncmp(pixel_t, "yuv_vyuy16", size) == 0)
  		*format = V4L2_PIX_FMT_VYUY;
@@ -57,7 +49,7 @@ index 92cc2fd..69139ee 100644
  		pr_err("%s: Need to extend format%s\n", __func__, pixel_t);
  		return -EINVAL;
 diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
-index 46ecdb1..3c704ba 100644
+index 37c5383f..60c03ad9 100644
 --- a/drivers/media/platform/tegra/camera/vi/channel.c
 +++ b/drivers/media/platform/tegra/camera/vi/channel.c
 @@ -205,7 +205,12 @@ static void tegra_channel_fmt_align(struct tegra_channel *chan,
@@ -74,7 +66,7 @@ index 46ecdb1..3c704ba 100644
  
  	/* Clamp the requested bytes per line value. If the maximum bytes per
  	 * line value is zero, the module doesn't support user configurable line
-@@ -1047,7 +1052,8 @@ tegra_channel_querycap(struct file *file, void *fh, struct v4l2_capability *cap)
+@@ -1050,7 +1055,8 @@ tegra_channel_querycap(struct file *file, void *fh, struct v4l2_capability *cap)
  
  	cap->device_caps = V4L2_CAP_VIDEO_CAPTURE | V4L2_CAP_STREAMING;
  	cap->device_caps |= V4L2_CAP_EXT_PIX_FORMAT;
@@ -84,7 +76,7 @@ index 46ecdb1..3c704ba 100644
  
  	len = strscpy(cap->driver, "tegra-video", sizeof(cap->driver));
  	if (len < 0)
-@@ -2301,6 +2307,62 @@ static int tegra_channel_g_parm(struct file *file, void *fh,
+@@ -2304,6 +2310,62 @@ static int tegra_channel_g_parm(struct file *file, void *fh,
  	return v4l2_g_parm_cap(chan->video, sd, a);
  }
  
@@ -147,7 +139,7 @@ index 46ecdb1..3c704ba 100644
  static const struct v4l2_ioctl_ops tegra_channel_ioctl_ops = {
  	.vidioc_querycap		= tegra_channel_querycap,
  	.vidioc_enum_framesizes		= tegra_channel_enum_framesizes,
-@@ -2334,6 +2396,9 @@ static const struct v4l2_ioctl_ops tegra_channel_ioctl_ops = {
+@@ -2337,6 +2399,9 @@ static const struct v4l2_ioctl_ops tegra_channel_ioctl_ops = {
  	.vidioc_s_input			= tegra_channel_s_input,
  	.vidioc_log_status		= tegra_channel_log_status,
  	.vidioc_default			= tegra_channel_default_ioctl,
@@ -157,7 +149,7 @@ index 46ecdb1..3c704ba 100644
  };
  
  static int tegra_channel_close(struct file *fp);
-@@ -2549,6 +2614,362 @@ static int tegra_channel_csi_init(struct tegra_channel *chan)
+@@ -2552,6 +2617,374 @@ static int tegra_channel_csi_init(struct tegra_channel *chan)
  	return ret;
  }
  
@@ -229,10 +221,19 @@ index 46ecdb1..3c704ba 100644
 + * TRY_FMT all return the same V4L2_META_FMT_D4XX / D4XX_META_BUFSIZE
 + * descriptor. Share one helper to keep them from drifting apart.
 + */
++static unsigned int tegra_metadata_buffer_size(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->max_buffer_size)
++		return chan->embedded.ops->max_buffer_size;
++
++	return D4XX_META_BUFSIZE;
++}
++
 +static int tegra_metadata_fill_format(struct file *file,
 +				    struct v4l2_format *format)
 +{
 +	struct v4l2_fh *vfh = file->private_data;
++	struct tegra_channel *chan = video_drvdata(file);
 +	struct v4l2_meta_format *fmt = &format->fmt.meta;
 +
 +	if (format->type != vfh->vdev->queue->type)
@@ -240,7 +241,7 @@ index 46ecdb1..3c704ba 100644
 +
 +	memset(fmt, 0, sizeof(*fmt));
 +	fmt->dataformat = V4L2_META_FMT_D4XX;
-+	fmt->buffersize = D4XX_META_BUFSIZE;
++	fmt->buffersize = tegra_metadata_buffer_size(chan);
 +
 +	return 0;
 +}
@@ -283,19 +284,20 @@ index 46ecdb1..3c704ba 100644
 +                    unsigned int sizes[], struct device *alloc_devs[])
 +{
 +	struct tegra_channel *chan = vb2_get_drv_priv(vq);
++	unsigned int size = tegra_metadata_buffer_size(chan);
 +
 +	if (*nplanes) {
 +		if (*nplanes != 1)
 +			return -EINVAL;
 +
-+		if (sizes[0] < D4XX_META_BUFSIZE)
++		if (sizes[0] < size)
 +			return -EINVAL;
 +
 +		return 0;
 +	}
 +
 +	*nplanes = 1;
-+	sizes[0] = D4XX_META_BUFSIZE;
++	sizes[0] = size;
 +	alloc_devs[0] = chan->vi->dev;
 +
 +
@@ -304,10 +306,12 @@ index 46ecdb1..3c704ba 100644
 +
 +static int tegra_metadata_buffer_prepare(struct vb2_buffer *vb)
 +{
++	struct tegra_channel *chan = vb2_get_drv_priv(vb->vb2_queue);
++
 +	if (vb->num_planes != 1)
 +		return -EINVAL;
 +
-+	if (vb2_plane_size(vb, 0) < D4XX_META_BUFSIZE)
++	if (vb2_plane_size(vb, 0) < tegra_metadata_buffer_size(chan))
 +		return -EINVAL;
 +
 +	return 0;
@@ -520,7 +524,7 @@ index 46ecdb1..3c704ba 100644
  int tegra_channel_init_video(struct tegra_channel *chan)
  {
  	struct tegra_mc_vi *vi = chan->vi;
-@@ -2729,13 +3150,14 @@ int tegra_channel_cleanup(struct tegra_channel *chan)
+@@ -2732,13 +3165,14 @@ int tegra_channel_cleanup(struct tegra_channel *chan)
  {
  	struct device *vi_unit_dev = tegra_channel_get_vi_unit(chan);
  
@@ -543,7 +547,7 @@ index 46ecdb1..3c704ba 100644
  	tegra_channel_dealloc_buffer_queue(chan);
  
 diff --git a/drivers/media/platform/tegra/camera/vi/graph.c b/drivers/media/platform/tegra/camera/vi/graph.c
-index 7c2d05e..7c81889 100644
+index 7c2d05e7..5ed212b7 100644
 --- a/drivers/media/platform/tegra/camera/vi/graph.c
 +++ b/drivers/media/platform/tegra/camera/vi/graph.c
 @@ -292,6 +292,11 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
@@ -558,7 +562,7 @@ index 7c2d05e..7c81889 100644
  	int ret;
  
  	dev_dbg(chan->vi->dev, "notify complete, all subdevs registered\n");
-@@ -325,16 +330,54 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
+@@ -325,16 +330,55 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
  	if (ret < 0)
  		goto graph_error;
  
@@ -573,6 +577,7 @@ index 7c2d05e..7c81889 100644
 +
 +	if (sensor_mode &&
 +		sensor_mode->image_properties.embedded_metadata_height > 0) {
++		chan->embedded.ops = s_data ? s_data->embedded_metadata_ops : NULL;
 +		ret = tegra_channel_init_video_embedded(chan);
 +		if (ret < 0) {
 +			dev_err(chan->vi->dev,
@@ -614,7 +619,7 @@ index 7c2d05e..7c81889 100644
  graph_error:
  	video_unregister_device(chan->video);
  register_device_error:
-@@ -398,6 +441,7 @@ static void tegra_vi_graph_notify_unbind(struct v4l2_async_notifier *notifier,
+@@ -398,6 +442,7 @@ static void tegra_vi_graph_notify_unbind(struct v4l2_async_notifier *notifier,
  
  	/* cleanup for complete */
  	if (chan->link_status) {
@@ -623,7 +628,7 @@ index 7c2d05e..7c81889 100644
  		tegra_channel_cleanup_video(chan);
  		chan->link_status--;
 diff --git a/drivers/media/platform/tegra/camera/vi/mc_common.c b/drivers/media/platform/tegra/camera/vi/mc_common.c
-index ae6b492..6288d71 100644
+index ae6b4927..6288d712 100644
 --- a/drivers/media/platform/tegra/camera/vi/mc_common.c
 +++ b/drivers/media/platform/tegra/camera/vi/mc_common.c
 @@ -164,6 +164,10 @@ static int vi_parse_dt(struct tegra_mc_vi *vi, struct platform_device *dev)
@@ -668,7 +673,7 @@ index ae6b492..6288d71 100644
  	if (ports == NULL)
  		ports = node;
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-index c6093a7..c7c7454 100644
+index 90e46039..6d1c9192 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 @@ -16,6 +16,7 @@
@@ -705,10 +710,35 @@ index c6093a7..c7c7454 100644
  		desc_memoryinfo->surface[VI_ATOMP_SURFACE_EMBEDDED].size
  			= desc->ch_cfg.frame.embed_x * desc->ch_cfg.frame.embed_y;
  
-@@ -445,6 +451,56 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -445,6 +451,90 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  		chan->capture_descr_sequence += 1;
  }
  
++static unsigned int vi5_metadata_buffer_size(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->max_buffer_size)
++		return chan->embedded.ops->max_buffer_size;
++
++	return D4XX_META_BUFSIZE;
++}
++
++static unsigned int vi5_metadata_bytesused(struct tegra_channel *chan,
++					   const void *metadata_addr,
++					   unsigned int captured_size)
++{
++	const struct tegra_embedded_metadata_ops *ops = chan->embedded.ops;
++	size_t bytesused;
++
++	if (!ops || !ops->get_bytesused)
++		return captured_size;
++
++	bytesused = ops->get_bytesused(metadata_addr, captured_size);
++	if (bytesused && bytesused <= captured_size)
++		return bytesused;
++
++	return 0;
++}
++
 +static void vi5_release_metadata_buffer(struct tegra_channel *chan,
 +	struct tegra_channel_buffer *buf)
 +{
@@ -717,6 +747,8 @@ index c6093a7..c7c7454 100644
 +	struct vb2_v4l2_buffer *vbuf = &buf->buf;
 +	void *frm_buffer;
 +	void *metadata_addr;
++	unsigned int buffer_size = vi5_metadata_buffer_size(chan);
++	unsigned int bytesused;
 +	unsigned int descr_index = buf->capture_descr_index[0];
 +	unsigned int emb_offset;
 +
@@ -741,20 +773,27 @@ index c6093a7..c7c7454 100644
 +	}
 +
 +	if (!chan->emb_buf_stride ||
-+		chan->emb_buf_size < D4XX_META_BUFSIZE ||
++		chan->emb_buf_size < buffer_size ||
++		vb2_plane_size(evb, 0) < buffer_size ||
 +		descr_index >= chan->capture_queue_depth ||
 +		check_mul_overflow(descr_index, chan->emb_buf_stride,
 +			&emb_offset) ||
-+		emb_offset > chan->emb_buf_size - D4XX_META_BUFSIZE) {
++		emb_offset > chan->emb_buf_size - buffer_size) {
 +		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
 +		return;
 +	}
 +
 +	metadata_addr = (u8 *)chan->emb_buf_addr + emb_offset;
-+	memcpy(frm_buffer, metadata_addr, D4XX_META_BUFSIZE);
++	bytesused = vi5_metadata_bytesused(chan, metadata_addr, buffer_size);
++	if (!bytesused) {
++		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
++		return;
++	}
++
++	memcpy(frm_buffer, metadata_addr, bytesused);
 +	evbuf = to_vb2_v4l2_buffer(evb);
 +	evbuf->sequence = vbuf->sequence;
-+	vb2_set_plane_payload(evb, 0, D4XX_META_PAYLOAD);
++	vb2_set_plane_payload(evb, 0, bytesused);
 +	evb->timestamp = vbuf->vb2_buf.timestamp;
 +	vb2_buffer_done(evb, VB2_BUF_STATE_DONE);
 +}
@@ -762,7 +801,7 @@ index c6093a7..c7c7454 100644
  static void vi5_release_buffer(struct tegra_channel *chan,
  	struct tegra_channel_buffer *buf)
  {
-@@ -454,6 +510,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+@@ -454,6 +544,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
  	vbuf->field = V4L2_FIELD_NONE;
  	vb2_set_plane_payload(&vbuf->vb2_buf, 0, chan->format.sizeimage);
  
@@ -772,7 +811,7 @@ index c6093a7..c7c7454 100644
  	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);
  }
  
-@@ -665,6 +724,15 @@ static int vi5_channel_error_recover(struct tegra_channel *chan,
+@@ -694,6 +787,15 @@ static int vi5_channel_error_recover(struct tegra_channel *chan,
  			err = PTR_ERR(chan);
  			goto done;
  		}
@@ -788,7 +827,7 @@ index c6093a7..c7c7454 100644
  		err = tegra_channel_capture_setup(chan, vi_port);
  		if (err < 0)
  			goto done;
-@@ -844,6 +912,75 @@ static void vi5_unit_get_device_handle(struct platform_device *pdev,
+@@ -873,6 +975,75 @@ static void vi5_unit_get_device_handle(struct platform_device *pdev,
  		dev_err(&pdev->dev, "dev pointer is NULL\n");
  }
  
@@ -864,7 +903,7 @@ index c6093a7..c7c7454 100644
  static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
  {
  	struct tegra_channel *chan = vb2_get_drv_priv(vq);
-@@ -856,7 +993,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+@@ -885,7 +1056,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
  	struct device_node *node;
  	struct sensor_mode_properties *sensor_mode;
  	struct camera_common_data *s_data;
@@ -872,7 +911,7 @@ index c6093a7..c7c7454 100644
  
  	/* Skip in bypass mode */
  	if (!chan->bypass) {
-@@ -879,7 +1015,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+@@ -908,7 +1078,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
  				if (s_data != NULL && node != NULL) {
  					int idx = s_data->mode_prop_idx;
  
@@ -880,7 +919,7 @@ index c6093a7..c7c7454 100644
  					if (idx < s_data->sensor_props.\
  								num_modes) {
  						sensor_mode =
-@@ -893,46 +1028,14 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+@@ -922,46 +1091,14 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
  							sensor_mode->\
  							 image_properties.\
  						      embedded_metadata_height;
@@ -933,7 +972,7 @@ index c6093a7..c7c7454 100644
  				}
  			}
  			ret = tegra_channel_capture_setup(chan, vi_port);
-@@ -1021,7 +1124,10 @@ static int vi5_channel_stop_streaming(struct vb2_queue *vq)
+@@ -1050,7 +1187,10 @@ static int vi5_channel_stop_streaming(struct vb2_queue *vq)
  										&vi_unit_dev);
  				dma_free_coherent(vi_unit_dev, chan->emb_buf_size,
  								chan->emb_buf_addr, chan->emb_buf);
@@ -945,10 +984,10 @@ index c6093a7..c7c7454 100644
  
  			vi_channel_close_ex(chan->vi_channel_id[vi_port],
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-index 1d0c113..1d375de 100644
+index 4baafc71..afa1a2c6 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-@@ -82,6 +82,8 @@ static const struct tegra_video_format vi5_video_formats[] = {
+@@ -88,6 +88,8 @@ static const struct tegra_video_format vi5_video_formats[] = {
  	/* RAW 7: TODO */
  
  	/* RAW 8 */
@@ -957,7 +996,7 @@ index 1d0c113..1d375de 100644
  	TEGRA_VIDEO_FORMAT(RAW8, 8, SRGGB8_1X8, 1, 1, T_R8,
  				RAW8, SRGGB8, "RGRG.. GBGB.."),
  	TEGRA_VIDEO_FORMAT(RAW8, 8, SGRBG8_1X8, 1, 1, T_R8,
-@@ -112,22 +114,22 @@ static const struct tegra_video_format vi5_video_formats[] = {
+@@ -128,22 +130,22 @@ static const struct tegra_video_format vi5_video_formats[] = {
  				RAW12, SBGGR12, "BGBG.. GRGR.."),
  
  	/* RGB888 */
@@ -988,7 +1027,7 @@ index 1d0c113..1d375de 100644
  	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
  				YUV422_8, UYVY, "YUV 4:2:2 UYVY"),
  	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_2X8, 2, 1, T_V8_Y8__U8_Y8,
-@@ -136,6 +138,18 @@ static const struct tegra_video_format vi5_video_formats[] = {
+@@ -152,6 +154,18 @@ static const struct tegra_video_format vi5_video_formats[] = {
  				YUV422_8, YUYV, "YUV 4:2:2 YUYV"),
  	TEGRA_VIDEO_FORMAT(YUV422, 16, YVYU8_2X8, 2, 1, T_Y8_V8__Y8_U8,
  				YUV422_8, YVYU, "YUV 4:2:2 YVYU"),
@@ -1007,11 +1046,46 @@ index 1d0c113..1d375de 100644
  };
  
  #endif
+diff --git a/include/media/camera_common.h b/include/media/camera_common.h
+index 6b5ae91d..229a4d53 100644
+--- a/include/media/camera_common.h
++++ b/include/media/camera_common.h
+@@ -30,6 +30,13 @@
+ #include <media/v4l2-ctrls.h>
+ #include <media/tegracam_core.h>
+ 
++#define TEGRA_HAS_EMBEDDED_METADATA_OPS 1
++
++struct tegra_embedded_metadata_ops {
++	u32 max_buffer_size;
++	size_t (*get_bytesused)(const u8 *data, size_t captured_size);
++};
++
+ /*
+  * Scaling factor for converting a Q10.22 fixed point value
+  * back to its original floating point value
+@@ -244,6 +251,7 @@ struct camera_common_data {
+ 	int	sensor_mode_id;
+ 	bool	use_sensor_mode_id;
+ 	bool	override_enable;
++	const struct tegra_embedded_metadata_ops *embedded_metadata_ops;
+ 	u32	version;
+ };
+ 
 diff --git a/include/media/mc_common.h b/include/media/mc_common.h
-index 607f1f5..cea3ca2 100644
+index 607f1f5f..b2d888ed 100644
 --- a/include/media/mc_common.h
 +++ b/include/media/mc_common.h
-@@ -238,6 +238,23 @@ struct tegra_channel {
+@@ -46,6 +46,8 @@
+ #define	DISABLE		0
+ #define MAX_SYNCPT_PER_CHANNEL	3
+ 
++struct tegra_embedded_metadata_ops;
++
+ #define CAPTURE_MIN_BUFFERS	1U
+ #define CAPTURE_MAX_BUFFERS	240U
+ 
+@@ -238,6 +240,24 @@ struct tegra_channel {
  	unsigned int embedded_data_width;
  	unsigned int embedded_data_height;
  
@@ -1030,12 +1104,13 @@ index 607f1f5..cea3ca2 100644
 +		void *alloc_ctx;
 +		struct media_pad pad;
 +		struct v4l2_ctrl_handler ctrl_handler;
++		const struct tegra_embedded_metadata_ops *ops;
 +	} embedded;
 +
  	DECLARE_BITMAP(fmts_bitmap, MAX_FORMAT_NUM);
  	atomic_t power_on_refcnt;
  	struct v4l2_fh *fh;
-@@ -278,6 +295,7 @@ struct tegra_channel {
+@@ -278,6 +298,7 @@ struct tegra_channel {
  
  	dma_addr_t emb_buf;
  	void *emb_buf_addr;
@@ -1043,7 +1118,7 @@ index 607f1f5..cea3ca2 100644
  	unsigned int emb_buf_size;
  };
  
-@@ -319,6 +337,9 @@ struct tegra_mc_vi {
+@@ -319,6 +340,9 @@ struct tegra_mc_vi {
  	unsigned int num_channels;
  	unsigned int num_subdevs;
  
@@ -1053,7 +1128,7 @@ index 607f1f5..cea3ca2 100644
  	struct tegra_csi_device *csi;
  	struct list_head vi_chans;
  	struct tegra_channel *tpg_start;
-@@ -414,8 +435,18 @@ void enqueue_inflight(struct tegra_channel *chan,
+@@ -414,8 +438,18 @@ void enqueue_inflight(struct tegra_channel *chan,
  struct tegra_channel_buffer *dequeue_inflight(struct tegra_channel *chan);
  int tegra_channel_set_power(struct tegra_channel *chan, bool on);
  
@@ -1073,7 +1148,7 @@ index 607f1f5..cea3ca2 100644
  struct tegra_vi_fops {
  	int (*vi_power_on)(struct tegra_channel *chan);
 diff --git a/include/media/tegra_camera_core.h b/include/media/tegra_camera_core.h
-index e6d9a2b..a4c6978 100644
+index e6d9a2b1..a4c69782 100644
 --- a/include/media/tegra_camera_core.h
 +++ b/include/media/tegra_camera_core.h
 @@ -18,7 +18,7 @@
@@ -1118,3 +1193,4 @@ index e6d9a2b..a4c6978 100644
  	TEGRA_VF_RGB555,
 -- 
 2.34.1
+

--- a/nvidia-oot/7.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/7.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -1,32 +1,33 @@
-From d6e775bcd09291a45bd7f35d6d54c02a0fa3c32f Mon Sep 17 00:00:00 2001
+From fa3cbe8f1435ae4eaaf1c1efbbb4c461f64387a4 Mon Sep 17 00:00:00 2001
 From: Dmitry Perchanov <dmitry.perchanov@intel.com>
-Date: Mon, 20 May 2024 18:08:02 +0300
+Date: Tue, 8 Sep 2026 17:30:25 +0800
 Subject: [PATCH] Porting nvidia driver patches to jetpack 6.0
 
-Allocate one page-aligned embedded-metadata DMA slot per VI capture descriptor.
-Descriptor setup and completion use the same slot so in-flight frames cannot
-overwrite each other's metadata.
+Allocate one page-aligned embedded-metadata DMA slot per VI capture descriptor. Descriptor setup and completion use the same slot so in-flight frames cannot overwrite each other metadata.
+
+Add a per-sensor metadata hook so queue capacity and each frame actual payload length remain separate. Legacy D4xx keeps its 68-byte contract; sensors with variable metadata publish validated bytesused.
 
 Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
 ---
  drivers/media/i2c/Makefile                    |   5 +
  drivers/media/i2c/max9295.c                   | 139 ++++++
- drivers/media/i2c/max9296.c                   | 193 +++++++++
+ drivers/media/i2c/max9296.c                   | 193 ++++++++
  .../platform/tegra/camera/sensor_common.c     |   4 +
- .../media/platform/tegra/camera/vi/channel.c  | 408 +++++++++++++++++-
- .../media/platform/tegra/camera/vi/graph.c    |  38 +-
+ .../media/platform/tegra/camera/vi/channel.c  | 420 +++++++++++++++++-
+ .../media/platform/tegra/camera/vi/graph.c    |  39 +-
  .../platform/tegra/camera/vi/mc_common.c      |  27 ++
- .../media/platform/tegra/camera/vi/vi5_fops.c | 188 ++++++--
+ .../media/platform/tegra/camera/vi/vi5_fops.c | 223 ++++++++--
  .../platform/tegra/camera/vi/vi5_formats.h    |  30 +-
+ include/media/camera_common.h                 |   8 +
  include/media/gmsl-link.h                     |   5 +
  include/media/max9295.h                       |   4 +
  include/media/max9296.h                       |   8 +
- include/media/mc_common.h                     |  23 +
+ include/media/mc_common.h                     |  29 ++
  include/media/tegra_camera_core.h             |  12 +-
- 14 files changed, 1031 insertions(+), 53 deletions(-)
+ 15 files changed, 1093 insertions(+), 53 deletions(-)
 
 diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
-index fdf09df..0e40687 100644
+index fdf09df6..0e406878 100644
 --- a/drivers/media/i2c/Makefile
 +++ b/drivers/media/i2c/Makefile
 @@ -17,6 +17,11 @@ subdir-ccflags-y += -Werror
@@ -42,7 +43,7 @@ index fdf09df..0e40687 100644
  obj-m += max96712.o
  
 diff --git a/drivers/media/i2c/max9295.c b/drivers/media/i2c/max9295.c
-index b363d5f..b2b3599 100644
+index b363d5f6..b2b3599c 100644
 --- a/drivers/media/i2c/max9295.c
 +++ b/drivers/media/i2c/max9295.c
 @@ -465,6 +465,145 @@ static  struct regmap_config max9295_regmap_config = {
@@ -192,7 +193,7 @@ index b363d5f..b2b3599 100644
  static int max9295_probe(struct i2c_client *client)
  #else
 diff --git a/drivers/media/i2c/max9296.c b/drivers/media/i2c/max9296.c
-index 1ceaf3c..46516d6 100644
+index 1ceaf3cd..46516d63 100644
 --- a/drivers/media/i2c/max9296.c
 +++ b/drivers/media/i2c/max9296.c
 @@ -34,6 +34,8 @@
@@ -410,7 +411,7 @@ index 1ceaf3c..46516d6 100644
  	{ .compatible = "maxim,max9296", },
  	{ },
 diff --git a/drivers/media/platform/tegra/camera/sensor_common.c b/drivers/media/platform/tegra/camera/sensor_common.c
-index 1de2ac3..f688610 100644
+index 1de2ac35..f688610d 100644
 --- a/drivers/media/platform/tegra/camera/sensor_common.c
 +++ b/drivers/media/platform/tegra/camera/sensor_common.c
 @@ -306,6 +306,10 @@ static int extract_pixel_format(
@@ -425,7 +426,7 @@ index 1de2ac3..f688610 100644
  		pr_err("%s: Need to extend format%s\n", __func__, pixel_t);
  		return -EINVAL;
 diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
-index c5d149b..c01eeb2 100644
+index c5d149bc..80460aee 100644
 --- a/drivers/media/platform/tegra/camera/vi/channel.c
 +++ b/drivers/media/platform/tegra/camera/vi/channel.c
 @@ -231,7 +231,12 @@ static void tegra_channel_fmt_align(struct tegra_channel *chan,
@@ -529,7 +530,7 @@ index c5d149b..c01eeb2 100644
  };
  
  static int tegra_channel_close(struct file *fp);
-@@ -2658,6 +2727,334 @@ static int tegra_channel_csi_init(struct tegra_channel *chan)
+@@ -2658,6 +2727,346 @@ static int tegra_channel_csi_init(struct tegra_channel *chan)
  	return ret;
  }
  
@@ -596,10 +597,19 @@ index c5d149b..c01eeb2 100644
 +	return 0;
 +}
 +
++static unsigned int tegra_metadata_buffer_size(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->max_buffer_size)
++		return chan->embedded.ops->max_buffer_size;
++
++	return D4XX_META_BUFSIZE;
++}
++
 +static int tegra_metadata_get_format(struct file *file, void *fh,
 +                                    struct v4l2_format *format)
 +{
 +	struct v4l2_fh *vfh = file->private_data;
++	struct tegra_channel *chan = video_drvdata(file);
 +	struct v4l2_meta_format *fmt = &format->fmt.meta;
 +
 +	if (format->type != vfh->vdev->queue->type)
@@ -608,7 +618,7 @@ index c5d149b..c01eeb2 100644
 +	memset(fmt, 0, sizeof(*fmt));
 +
 +	fmt->dataformat = V4L2_META_FMT_D4XX;
-+	fmt->buffersize = 255;
++	fmt->buffersize = tegra_metadata_buffer_size(chan);
 +
 +	return 0;
 +}
@@ -644,19 +654,20 @@ index c5d149b..c01eeb2 100644
 +                    unsigned int sizes[], struct device *alloc_devs[])
 +{
 +	struct tegra_channel *chan = vb2_get_drv_priv(vq);
++	unsigned int size = tegra_metadata_buffer_size(chan);
 +
 +	if (*nplanes) {
 +		if (*nplanes != 1)
 +			return -EINVAL;
 +
-+		if (sizes[0] < 255)
++		if (sizes[0] < size)
 +			return -EINVAL;
 +
 +		return 0;
 +	}
 +
 +	*nplanes = 1;
-+	sizes[0] = 255;
++	sizes[0] = size;
 +	alloc_devs[0] = chan->vi->dev;
 +
 +
@@ -665,10 +676,12 @@ index c5d149b..c01eeb2 100644
 +
 +static int tegra_metadata_buffer_prepare(struct vb2_buffer *vb)
 +{
++	struct tegra_channel *chan = vb2_get_drv_priv(vb->vb2_queue);
++
 +	if (vb->num_planes != 1)
 +		return -EINVAL;
 +
-+	if (vb2_plane_size(vb, 0) < 255)
++	if (vb2_plane_size(vb, 0) < tegra_metadata_buffer_size(chan))
 +		return -EINVAL;
 +
 +	return 0;
@@ -864,7 +877,7 @@ index c5d149b..c01eeb2 100644
  int tegra_channel_init_video(struct tegra_channel *chan)
  {
  	struct tegra_mc_vi *vi = chan->vi;
-@@ -2858,6 +3255,13 @@ int tegra_channel_cleanup(struct tegra_channel *chan)
+@@ -2858,6 +3267,13 @@ int tegra_channel_cleanup(struct tegra_channel *chan)
  			chan->emb_buf_size,
  			chan->emb_buf_addr, chan->emb_buf);
  		chan->emb_buf_size = 0;
@@ -879,7 +892,7 @@ index c5d149b..c01eeb2 100644
  
  	tegra_channel_dealloc_buffer_queue(chan);
 diff --git a/drivers/media/platform/tegra/camera/vi/graph.c b/drivers/media/platform/tegra/camera/vi/graph.c
-index 097db3f..8e2a600 100644
+index 097db3f7..b652336e 100644
 --- a/drivers/media/platform/tegra/camera/vi/graph.c
 +++ b/drivers/media/platform/tegra/camera/vi/graph.c
 @@ -291,6 +291,11 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
@@ -894,7 +907,7 @@ index 097db3f..8e2a600 100644
  	int ret;
  
  	dev_dbg(chan->vi->dev, "notify complete, all subdevs registered\n");
-@@ -324,16 +329,46 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
+@@ -324,16 +329,47 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
  	if (ret < 0)
  		goto graph_error;
  
@@ -909,6 +922,7 @@ index 097db3f..8e2a600 100644
 +
 +	if (sensor_mode &&
 +		sensor_mode->image_properties.embedded_metadata_height > 0) {
++		chan->embedded.ops = s_data ? s_data->embedded_metadata_ops : NULL;
 +		ret = tegra_channel_init_video_embedded(chan);
 +		if (ret < 0) {
 +			dev_err(chan->vi->dev,
@@ -942,7 +956,7 @@ index 097db3f..8e2a600 100644
  graph_error:
  	video_unregister_device(chan->video);
  register_device_error:
-@@ -397,6 +432,7 @@ static void tegra_vi_graph_notify_unbind(struct v4l2_async_notifier *notifier,
+@@ -397,6 +433,7 @@ static void tegra_vi_graph_notify_unbind(struct v4l2_async_notifier *notifier,
  
  	/* cleanup for complete */
  	if (chan->link_status) {
@@ -951,7 +965,7 @@ index 097db3f..8e2a600 100644
  		tegra_channel_cleanup_video(chan);
  		chan->link_status--;
 diff --git a/drivers/media/platform/tegra/camera/vi/mc_common.c b/drivers/media/platform/tegra/camera/vi/mc_common.c
-index ee1d6e2..a499d8d 100644
+index ee1d6e26..a499d8d1 100644
 --- a/drivers/media/platform/tegra/camera/vi/mc_common.c
 +++ b/drivers/media/platform/tegra/camera/vi/mc_common.c
 @@ -164,6 +164,10 @@ static int vi_parse_dt(struct tegra_mc_vi *vi, struct platform_device *dev)
@@ -996,10 +1010,10 @@ index ee1d6e2..a499d8d 100644
  	if (ports == NULL)
  		ports = node;
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-index c68751f..b4b9d86 100644
+index c68751f8..526e103a 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -7,6 +7,7 @@
+@@ -7,11 +7,13 @@
  #include <linux/fs.h>
  #include <linux/kthread.h>
  #include <linux/nvhost.h>
@@ -1007,7 +1021,13 @@ index c68751f..b4b9d86 100644
  #include <linux/pm_runtime.h>
  #include <linux/semaphore.h>
  #include <linux/syscalls.h>
-@@ -67,6 +68,8 @@ static const struct capture_descriptor capture_template = {
+ #include <media/fusa-capture/capture-vi-channel.h>
+ #include <media/fusa-capture/capture-vi.h>
++#include <media/camera_common.h>
+ #include <media/mc_common.h>
+ #include <media/tegra-v4l2-camera.h>
+ #include <media/tegra_camera_platform.h>
+@@ -67,6 +69,8 @@ static const struct capture_descriptor capture_template = {
  	},
  };
  
@@ -1016,7 +1036,7 @@ index c68751f..b4b9d86 100644
  static void vi5_init_video_formats(struct tegra_channel *chan)
  {
  	int i;
-@@ -442,12 +445,15 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -442,12 +446,15 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  	}
  
  	if (chan->embedded_data_height > 0) {
@@ -1033,10 +1053,35 @@ index c68751f..b4b9d86 100644
  		desc_memoryinfo->surface[VI_ATOMP_SURFACE_EMBEDDED].size
  			= desc->ch_cfg.frame.embed_x * desc->ch_cfg.frame.embed_y;
  
-@@ -463,6 +469,56 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -463,6 +470,90 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  		chan->capture_descr_sequence += 1;
  }
  
++static unsigned int vi5_metadata_buffer_size(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->max_buffer_size)
++		return chan->embedded.ops->max_buffer_size;
++
++	return D4XX_META_BUFSIZE;
++}
++
++static unsigned int vi5_metadata_bytesused(struct tegra_channel *chan,
++					   const void *metadata_addr,
++					   unsigned int captured_size)
++{
++	const struct tegra_embedded_metadata_ops *ops = chan->embedded.ops;
++	size_t bytesused;
++
++	if (!ops || !ops->get_bytesused)
++		return captured_size;
++
++	bytesused = ops->get_bytesused(metadata_addr, captured_size);
++	if (bytesused && bytesused <= captured_size)
++		return bytesused;
++
++	return 0;
++}
++
 +static void vi5_release_metadata_buffer(struct tegra_channel *chan,
 +	struct tegra_channel_buffer *buf)
 +{
@@ -1045,6 +1090,8 @@ index c68751f..b4b9d86 100644
 +	struct vb2_v4l2_buffer *vbuf = &buf->buf;
 +	void *frm_buffer;
 +	void *metadata_addr;
++	unsigned int buffer_size = vi5_metadata_buffer_size(chan);
++	unsigned int bytesused;
 +	unsigned int descr_index = buf->capture_descr_index[0];
 +	unsigned int emb_offset;
 +
@@ -1069,20 +1116,27 @@ index c68751f..b4b9d86 100644
 +	}
 +
 +	if (!chan->emb_buf_stride ||
-+		chan->emb_buf_size < 255 ||
++		chan->emb_buf_size < buffer_size ||
++		vb2_plane_size(evb, 0) < buffer_size ||
 +		descr_index >= chan->capture_queue_depth ||
 +		check_mul_overflow(descr_index, chan->emb_buf_stride,
 +			&emb_offset) ||
-+		emb_offset > chan->emb_buf_size - 255) {
++		emb_offset > chan->emb_buf_size - buffer_size) {
 +		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
 +		return;
 +	}
 +
 +	metadata_addr = (u8 *)chan->emb_buf_addr + emb_offset;
-+	memcpy(frm_buffer, metadata_addr, 255);
++	bytesused = vi5_metadata_bytesused(chan, metadata_addr, buffer_size);
++	if (!bytesused) {
++		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
++		return;
++	}
++
++	memcpy(frm_buffer, metadata_addr, bytesused);
 +	evbuf = to_vb2_v4l2_buffer(evb);
 +	evbuf->sequence = vbuf->sequence;
-+	vb2_set_plane_payload(evb, 0, 68);
++	vb2_set_plane_payload(evb, 0, bytesused);
 +	evb->timestamp = vbuf->vb2_buf.timestamp;
 +	vb2_buffer_done(evb, VB2_BUF_STATE_DONE);
 +}
@@ -1090,7 +1144,7 @@ index c68751f..b4b9d86 100644
  static void vi5_release_buffer(struct tegra_channel *chan,
  	struct tegra_channel_buffer *buf)
  {
-@@ -477,6 +533,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+@@ -477,6 +568,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
  	vbuf->field = V4L2_FIELD_NONE;
  	vb2_set_plane_payload(&vbuf->vb2_buf, 0, chan->format.sizeimage);
  
@@ -1100,7 +1154,7 @@ index c68751f..b4b9d86 100644
  	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);
  }
  
-@@ -689,6 +748,15 @@ static int vi5_channel_error_recover(struct tegra_channel *chan,
+@@ -689,6 +783,15 @@ static int vi5_channel_error_recover(struct tegra_channel *chan,
  			err = PTR_ERR(chan);
  			goto done;
  		}
@@ -1116,7 +1170,7 @@ index c68751f..b4b9d86 100644
  		err = tegra_channel_capture_setup(chan, vi_port);
  		if (err < 0)
  			goto done;
-@@ -882,6 +950,75 @@ static void vi5_unit_get_device_handle(struct platform_device *pdev,
+@@ -882,6 +985,75 @@ static void vi5_unit_get_device_handle(struct platform_device *pdev,
  		dev_err(&pdev->dev, "dev pointer is NULL\n");
  }
  
@@ -1192,7 +1246,7 @@ index c68751f..b4b9d86 100644
  static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
  {
  	struct tegra_channel *chan = vb2_get_drv_priv(vq);
-@@ -894,7 +1031,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+@@ -894,7 +1066,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
  	struct device_node *node;
  	struct sensor_mode_properties *sensor_mode;
  	struct camera_common_data *s_data;
@@ -1200,7 +1254,7 @@ index c68751f..b4b9d86 100644
  
  	/* Skip in bypass mode */
  	if (!chan->bypass) {
-@@ -917,7 +1053,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+@@ -917,7 +1088,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
  				if (s_data != NULL && node != NULL) {
  					int idx = s_data->mode_prop_idx;
  
@@ -1208,7 +1262,7 @@ index c68751f..b4b9d86 100644
  					if (idx < s_data->sensor_props.\
  								num_modes) {
  						sensor_mode =
-@@ -931,46 +1066,14 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+@@ -931,46 +1101,14 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
  							sensor_mode->\
  							 image_properties.\
  						      embedded_metadata_height;
@@ -1261,7 +1315,7 @@ index c68751f..b4b9d86 100644
  				}
  			}
  			ret = tegra_channel_capture_setup(chan, vi_port);
-@@ -1060,7 +1163,10 @@ static int vi5_channel_stop_streaming(struct vb2_queue *vq)
+@@ -1060,7 +1198,10 @@ static int vi5_channel_stop_streaming(struct vb2_queue *vq)
  										&vi_unit_dev);
  				dma_free_coherent(vi_unit_dev, chan->emb_buf_size,
  								chan->emb_buf_addr, chan->emb_buf);
@@ -1273,7 +1327,7 @@ index c68751f..b4b9d86 100644
  
  			vi_channel_close_ex(chan->vi_channel_id[vi_port],
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-index 4baafc7..afa1a2c 100644
+index 4baafc71..afa1a2c6 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 @@ -88,6 +88,8 @@ static const struct tegra_video_format vi5_video_formats[] = {
@@ -1335,8 +1389,34 @@ index 4baafc7..afa1a2c 100644
  };
  
  #endif
+diff --git a/include/media/camera_common.h b/include/media/camera_common.h
+index a7a1d267..e453509e 100644
+--- a/include/media/camera_common.h
++++ b/include/media/camera_common.h
+@@ -41,6 +41,13 @@
+ #include <media/v4l2-ctrls.h>
+ #include <media/tegracam_core.h>
+ 
++#define TEGRA_HAS_EMBEDDED_METADATA_OPS 1
++
++struct tegra_embedded_metadata_ops {
++	u32 max_buffer_size;
++	size_t (*get_bytesused)(const u8 *data, size_t captured_size);
++};
++
+ /*
+  * Scaling factor for converting a Q10.22 fixed point value
+  * back to its original floating point value
+@@ -255,6 +262,7 @@ struct camera_common_data {
+ 	int	sensor_mode_id;
+ 	bool	use_sensor_mode_id;
+ 	bool	override_enable;
++	const struct tegra_embedded_metadata_ops *embedded_metadata_ops;
+ 	u32	version;
+ };
+ 
 diff --git a/include/media/gmsl-link.h b/include/media/gmsl-link.h
-index ad902d0..cebeb37 100644
+index ad902d0a..cebeb37e 100644
 --- a/include/media/gmsl-link.h
 +++ b/include/media/gmsl-link.h
 @@ -40,6 +40,11 @@
@@ -1352,7 +1432,7 @@ index ad902d0..cebeb37 100644
  #define GMSL_ST_ID_UNUSED 0xFF
  
 diff --git a/include/media/max9295.h b/include/media/max9295.h
-index bf801aa..c576e3e 100644
+index bf801aa2..c576e3e5 100644
 --- a/include/media/max9295.h
 +++ b/include/media/max9295.h
 @@ -12,6 +12,7 @@
@@ -1381,7 +1461,7 @@ index bf801aa..c576e3e 100644
  
  #endif  /* __MAX9295_H__ */
 diff --git a/include/media/max9296.h b/include/media/max9296.h
-index 210dbc8..6b4c796 100644
+index 210dbc80..6b4c796e 100644
 --- a/include/media/max9296.h
 +++ b/include/media/max9296.h
 @@ -12,6 +12,7 @@
@@ -1414,10 +1494,19 @@ index 210dbc8..6b4c796 100644
  
  #endif  /* __MAX9296_H__ */
 diff --git a/include/media/mc_common.h b/include/media/mc_common.h
-index 607f1f5..7ad678d 100644
+index 607f1f5f..73768f05 100644
 --- a/include/media/mc_common.h
 +++ b/include/media/mc_common.h
-@@ -238,6 +238,23 @@ struct tegra_channel {
+@@ -43,6 +43,8 @@
+ #define	MAX_SUBDEVICES	4
+ #define	QUEUED_BUFFERS	4
+ #define	ENABLE		1
++
++struct tegra_embedded_metadata_ops;
+ #define	DISABLE		0
+ #define MAX_SYNCPT_PER_CHANNEL	3
+ 
+@@ -238,6 +240,24 @@ struct tegra_channel {
  	unsigned int embedded_data_width;
  	unsigned int embedded_data_height;
  
@@ -1436,12 +1525,13 @@ index 607f1f5..7ad678d 100644
 +		void *alloc_ctx;
 +		struct media_pad pad;
 +		struct v4l2_ctrl_handler ctrl_handler;
++		const struct tegra_embedded_metadata_ops *ops;
 +	} embedded;
 +
  	DECLARE_BITMAP(fmts_bitmap, MAX_FORMAT_NUM);
  	atomic_t power_on_refcnt;
  	struct v4l2_fh *fh;
-@@ -278,6 +295,7 @@ struct tegra_channel {
+@@ -278,6 +298,7 @@ struct tegra_channel {
  
  	dma_addr_t emb_buf;
  	void *emb_buf_addr;
@@ -1449,7 +1539,7 @@ index 607f1f5..7ad678d 100644
  	unsigned int emb_buf_size;
  };
  
-@@ -319,6 +337,9 @@ struct tegra_mc_vi {
+@@ -319,6 +340,9 @@ struct tegra_mc_vi {
  	unsigned int num_channels;
  	unsigned int num_subdevs;
  
@@ -1459,9 +1549,13 @@ index 607f1f5..7ad678d 100644
  	struct tegra_csi_device *csi;
  	struct list_head vi_chans;
  	struct tegra_channel *tpg_start;
-@@ -415,7 +436,9 @@ struct tegra_channel_buffer *dequeue_inflight(struct tegra_channel *chan);
+@@ -414,8 +438,13 @@ void enqueue_inflight(struct tegra_channel *chan,
+ struct tegra_channel_buffer *dequeue_inflight(struct tegra_channel *chan);
  int tegra_channel_set_power(struct tegra_channel *chan, bool on);
  
++/* Legacy D4xx embedded-metadata allocation and payload contract. */
++#define D4XX_META_BUFSIZE	68
++
  int tegra_channel_init_video(struct tegra_channel *chan);
 +int tegra_channel_init_video_embedded(struct tegra_channel *chan);
  int tegra_channel_cleanup_video(struct tegra_channel *chan);
@@ -1470,7 +1564,7 @@ index 607f1f5..7ad678d 100644
  struct tegra_vi_fops {
  	int (*vi_power_on)(struct tegra_channel *chan);
 diff --git a/include/media/tegra_camera_core.h b/include/media/tegra_camera_core.h
-index e6d9a2b..a4c6978 100644
+index e6d9a2b1..a4c69782 100644
 --- a/include/media/tegra_camera_core.h
 +++ b/include/media/tegra_camera_core.h
 @@ -18,7 +18,7 @@
@@ -1513,5 +1607,3 @@ index e6d9a2b..a4c6978 100644
  	TEGRA_VF_EMBEDDED8,
  	TEGRA_VF_RGB565,
  	TEGRA_VF_RGB555,
--- 
-2.34.1

--- a/nvidia-oot/7.1/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/7.1/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -1,32 +1,33 @@
-From 0c9ebb8cd406ec764ab44f6692c07596f1b7ba2b Mon Sep 17 00:00:00 2001
+From f96c37fa87be511e988c2d5aba5351a5a86b55b4 Mon Sep 17 00:00:00 2001
 From: Dmitry Perchanov <dmitry.perchanov@intel.com>
-Date: Mon, 20 May 2024 18:08:02 +0300
+Date: Tue, 8 Sep 2026 17:30:26 +0800
 Subject: [PATCH] Porting nvidia driver patches to jetpack 6.0
 
-Allocate one page-aligned embedded-metadata DMA slot per VI capture descriptor.
-Descriptor setup and completion use the same slot so in-flight frames cannot
-overwrite each other's metadata.
+Allocate one page-aligned embedded-metadata DMA slot per VI capture descriptor. Descriptor setup and completion use the same slot so in-flight frames cannot overwrite each other metadata.
+
+Add a per-sensor metadata hook so queue capacity and each frame actual payload length remain separate. Legacy D4xx keeps its 68-byte contract; sensors with variable metadata publish validated bytesused.
 
 Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
 ---
  drivers/media/i2c/Makefile                    |   5 +
  drivers/media/i2c/max9295.c                   | 139 ++++++
- drivers/media/i2c/max9296.c                   | 193 +++++++++
+ drivers/media/i2c/max9296.c                   | 193 ++++++++
  .../platform/tegra/camera/sensor_common.c     |   4 +
- .../media/platform/tegra/camera/vi/channel.c  | 408 +++++++++++++++++-
- .../media/platform/tegra/camera/vi/graph.c    |  38 +-
+ .../media/platform/tegra/camera/vi/channel.c  | 420 +++++++++++++++++-
+ .../media/platform/tegra/camera/vi/graph.c    |  39 +-
  .../platform/tegra/camera/vi/mc_common.c      |  27 ++
- .../media/platform/tegra/camera/vi/vi5_fops.c | 188 ++++++--
+ .../media/platform/tegra/camera/vi/vi5_fops.c | 223 ++++++++--
  .../platform/tegra/camera/vi/vi5_formats.h    |  30 +-
+ include/media/camera_common.h                 |   8 +
  include/media/gmsl-link.h                     |   5 +
  include/media/max9295.h                       |   4 +
  include/media/max9296.h                       |   8 +
- include/media/mc_common.h                     |  23 +
+ include/media/mc_common.h                     |  29 ++
  include/media/tegra_camera_core.h             |  10 +-
- 14 files changed, 1029 insertions(+), 53 deletions(-)
+ 15 files changed, 1091 insertions(+), 53 deletions(-)
 
 diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
-index 3b3a3c1..293b9cf 100644
+index 3b3a3c14..293b9cf3 100644
 --- a/drivers/media/i2c/Makefile
 +++ b/drivers/media/i2c/Makefile
 @@ -17,6 +17,11 @@ subdir-ccflags-y += -Werror
@@ -42,7 +43,7 @@ index 3b3a3c1..293b9cf 100644
  obj-m += max96712.o
  
 diff --git a/drivers/media/i2c/max9295.c b/drivers/media/i2c/max9295.c
-index b363d5f..b2b3599 100644
+index b363d5f6..b2b3599c 100644
 --- a/drivers/media/i2c/max9295.c
 +++ b/drivers/media/i2c/max9295.c
 @@ -465,6 +465,145 @@ static  struct regmap_config max9295_regmap_config = {
@@ -192,7 +193,7 @@ index b363d5f..b2b3599 100644
  static int max9295_probe(struct i2c_client *client)
  #else
 diff --git a/drivers/media/i2c/max9296.c b/drivers/media/i2c/max9296.c
-index 1ceaf3c..46516d6 100644
+index 1ceaf3cd..46516d63 100644
 --- a/drivers/media/i2c/max9296.c
 +++ b/drivers/media/i2c/max9296.c
 @@ -34,6 +34,8 @@
@@ -410,7 +411,7 @@ index 1ceaf3c..46516d6 100644
  	{ .compatible = "maxim,max9296", },
  	{ },
 diff --git a/drivers/media/platform/tegra/camera/sensor_common.c b/drivers/media/platform/tegra/camera/sensor_common.c
-index f31bba7..9812286 100644
+index f31bba7d..9812286a 100644
 --- a/drivers/media/platform/tegra/camera/sensor_common.c
 +++ b/drivers/media/platform/tegra/camera/sensor_common.c
 @@ -357,6 +357,10 @@ static int extract_pixel_format(
@@ -425,7 +426,7 @@ index f31bba7..9812286 100644
  		pr_err("%s: Need to extend format%s\n", __func__, pixel_t);
  		return -EINVAL;
 diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
-index 5febe52..19b9bc4 100644
+index 5febe52e..efffe87c 100644
 --- a/drivers/media/platform/tegra/camera/vi/channel.c
 +++ b/drivers/media/platform/tegra/camera/vi/channel.c
 @@ -231,7 +231,12 @@ static void tegra_channel_fmt_align(struct tegra_channel *chan,
@@ -529,7 +530,7 @@ index 5febe52..19b9bc4 100644
  };
  
  static int tegra_channel_close(struct file *fp);
-@@ -2674,6 +2743,334 @@ static int tegra_channel_csi_init(struct tegra_channel *chan)
+@@ -2674,6 +2743,346 @@ static int tegra_channel_csi_init(struct tegra_channel *chan)
  	return ret;
  }
  
@@ -596,10 +597,19 @@ index 5febe52..19b9bc4 100644
 +	return 0;
 +}
 +
++static unsigned int tegra_metadata_buffer_size(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->max_buffer_size)
++		return chan->embedded.ops->max_buffer_size;
++
++	return D4XX_META_BUFSIZE;
++}
++
 +static int tegra_metadata_get_format(struct file *file, void *fh,
 +                                    struct v4l2_format *format)
 +{
 +	struct v4l2_fh *vfh = file->private_data;
++	struct tegra_channel *chan = video_drvdata(file);
 +	struct v4l2_meta_format *fmt = &format->fmt.meta;
 +
 +	if (format->type != vfh->vdev->queue->type)
@@ -608,7 +618,7 @@ index 5febe52..19b9bc4 100644
 +	memset(fmt, 0, sizeof(*fmt));
 +
 +	fmt->dataformat = V4L2_META_FMT_D4XX;
-+	fmt->buffersize = 255;
++	fmt->buffersize = tegra_metadata_buffer_size(chan);
 +
 +	return 0;
 +}
@@ -644,19 +654,20 @@ index 5febe52..19b9bc4 100644
 +                    unsigned int sizes[], struct device *alloc_devs[])
 +{
 +	struct tegra_channel *chan = vb2_get_drv_priv(vq);
++	unsigned int size = tegra_metadata_buffer_size(chan);
 +
 +	if (*nplanes) {
 +		if (*nplanes != 1)
 +			return -EINVAL;
 +
-+		if (sizes[0] < 255)
++		if (sizes[0] < size)
 +			return -EINVAL;
 +
 +		return 0;
 +	}
 +
 +	*nplanes = 1;
-+	sizes[0] = 255;
++	sizes[0] = size;
 +	alloc_devs[0] = chan->vi->dev;
 +
 +
@@ -665,10 +676,12 @@ index 5febe52..19b9bc4 100644
 +
 +static int tegra_metadata_buffer_prepare(struct vb2_buffer *vb)
 +{
++	struct tegra_channel *chan = vb2_get_drv_priv(vb->vb2_queue);
++
 +	if (vb->num_planes != 1)
 +		return -EINVAL;
 +
-+	if (vb2_plane_size(vb, 0) < 255)
++	if (vb2_plane_size(vb, 0) < tegra_metadata_buffer_size(chan))
 +		return -EINVAL;
 +
 +	return 0;
@@ -864,7 +877,7 @@ index 5febe52..19b9bc4 100644
  int tegra_channel_init_video(struct tegra_channel *chan)
  {
  	struct tegra_mc_vi *vi = chan->vi;
-@@ -2874,6 +3271,13 @@ int tegra_channel_cleanup(struct tegra_channel *chan)
+@@ -2874,6 +3283,13 @@ int tegra_channel_cleanup(struct tegra_channel *chan)
  			chan->emb_buf_size,
  			chan->emb_buf_addr, chan->emb_buf);
  		chan->emb_buf_size = 0;
@@ -879,7 +892,7 @@ index 5febe52..19b9bc4 100644
  
  	tegra_channel_dealloc_buffer_queue(chan);
 diff --git a/drivers/media/platform/tegra/camera/vi/graph.c b/drivers/media/platform/tegra/camera/vi/graph.c
-index 097db3f..8e2a600 100644
+index 097db3f7..b652336e 100644
 --- a/drivers/media/platform/tegra/camera/vi/graph.c
 +++ b/drivers/media/platform/tegra/camera/vi/graph.c
 @@ -291,6 +291,11 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
@@ -894,7 +907,7 @@ index 097db3f..8e2a600 100644
  	int ret;
  
  	dev_dbg(chan->vi->dev, "notify complete, all subdevs registered\n");
-@@ -324,16 +329,46 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
+@@ -324,16 +329,47 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
  	if (ret < 0)
  		goto graph_error;
  
@@ -909,6 +922,7 @@ index 097db3f..8e2a600 100644
 +
 +	if (sensor_mode &&
 +		sensor_mode->image_properties.embedded_metadata_height > 0) {
++		chan->embedded.ops = s_data ? s_data->embedded_metadata_ops : NULL;
 +		ret = tegra_channel_init_video_embedded(chan);
 +		if (ret < 0) {
 +			dev_err(chan->vi->dev,
@@ -942,7 +956,7 @@ index 097db3f..8e2a600 100644
  graph_error:
  	video_unregister_device(chan->video);
  register_device_error:
-@@ -397,6 +432,7 @@ static void tegra_vi_graph_notify_unbind(struct v4l2_async_notifier *notifier,
+@@ -397,6 +433,7 @@ static void tegra_vi_graph_notify_unbind(struct v4l2_async_notifier *notifier,
  
  	/* cleanup for complete */
  	if (chan->link_status) {
@@ -951,7 +965,7 @@ index 097db3f..8e2a600 100644
  		tegra_channel_cleanup_video(chan);
  		chan->link_status--;
 diff --git a/drivers/media/platform/tegra/camera/vi/mc_common.c b/drivers/media/platform/tegra/camera/vi/mc_common.c
-index ee1d6e2..a499d8d 100644
+index ee1d6e26..a499d8d1 100644
 --- a/drivers/media/platform/tegra/camera/vi/mc_common.c
 +++ b/drivers/media/platform/tegra/camera/vi/mc_common.c
 @@ -164,6 +164,10 @@ static int vi_parse_dt(struct tegra_mc_vi *vi, struct platform_device *dev)
@@ -996,10 +1010,10 @@ index ee1d6e2..a499d8d 100644
  	if (ports == NULL)
  		ports = node;
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-index 0535607..c858d91 100644
+index 05356074..90cc0bd3 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -7,6 +7,7 @@
+@@ -7,11 +7,13 @@
  #include <linux/fs.h>
  #include <linux/kthread.h>
  #include <linux/nvhost.h>
@@ -1007,7 +1021,13 @@ index 0535607..c858d91 100644
  #include <linux/pm_runtime.h>
  #include <linux/semaphore.h>
  #include <linux/syscalls.h>
-@@ -67,6 +68,8 @@ static const struct capture_descriptor capture_template = {
+ #include <media/fusa-capture/capture-vi-channel.h>
+ #include <media/fusa-capture/capture-vi.h>
++#include <media/camera_common.h>
+ #include <media/mc_common.h>
+ #include <media/tegra-v4l2-camera.h>
+ #include <media/tegra_camera_platform.h>
+@@ -67,6 +69,8 @@ static const struct capture_descriptor capture_template = {
  	},
  };
  
@@ -1016,7 +1036,7 @@ index 0535607..c858d91 100644
  static void vi5_init_video_formats(struct tegra_channel *chan)
  {
  	int i;
-@@ -442,12 +445,15 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -442,12 +446,15 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  	}
  
  	if (chan->embedded_data_height > 0) {
@@ -1033,10 +1053,35 @@ index 0535607..c858d91 100644
  		desc_memoryinfo->surface[VI_ATOMP_SURFACE_EMBEDDED].size
  			= desc->ch_cfg.frame.embed_x * desc->ch_cfg.frame.embed_y;
  
-@@ -463,6 +469,56 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -463,6 +470,90 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  		chan->capture_descr_sequence += 1;
  }
  
++static unsigned int vi5_metadata_buffer_size(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->max_buffer_size)
++		return chan->embedded.ops->max_buffer_size;
++
++	return D4XX_META_BUFSIZE;
++}
++
++static unsigned int vi5_metadata_bytesused(struct tegra_channel *chan,
++					   const void *metadata_addr,
++					   unsigned int captured_size)
++{
++	const struct tegra_embedded_metadata_ops *ops = chan->embedded.ops;
++	size_t bytesused;
++
++	if (!ops || !ops->get_bytesused)
++		return captured_size;
++
++	bytesused = ops->get_bytesused(metadata_addr, captured_size);
++	if (bytesused && bytesused <= captured_size)
++		return bytesused;
++
++	return 0;
++}
++
 +static void vi5_release_metadata_buffer(struct tegra_channel *chan,
 +	struct tegra_channel_buffer *buf)
 +{
@@ -1045,6 +1090,8 @@ index 0535607..c858d91 100644
 +	struct vb2_v4l2_buffer *vbuf = &buf->buf;
 +	void *frm_buffer;
 +	void *metadata_addr;
++	unsigned int buffer_size = vi5_metadata_buffer_size(chan);
++	unsigned int bytesused;
 +	unsigned int descr_index = buf->capture_descr_index[0];
 +	unsigned int emb_offset;
 +
@@ -1069,20 +1116,27 @@ index 0535607..c858d91 100644
 +	}
 +
 +	if (!chan->emb_buf_stride ||
-+		chan->emb_buf_size < 255 ||
++		chan->emb_buf_size < buffer_size ||
++		vb2_plane_size(evb, 0) < buffer_size ||
 +		descr_index >= chan->capture_queue_depth ||
 +		check_mul_overflow(descr_index, chan->emb_buf_stride,
 +			&emb_offset) ||
-+		emb_offset > chan->emb_buf_size - 255) {
++		emb_offset > chan->emb_buf_size - buffer_size) {
 +		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
 +		return;
 +	}
 +
 +	metadata_addr = (u8 *)chan->emb_buf_addr + emb_offset;
-+	memcpy(frm_buffer, metadata_addr, 255);
++	bytesused = vi5_metadata_bytesused(chan, metadata_addr, buffer_size);
++	if (!bytesused) {
++		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
++		return;
++	}
++
++	memcpy(frm_buffer, metadata_addr, bytesused);
 +	evbuf = to_vb2_v4l2_buffer(evb);
 +	evbuf->sequence = vbuf->sequence;
-+	vb2_set_plane_payload(evb, 0, 255);
++	vb2_set_plane_payload(evb, 0, bytesused);
 +	evb->timestamp = vbuf->vb2_buf.timestamp;
 +	vb2_buffer_done(evb, VB2_BUF_STATE_DONE);
 +}
@@ -1090,7 +1144,7 @@ index 0535607..c858d91 100644
  static void vi5_release_buffer(struct tegra_channel *chan,
  	struct tegra_channel_buffer *buf)
  {
-@@ -477,6 +533,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+@@ -477,6 +568,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
  	vbuf->field = V4L2_FIELD_NONE;
  	vb2_set_plane_payload(&vbuf->vb2_buf, 0, chan->format.sizeimage);
  
@@ -1100,7 +1154,7 @@ index 0535607..c858d91 100644
  	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);
  }
  
-@@ -718,6 +777,15 @@ static int vi5_channel_error_recover(struct tegra_channel *chan,
+@@ -718,6 +812,15 @@ static int vi5_channel_error_recover(struct tegra_channel *chan,
  			err = PTR_ERR(chan);
  			goto done;
  		}
@@ -1116,7 +1170,7 @@ index 0535607..c858d91 100644
  		err = tegra_channel_capture_setup(chan, vi_port);
  		if (err < 0)
  			goto done;
-@@ -911,6 +979,75 @@ static void vi5_unit_get_device_handle(struct platform_device *pdev,
+@@ -911,6 +1014,75 @@ static void vi5_unit_get_device_handle(struct platform_device *pdev,
  		dev_err(&pdev->dev, "dev pointer is NULL\n");
  }
  
@@ -1192,7 +1246,7 @@ index 0535607..c858d91 100644
  static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
  {
  	struct tegra_channel *chan = vb2_get_drv_priv(vq);
-@@ -923,7 +1060,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+@@ -923,7 +1095,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
  	struct device_node *node;
  	struct sensor_mode_properties *sensor_mode;
  	struct camera_common_data *s_data;
@@ -1200,7 +1254,7 @@ index 0535607..c858d91 100644
  
  	/* Skip in bypass mode */
  	if (!chan->bypass) {
-@@ -946,7 +1082,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+@@ -946,7 +1117,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
  				if (s_data != NULL && node != NULL) {
  					int idx = s_data->mode_prop_idx;
  
@@ -1208,7 +1262,7 @@ index 0535607..c858d91 100644
  					if (idx < s_data->sensor_props.\
  								num_modes) {
  						sensor_mode =
-@@ -960,46 +1095,14 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+@@ -960,46 +1130,14 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
  							sensor_mode->\
  							 image_properties.\
  						      embedded_metadata_height;
@@ -1261,7 +1315,7 @@ index 0535607..c858d91 100644
  				}
  			}
  			ret = tegra_channel_capture_setup(chan, vi_port);
-@@ -1089,7 +1192,10 @@ static int vi5_channel_stop_streaming(struct vb2_queue *vq)
+@@ -1089,7 +1227,10 @@ static int vi5_channel_stop_streaming(struct vb2_queue *vq)
  										&vi_unit_dev);
  				dma_free_coherent(vi_unit_dev, chan->emb_buf_size,
  								chan->emb_buf_addr, chan->emb_buf);
@@ -1273,7 +1327,7 @@ index 0535607..c858d91 100644
  
  			vi_channel_close_ex(chan->vi_channel_id[vi_port],
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-index d040393..bd22b58 100644
+index d0403936..bd22b58c 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 @@ -88,6 +88,8 @@ static const struct tegra_video_format vi5_video_formats[] = {
@@ -1335,8 +1389,34 @@ index d040393..bd22b58 100644
  };
  
  #endif
+diff --git a/include/media/camera_common.h b/include/media/camera_common.h
+index a7a1d267..e453509e 100644
+--- a/include/media/camera_common.h
++++ b/include/media/camera_common.h
+@@ -41,6 +41,13 @@
+ #include <media/v4l2-ctrls.h>
+ #include <media/tegracam_core.h>
+ 
++#define TEGRA_HAS_EMBEDDED_METADATA_OPS 1
++
++struct tegra_embedded_metadata_ops {
++	u32 max_buffer_size;
++	size_t (*get_bytesused)(const u8 *data, size_t captured_size);
++};
++
+ /*
+  * Scaling factor for converting a Q10.22 fixed point value
+  * back to its original floating point value
+@@ -255,6 +262,7 @@ struct camera_common_data {
+ 	int	sensor_mode_id;
+ 	bool	use_sensor_mode_id;
+ 	bool	override_enable;
++	const struct tegra_embedded_metadata_ops *embedded_metadata_ops;
+ 	u32	version;
+ };
+ 
 diff --git a/include/media/gmsl-link.h b/include/media/gmsl-link.h
-index ad902d0..cebeb37 100644
+index ad902d0a..cebeb37e 100644
 --- a/include/media/gmsl-link.h
 +++ b/include/media/gmsl-link.h
 @@ -40,6 +40,11 @@
@@ -1352,7 +1432,7 @@ index ad902d0..cebeb37 100644
  #define GMSL_ST_ID_UNUSED 0xFF
  
 diff --git a/include/media/max9295.h b/include/media/max9295.h
-index bf801aa..c576e3e 100644
+index bf801aa2..c576e3e5 100644
 --- a/include/media/max9295.h
 +++ b/include/media/max9295.h
 @@ -12,6 +12,7 @@
@@ -1381,7 +1461,7 @@ index bf801aa..c576e3e 100644
  
  #endif  /* __MAX9295_H__ */
 diff --git a/include/media/max9296.h b/include/media/max9296.h
-index 210dbc8..6b4c796 100644
+index 210dbc80..6b4c796e 100644
 --- a/include/media/max9296.h
 +++ b/include/media/max9296.h
 @@ -12,6 +12,7 @@
@@ -1414,10 +1494,19 @@ index 210dbc8..6b4c796 100644
  
  #endif  /* __MAX9296_H__ */
 diff --git a/include/media/mc_common.h b/include/media/mc_common.h
-index 607f1f5..7ad678d 100644
+index 607f1f5f..73768f05 100644
 --- a/include/media/mc_common.h
 +++ b/include/media/mc_common.h
-@@ -238,6 +238,23 @@ struct tegra_channel {
+@@ -43,6 +43,8 @@
+ #define	MAX_SUBDEVICES	4
+ #define	QUEUED_BUFFERS	4
+ #define	ENABLE		1
++
++struct tegra_embedded_metadata_ops;
+ #define	DISABLE		0
+ #define MAX_SYNCPT_PER_CHANNEL	3
+ 
+@@ -238,6 +240,24 @@ struct tegra_channel {
  	unsigned int embedded_data_width;
  	unsigned int embedded_data_height;
  
@@ -1436,12 +1525,13 @@ index 607f1f5..7ad678d 100644
 +		void *alloc_ctx;
 +		struct media_pad pad;
 +		struct v4l2_ctrl_handler ctrl_handler;
++		const struct tegra_embedded_metadata_ops *ops;
 +	} embedded;
 +
  	DECLARE_BITMAP(fmts_bitmap, MAX_FORMAT_NUM);
  	atomic_t power_on_refcnt;
  	struct v4l2_fh *fh;
-@@ -278,6 +295,7 @@ struct tegra_channel {
+@@ -278,6 +298,7 @@ struct tegra_channel {
  
  	dma_addr_t emb_buf;
  	void *emb_buf_addr;
@@ -1449,7 +1539,7 @@ index 607f1f5..7ad678d 100644
  	unsigned int emb_buf_size;
  };
  
-@@ -319,6 +337,9 @@ struct tegra_mc_vi {
+@@ -319,6 +340,9 @@ struct tegra_mc_vi {
  	unsigned int num_channels;
  	unsigned int num_subdevs;
  
@@ -1459,9 +1549,13 @@ index 607f1f5..7ad678d 100644
  	struct tegra_csi_device *csi;
  	struct list_head vi_chans;
  	struct tegra_channel *tpg_start;
-@@ -415,7 +436,9 @@ struct tegra_channel_buffer *dequeue_inflight(struct tegra_channel *chan);
+@@ -414,8 +438,13 @@ void enqueue_inflight(struct tegra_channel *chan,
+ struct tegra_channel_buffer *dequeue_inflight(struct tegra_channel *chan);
  int tegra_channel_set_power(struct tegra_channel *chan, bool on);
  
++/* Legacy D4xx embedded-metadata allocation and payload contract. */
++#define D4XX_META_BUFSIZE	68
++
  int tegra_channel_init_video(struct tegra_channel *chan);
 +int tegra_channel_init_video_embedded(struct tegra_channel *chan);
  int tegra_channel_cleanup_video(struct tegra_channel *chan);
@@ -1470,7 +1564,7 @@ index 607f1f5..7ad678d 100644
  struct tegra_vi_fops {
  	int (*vi_power_on)(struct tegra_channel *chan);
 diff --git a/include/media/tegra_camera_core.h b/include/media/tegra_camera_core.h
-index be84820..0e8acb1 100644
+index be84820c..0e8acb1f 100644
 --- a/include/media/tegra_camera_core.h
 +++ b/include/media/tegra_camera_core.h
 @@ -30,7 +30,7 @@
@@ -1504,5 +1598,3 @@ index be84820..0e8acb1 100644
  };
  
  /* Supported CSI to VI Data Formats */
--- 
-2.34.1

--- a/nvidia-oot/7.2/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/7.2/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -1,5 +1,33 @@
+From 824f0e78a4e5a54218ecac44e3827ec40f75606a Mon Sep 17 00:00:00 2001
+From: Dmitry Perchanov <dmitry.perchanov@intel.com>
+Date: Tue, 8 Sep 2026 17:30:26 +0800
+Subject: [PATCH] Porting nvidia driver patches to jetpack 6.0
+
+Allocate one page-aligned embedded-metadata DMA slot per VI capture descriptor. Descriptor setup and completion use the same slot so in-flight frames cannot overwrite each other metadata.
+
+Add a per-sensor metadata hook so queue capacity and each frame actual payload length remain separate. Legacy D4xx keeps its 68-byte contract; sensors with variable metadata publish validated bytesused.
+
+Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
+---
+ drivers/media/i2c/Makefile                    |   5 +
+ drivers/media/i2c/max9295.c                   | 139 ++++++
+ drivers/media/i2c/max9296.c                   | 193 ++++++++
+ .../platform/tegra/camera/sensor_common.c     |   4 +
+ .../media/platform/tegra/camera/vi/channel.c  | 420 +++++++++++++++++-
+ .../media/platform/tegra/camera/vi/graph.c    |  39 +-
+ .../platform/tegra/camera/vi/mc_common.c      |  27 ++
+ .../media/platform/tegra/camera/vi/vi5_fops.c | 223 ++++++++--
+ .../platform/tegra/camera/vi/vi5_formats.h    |  30 +-
+ include/media/camera_common.h                 |   8 +
+ include/media/gmsl-link.h                     |   5 +
+ include/media/max9295.h                       |   4 +
+ include/media/max9296.h                       |   8 +
+ include/media/mc_common.h                     |  29 ++
+ include/media/tegra_camera_core.h             |  10 +-
+ 15 files changed, 1091 insertions(+), 53 deletions(-)
+
 diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
-index fdf09df61137d7bb2c76c59fbabf597d655037d1..0e40687893598cd928c0fad034658ea39d7e692a 100644
+index fdf09df..0e40687 100644
 --- a/drivers/media/i2c/Makefile
 +++ b/drivers/media/i2c/Makefile
 @@ -17,6 +17,11 @@ subdir-ccflags-y += -Werror
@@ -15,7 +43,7 @@ index fdf09df61137d7bb2c76c59fbabf597d655037d1..0e40687893598cd928c0fad034658ea3
  obj-m += max96712.o
  
 diff --git a/drivers/media/i2c/max9295.c b/drivers/media/i2c/max9295.c
-index b363d5f67926b9affeab4b2b917e2f7e127b322b..b2b3599c2e8b23e57829b76d9ef4d0062a831ff1 100644
+index b363d5f..b2b3599 100644
 --- a/drivers/media/i2c/max9295.c
 +++ b/drivers/media/i2c/max9295.c
 @@ -465,6 +465,145 @@ static  struct regmap_config max9295_regmap_config = {
@@ -165,7 +193,7 @@ index b363d5f67926b9affeab4b2b917e2f7e127b322b..b2b3599c2e8b23e57829b76d9ef4d006
  static int max9295_probe(struct i2c_client *client)
  #else
 diff --git a/drivers/media/i2c/max9296.c b/drivers/media/i2c/max9296.c
-index 1ceaf3cd5cb1d3915905744700f6831b5fc83f84..46516d63c506d3b126141cb8576d39bd499199f1 100644
+index 1ceaf3c..46516d6 100644
 --- a/drivers/media/i2c/max9296.c
 +++ b/drivers/media/i2c/max9296.c
 @@ -34,6 +34,8 @@
@@ -383,7 +411,7 @@ index 1ceaf3cd5cb1d3915905744700f6831b5fc83f84..46516d63c506d3b126141cb8576d39bd
  	{ .compatible = "maxim,max9296", },
  	{ },
 diff --git a/drivers/media/platform/tegra/camera/sensor_common.c b/drivers/media/platform/tegra/camera/sensor_common.c
-index 3d86b3dfc986a334650081da919d22af81b9e70b..66227cc5bf6e0c8508f5cb98c1e0b75ba3e083a7 100644
+index 3d86b3d..66227cc 100644
 --- a/drivers/media/platform/tegra/camera/sensor_common.c
 +++ b/drivers/media/platform/tegra/camera/sensor_common.c
 @@ -341,6 +341,10 @@ static int extract_pixel_format(
@@ -398,7 +426,7 @@ index 3d86b3dfc986a334650081da919d22af81b9e70b..66227cc5bf6e0c8508f5cb98c1e0b75b
  		pr_err("%s: Need to extend format%s\n", __func__, pixel_t);
  		return -EINVAL;
 diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
-index 33700bb3247aefe991636d3de8de43d583bf046f..26d19f578bbea4bc5ca2a3214b422e9853c2085c 100644
+index 33700bb..ac5fb8d 100644
 --- a/drivers/media/platform/tegra/camera/vi/channel.c
 +++ b/drivers/media/platform/tegra/camera/vi/channel.c
 @@ -231,7 +231,12 @@ static void tegra_channel_fmt_align(struct tegra_channel *chan,
@@ -502,7 +530,7 @@ index 33700bb3247aefe991636d3de8de43d583bf046f..26d19f578bbea4bc5ca2a3214b422e98
  };
  
  static int tegra_channel_close(struct file *fp);
-@@ -2678,6 +2747,334 @@ static int tegra_channel_csi_init(struct tegra_channel *chan)
+@@ -2678,6 +2747,346 @@ static int tegra_channel_csi_init(struct tegra_channel *chan)
  	return ret;
  }
  
@@ -569,10 +597,19 @@ index 33700bb3247aefe991636d3de8de43d583bf046f..26d19f578bbea4bc5ca2a3214b422e98
 +	return 0;
 +}
 +
++static unsigned int tegra_metadata_buffer_size(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->max_buffer_size)
++		return chan->embedded.ops->max_buffer_size;
++
++	return D4XX_META_BUFSIZE;
++}
++
 +static int tegra_metadata_get_format(struct file *file, void *fh,
 +                                    struct v4l2_format *format)
 +{
 +	struct v4l2_fh *vfh = file->private_data;
++	struct tegra_channel *chan = video_drvdata(file);
 +	struct v4l2_meta_format *fmt = &format->fmt.meta;
 +
 +	if (format->type != vfh->vdev->queue->type)
@@ -581,7 +618,7 @@ index 33700bb3247aefe991636d3de8de43d583bf046f..26d19f578bbea4bc5ca2a3214b422e98
 +	memset(fmt, 0, sizeof(*fmt));
 +
 +	fmt->dataformat = V4L2_META_FMT_D4XX;
-+	fmt->buffersize = 255;
++	fmt->buffersize = tegra_metadata_buffer_size(chan);
 +
 +	return 0;
 +}
@@ -617,19 +654,20 @@ index 33700bb3247aefe991636d3de8de43d583bf046f..26d19f578bbea4bc5ca2a3214b422e98
 +                    unsigned int sizes[], struct device *alloc_devs[])
 +{
 +	struct tegra_channel *chan = vb2_get_drv_priv(vq);
++	unsigned int size = tegra_metadata_buffer_size(chan);
 +
 +	if (*nplanes) {
 +		if (*nplanes != 1)
 +			return -EINVAL;
 +
-+		if (sizes[0] < 255)
++		if (sizes[0] < size)
 +			return -EINVAL;
 +
 +		return 0;
 +	}
 +
 +	*nplanes = 1;
-+	sizes[0] = 255;
++	sizes[0] = size;
 +	alloc_devs[0] = chan->vi->dev;
 +
 +
@@ -638,10 +676,12 @@ index 33700bb3247aefe991636d3de8de43d583bf046f..26d19f578bbea4bc5ca2a3214b422e98
 +
 +static int tegra_metadata_buffer_prepare(struct vb2_buffer *vb)
 +{
++	struct tegra_channel *chan = vb2_get_drv_priv(vb->vb2_queue);
++
 +	if (vb->num_planes != 1)
 +		return -EINVAL;
 +
-+	if (vb2_plane_size(vb, 0) < 255)
++	if (vb2_plane_size(vb, 0) < tegra_metadata_buffer_size(chan))
 +		return -EINVAL;
 +
 +	return 0;
@@ -837,7 +877,7 @@ index 33700bb3247aefe991636d3de8de43d583bf046f..26d19f578bbea4bc5ca2a3214b422e98
  int tegra_channel_init_video(struct tegra_channel *chan)
  {
  	struct tegra_mc_vi *vi = chan->vi;
-@@ -2878,6 +3275,13 @@ int tegra_channel_cleanup(struct tegra_channel *chan)
+@@ -2878,6 +3287,13 @@ int tegra_channel_cleanup(struct tegra_channel *chan)
  			chan->emb_buf_size,
  			chan->emb_buf_addr, chan->emb_buf);
  		chan->emb_buf_size = 0;
@@ -852,7 +892,7 @@ index 33700bb3247aefe991636d3de8de43d583bf046f..26d19f578bbea4bc5ca2a3214b422e98
  
  	tegra_channel_dealloc_buffer_queue(chan);
 diff --git a/drivers/media/platform/tegra/camera/vi/graph.c b/drivers/media/platform/tegra/camera/vi/graph.c
-index 097db3f747c31b46faa7d446b6e1f42e0e6466a6..8e2a600f31c233eedcc4cc9ae0dab908ca0fd826 100644
+index 097db3f..b652336 100644
 --- a/drivers/media/platform/tegra/camera/vi/graph.c
 +++ b/drivers/media/platform/tegra/camera/vi/graph.c
 @@ -291,6 +291,11 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
@@ -867,7 +907,7 @@ index 097db3f747c31b46faa7d446b6e1f42e0e6466a6..8e2a600f31c233eedcc4cc9ae0dab908
  	int ret;
  
  	dev_dbg(chan->vi->dev, "notify complete, all subdevs registered\n");
-@@ -324,16 +329,46 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
+@@ -324,16 +329,47 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
  	if (ret < 0)
  		goto graph_error;
  
@@ -882,6 +922,7 @@ index 097db3f747c31b46faa7d446b6e1f42e0e6466a6..8e2a600f31c233eedcc4cc9ae0dab908
 +
 +	if (sensor_mode &&
 +		sensor_mode->image_properties.embedded_metadata_height > 0) {
++		chan->embedded.ops = s_data ? s_data->embedded_metadata_ops : NULL;
 +		ret = tegra_channel_init_video_embedded(chan);
 +		if (ret < 0) {
 +			dev_err(chan->vi->dev,
@@ -915,7 +956,7 @@ index 097db3f747c31b46faa7d446b6e1f42e0e6466a6..8e2a600f31c233eedcc4cc9ae0dab908
  graph_error:
  	video_unregister_device(chan->video);
  register_device_error:
-@@ -397,6 +432,7 @@ static void tegra_vi_graph_notify_unbind(struct v4l2_async_notifier *notifier,
+@@ -397,6 +433,7 @@ static void tegra_vi_graph_notify_unbind(struct v4l2_async_notifier *notifier,
  
  	/* cleanup for complete */
  	if (chan->link_status) {
@@ -924,7 +965,7 @@ index 097db3f747c31b46faa7d446b6e1f42e0e6466a6..8e2a600f31c233eedcc4cc9ae0dab908
  		tegra_channel_cleanup_video(chan);
  		chan->link_status--;
 diff --git a/drivers/media/platform/tegra/camera/vi/mc_common.c b/drivers/media/platform/tegra/camera/vi/mc_common.c
-index ee1d6e26daea11406638213ff79cd66e735e651b..a499d8d11013a1d1eaad1e36af071ec721c83ef5 100644
+index ee1d6e2..a499d8d 100644
 --- a/drivers/media/platform/tegra/camera/vi/mc_common.c
 +++ b/drivers/media/platform/tegra/camera/vi/mc_common.c
 @@ -164,6 +164,10 @@ static int vi_parse_dt(struct tegra_mc_vi *vi, struct platform_device *dev)
@@ -969,10 +1010,10 @@ index ee1d6e26daea11406638213ff79cd66e735e651b..a499d8d11013a1d1eaad1e36af071ec7
  	if (ports == NULL)
  		ports = node;
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-index 69d76521b28f0c5b07ddbd7ac867c35c5cc0204c..a4ced49a7e06bfce89759abf93be4433e0409fa0 100644
+index 69d7652..860fd94 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -7,6 +7,7 @@
+@@ -7,11 +7,13 @@
  #include <linux/fs.h>
  #include <linux/kthread.h>
  #include <linux/nvhost.h>
@@ -980,7 +1021,13 @@ index 69d76521b28f0c5b07ddbd7ac867c35c5cc0204c..a4ced49a7e06bfce89759abf93be4433
  #include <linux/pm_runtime.h>
  #include <linux/semaphore.h>
  #include <linux/syscalls.h>
-@@ -67,6 +68,8 @@ static const struct capture_descriptor capture_template = {
+ #include <media/fusa-capture/capture-vi-channel.h>
+ #include <media/fusa-capture/capture-vi.h>
++#include <media/camera_common.h>
+ #include <media/mc_common.h>
+ #include <media/tegra-v4l2-camera.h>
+ #include <media/tegra_camera_platform.h>
+@@ -67,6 +69,8 @@ static const struct capture_descriptor capture_template = {
  	},
  };
  
@@ -989,7 +1036,7 @@ index 69d76521b28f0c5b07ddbd7ac867c35c5cc0204c..a4ced49a7e06bfce89759abf93be4433
  static void vi5_init_video_formats(struct tegra_channel *chan)
  {
  	int i;
-@@ -442,12 +445,15 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -442,12 +446,15 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  	}
  
  	if (chan->embedded_data_height > 0) {
@@ -1006,10 +1053,35 @@ index 69d76521b28f0c5b07ddbd7ac867c35c5cc0204c..a4ced49a7e06bfce89759abf93be4433
  		desc_memoryinfo->surface[VI_ATOMP_SURFACE_EMBEDDED].size
  			= desc->ch_cfg.frame.embed_x * desc->ch_cfg.frame.embed_y;
  
-@@ -463,6 +469,56 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -463,6 +470,90 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  		chan->capture_descr_sequence += 1;
  }
  
++static unsigned int vi5_metadata_buffer_size(struct tegra_channel *chan)
++{
++	if (chan->embedded.ops && chan->embedded.ops->max_buffer_size)
++		return chan->embedded.ops->max_buffer_size;
++
++	return D4XX_META_BUFSIZE;
++}
++
++static unsigned int vi5_metadata_bytesused(struct tegra_channel *chan,
++					   const void *metadata_addr,
++					   unsigned int captured_size)
++{
++	const struct tegra_embedded_metadata_ops *ops = chan->embedded.ops;
++	size_t bytesused;
++
++	if (!ops || !ops->get_bytesused)
++		return captured_size;
++
++	bytesused = ops->get_bytesused(metadata_addr, captured_size);
++	if (bytesused && bytesused <= captured_size)
++		return bytesused;
++
++	return 0;
++}
++
 +static void vi5_release_metadata_buffer(struct tegra_channel *chan,
 +	struct tegra_channel_buffer *buf)
 +{
@@ -1018,6 +1090,8 @@ index 69d76521b28f0c5b07ddbd7ac867c35c5cc0204c..a4ced49a7e06bfce89759abf93be4433
 +	struct vb2_v4l2_buffer *vbuf = &buf->buf;
 +	void *frm_buffer;
 +	void *metadata_addr;
++	unsigned int buffer_size = vi5_metadata_buffer_size(chan);
++	unsigned int bytesused;
 +	unsigned int descr_index = buf->capture_descr_index[0];
 +	unsigned int emb_offset;
 +
@@ -1042,20 +1116,27 @@ index 69d76521b28f0c5b07ddbd7ac867c35c5cc0204c..a4ced49a7e06bfce89759abf93be4433
 +	}
 +
 +	if (!chan->emb_buf_stride ||
-+		chan->emb_buf_size < 255 ||
++		chan->emb_buf_size < buffer_size ||
++		vb2_plane_size(evb, 0) < buffer_size ||
 +		descr_index >= chan->capture_queue_depth ||
 +		check_mul_overflow(descr_index, chan->emb_buf_stride,
 +			&emb_offset) ||
-+		emb_offset > chan->emb_buf_size - 255) {
++		emb_offset > chan->emb_buf_size - buffer_size) {
 +		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
 +		return;
 +	}
 +
 +	metadata_addr = (u8 *)chan->emb_buf_addr + emb_offset;
-+	memcpy(frm_buffer, metadata_addr, 255);
++	bytesused = vi5_metadata_bytesused(chan, metadata_addr, buffer_size);
++	if (!bytesused) {
++		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
++		return;
++	}
++
++	memcpy(frm_buffer, metadata_addr, bytesused);
 +	evbuf = to_vb2_v4l2_buffer(evb);
 +	evbuf->sequence = vbuf->sequence;
-+	vb2_set_plane_payload(evb, 0, 255);
++	vb2_set_plane_payload(evb, 0, bytesused);
 +	evb->timestamp = vbuf->vb2_buf.timestamp;
 +	vb2_buffer_done(evb, VB2_BUF_STATE_DONE);
 +}
@@ -1063,7 +1144,7 @@ index 69d76521b28f0c5b07ddbd7ac867c35c5cc0204c..a4ced49a7e06bfce89759abf93be4433
  static void vi5_release_buffer(struct tegra_channel *chan,
  	struct tegra_channel_buffer *buf)
  {
-@@ -477,6 +533,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+@@ -477,6 +568,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
  	vbuf->field = V4L2_FIELD_NONE;
  	vb2_set_plane_payload(&vbuf->vb2_buf, 0, chan->format.sizeimage);
  
@@ -1073,7 +1154,7 @@ index 69d76521b28f0c5b07ddbd7ac867c35c5cc0204c..a4ced49a7e06bfce89759abf93be4433
  	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);
  }
  
-@@ -718,6 +777,15 @@ static int vi5_channel_error_recover(struct tegra_channel *chan,
+@@ -718,6 +812,15 @@ static int vi5_channel_error_recover(struct tegra_channel *chan,
  			err = PTR_ERR(chan);
  			goto done;
  		}
@@ -1089,7 +1170,7 @@ index 69d76521b28f0c5b07ddbd7ac867c35c5cc0204c..a4ced49a7e06bfce89759abf93be4433
  		err = tegra_channel_capture_setup(chan, vi_port);
  		if (err < 0)
  			goto done;
-@@ -911,6 +979,75 @@ static void vi5_unit_get_device_handle(struct platform_device *pdev,
+@@ -911,6 +1014,75 @@ static void vi5_unit_get_device_handle(struct platform_device *pdev,
  		dev_err(&pdev->dev, "dev pointer is NULL\n");
  }
  
@@ -1165,7 +1246,7 @@ index 69d76521b28f0c5b07ddbd7ac867c35c5cc0204c..a4ced49a7e06bfce89759abf93be4433
  static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
  {
  	struct tegra_channel *chan = vb2_get_drv_priv(vq);
-@@ -923,7 +1060,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+@@ -923,7 +1095,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
  	struct device_node *node;
  	struct sensor_mode_properties *sensor_mode;
  	struct camera_common_data *s_data;
@@ -1173,7 +1254,7 @@ index 69d76521b28f0c5b07ddbd7ac867c35c5cc0204c..a4ced49a7e06bfce89759abf93be4433
  
  	/* Skip in bypass mode */
  	if (!chan->bypass) {
-@@ -946,7 +1082,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+@@ -946,7 +1117,6 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
  				if (s_data != NULL && node != NULL) {
  					int idx = s_data->mode_prop_idx;
  
@@ -1181,7 +1262,7 @@ index 69d76521b28f0c5b07ddbd7ac867c35c5cc0204c..a4ced49a7e06bfce89759abf93be4433
  					if (idx < s_data->sensor_props.\
  								num_modes) {
  						sensor_mode =
-@@ -960,46 +1095,14 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+@@ -960,46 +1130,14 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
  							sensor_mode->\
  							 image_properties.\
  						      embedded_metadata_height;
@@ -1234,7 +1315,7 @@ index 69d76521b28f0c5b07ddbd7ac867c35c5cc0204c..a4ced49a7e06bfce89759abf93be4433
  				}
  			}
  			ret = tegra_channel_capture_setup(chan, vi_port);
-@@ -1089,7 +1192,10 @@ static int vi5_channel_stop_streaming(struct vb2_queue *vq)
+@@ -1089,7 +1227,10 @@ static int vi5_channel_stop_streaming(struct vb2_queue *vq)
  										&vi_unit_dev);
  				dma_free_coherent(vi_unit_dev, chan->emb_buf_size,
  								chan->emb_buf_addr, chan->emb_buf);
@@ -1246,7 +1327,7 @@ index 69d76521b28f0c5b07ddbd7ac867c35c5cc0204c..a4ced49a7e06bfce89759abf93be4433
  
  			vi_channel_close_ex(chan->vi_channel_id[vi_port],
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-index d0403936b50ab7faf5426e63865332577cc6044a..c04ca61f927caba63fab1f00d99c06cc6f527772 100644
+index d040393..c04ca61 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 @@ -88,6 +88,8 @@ static const struct tegra_video_format vi5_video_formats[] = {
@@ -1308,8 +1389,34 @@ index d0403936b50ab7faf5426e63865332577cc6044a..c04ca61f927caba63fab1f00d99c06cc
  };
  
  #endif
+diff --git a/include/media/camera_common.h b/include/media/camera_common.h
+index d30b873..5e81f54 100644
+--- a/include/media/camera_common.h
++++ b/include/media/camera_common.h
+@@ -31,6 +31,13 @@
+ #include <media/v4l2-ctrls.h>
+ #include <media/tegracam_core.h>
+ 
++#define TEGRA_HAS_EMBEDDED_METADATA_OPS 1
++
++struct tegra_embedded_metadata_ops {
++	u32 max_buffer_size;
++	size_t (*get_bytesused)(const u8 *data, size_t captured_size);
++};
++
+ /*
+  * Scaling factor for converting a Q10.22 fixed point value
+  * back to its original floating point value
+@@ -250,6 +257,7 @@ struct camera_common_data {
+ 	int	sensor_mode_id;
+ 	bool	use_sensor_mode_id;
+ 	bool	override_enable;
++	const struct tegra_embedded_metadata_ops *embedded_metadata_ops;
+ 	u32	version;
+ };
+ 
 diff --git a/include/media/gmsl-link.h b/include/media/gmsl-link.h
-index ad902d0a70ce93a59e776d8ac108b4fe5908841d..cebeb37e6b31bd4784da9c147be03d6930112395 100644
+index ad902d0..cebeb37 100644
 --- a/include/media/gmsl-link.h
 +++ b/include/media/gmsl-link.h
 @@ -40,6 +40,11 @@
@@ -1325,7 +1432,7 @@ index ad902d0a70ce93a59e776d8ac108b4fe5908841d..cebeb37e6b31bd4784da9c147be03d69
  #define GMSL_ST_ID_UNUSED 0xFF
  
 diff --git a/include/media/max9295.h b/include/media/max9295.h
-index bf801aa244f3ca46a577ea23cfa43b4f40e5cbb3..c576e3e5de3535014e4b674ab390fa681e2949d7 100644
+index bf801aa..c576e3e 100644
 --- a/include/media/max9295.h
 +++ b/include/media/max9295.h
 @@ -12,6 +12,7 @@
@@ -1354,7 +1461,7 @@ index bf801aa244f3ca46a577ea23cfa43b4f40e5cbb3..c576e3e5de3535014e4b674ab390fa68
  
  #endif  /* __MAX9295_H__ */
 diff --git a/include/media/max9296.h b/include/media/max9296.h
-index 210dbc80a9c8bc4e9b1a25f6d79d5e2ad634b0d8..6b4c796e67eed83b94f875ea64b71b7f0b7649f2 100644
+index 210dbc8..6b4c796 100644
 --- a/include/media/max9296.h
 +++ b/include/media/max9296.h
 @@ -12,6 +12,7 @@
@@ -1387,10 +1494,19 @@ index 210dbc80a9c8bc4e9b1a25f6d79d5e2ad634b0d8..6b4c796e67eed83b94f875ea64b71b7f
  
  #endif  /* __MAX9296_H__ */
 diff --git a/include/media/mc_common.h b/include/media/mc_common.h
-index e74971f55565039894c5f30326afcc20fe5cc0b8..d908237fe91c8841a393644eabc38ae13f49cf33 100644
+index e74971f..d993547 100644
 --- a/include/media/mc_common.h
 +++ b/include/media/mc_common.h
-@@ -224,6 +224,23 @@ struct tegra_channel {
+@@ -29,6 +29,8 @@
+ #define	MAX_SUBDEVICES	4
+ #define	QUEUED_BUFFERS	4
+ #define	ENABLE		1
++
++struct tegra_embedded_metadata_ops;
+ #define	DISABLE		0
+ #define MAX_SYNCPT_PER_CHANNEL	3
+ 
+@@ -224,6 +226,24 @@ struct tegra_channel {
  	unsigned int embedded_data_width;
  	unsigned int embedded_data_height;
  
@@ -1409,12 +1525,13 @@ index e74971f55565039894c5f30326afcc20fe5cc0b8..d908237fe91c8841a393644eabc38ae1
 +		void *alloc_ctx;
 +		struct media_pad pad;
 +		struct v4l2_ctrl_handler ctrl_handler;
++		const struct tegra_embedded_metadata_ops *ops;
 +	} embedded;
 +
  	DECLARE_BITMAP(fmts_bitmap, MAX_FORMAT_NUM);
  	atomic_t power_on_refcnt;
  	struct v4l2_fh *fh;
-@@ -264,6 +281,7 @@ struct tegra_channel {
+@@ -264,6 +284,7 @@ struct tegra_channel {
  
  	dma_addr_t emb_buf;
  	void *emb_buf_addr;
@@ -1422,7 +1539,7 @@ index e74971f55565039894c5f30326afcc20fe5cc0b8..d908237fe91c8841a393644eabc38ae1
  	unsigned int emb_buf_size;
  };
  
-@@ -305,6 +323,9 @@ struct tegra_mc_vi {
+@@ -305,6 +326,9 @@ struct tegra_mc_vi {
  	unsigned int num_channels;
  	unsigned int num_subdevs;
  
@@ -1432,9 +1549,13 @@ index e74971f55565039894c5f30326afcc20fe5cc0b8..d908237fe91c8841a393644eabc38ae1
  	struct tegra_csi_device *csi;
  	struct list_head vi_chans;
  	struct tegra_channel *tpg_start;
-@@ -401,7 +422,9 @@ struct tegra_channel_buffer *dequeue_inflight(struct tegra_channel *chan);
+@@ -400,8 +424,13 @@ void enqueue_inflight(struct tegra_channel *chan,
+ struct tegra_channel_buffer *dequeue_inflight(struct tegra_channel *chan);
  int tegra_channel_set_power(struct tegra_channel *chan, bool on);
  
++/* Legacy D4xx embedded-metadata allocation and payload contract. */
++#define D4XX_META_BUFSIZE	68
++
  int tegra_channel_init_video(struct tegra_channel *chan);
 +int tegra_channel_init_video_embedded(struct tegra_channel *chan);
  int tegra_channel_cleanup_video(struct tegra_channel *chan);
@@ -1443,7 +1564,7 @@ index e74971f55565039894c5f30326afcc20fe5cc0b8..d908237fe91c8841a393644eabc38ae1
  struct tegra_vi_fops {
  	int (*vi_power_on)(struct tegra_channel *chan);
 diff --git a/include/media/tegra_camera_core.h b/include/media/tegra_camera_core.h
-index be84820ccd125fe4f7191c9c3b11ed2c94ac2415..0e8acb1f33c003df03d313b84d87d2e9af314964 100644
+index be84820..0e8acb1 100644
 --- a/include/media/tegra_camera_core.h
 +++ b/include/media/tegra_camera_core.h
 @@ -30,7 +30,7 @@


### PR DESCRIPTION
## Summary

- Add a generic `tegra_embedded_metadata_ops` hook in the JetPack 6.2 and JetPack 7 `0001` embedded-metadata carriers.
- Keep the legacy D4xx metadata contract unchanged.
- Let D500 request the UVC header maximum capacity (255 bytes) while deriving each frame's actual `bytesused` from its validated UVC header.
- Read and copy metadata from the current PR #638 descriptor slot, preserving video/metadata ownership.

## Design

Allocation capacity and payload length are separate:

- D4xx, with no sensor hook: the existing fixed allocation and payload contract.
- D500: 255-byte allocation capacity; the sensor hook validates the UVC info byte, Capture Timing block, and header length before returning the actual payload length. Current HKR payloads are 248 bytes for Depth/IR and 255 bytes for RGB.
- Invalid D500 framing completes the metadata buffer as an error instead of copying beyond the validated payload.

The hook is sensor-owned and generic. The Tegra VI path does not parse D500 stream semantics, and the pixel-buffer path is unchanged.

## Scope

The hook is folded into the `0001` embedded-metadata carriers used by JetPack 6.2/6.2.1/6.2.2 and JetPack 7.0/7.1/7.2. This PR remains stacked on PR #638 because runtime length parsing must use the per-descriptor metadata DMA slot introduced there.

## Validation

- The JetPack 6.2 carrier applies cleanly to L4T 36.4.3, 36.4.4, 36.4.7, and 36.5.0.
- JetPack 6.2.2 full build passed; the complete matching Image/module package was deployed on jetson67 with no module ABI errors.
- D500 2C RGB one-node: 361/361 video/metadata pairs, 119.9 FPS aggregate, MC1/MC3 at 60.1/60.0 FPS, with no drops, reuse, truncation, or source mismatch.
- D500 2C Depth + IR: 60 frames per stream passed at 30 FPS; actual metadata `bytesused` was 248 bytes for both streams.
- D500 3C Depth + IR + RGB: all streams passed together; actual metadata `bytesused` was 248 bytes for Depth/IR and 255 bytes for RGB, with no V4L2 errors, sequence drops, truncation, or stream mismatch.
- JetPack 7.0/7.1/7.2 patch application and CI builds passed on the previous head; CI for the updated head is running.

Depends-On: https://github.com/realsenseai/realsense_mipi_platform_driver/pull/638
