### PR TITLE
Fix VI embedded metadata reuse across video frames on JP7.2

### DIFF
--- a/nvidia-oot/7.2/0014-Fix-VI-per-frame-embedded-metadata.patch
+++ b/nvidia-oot/7.2/0014-Fix-VI-per-frame-embedded-metadata.patch
@@ -1,0 +1,116 @@
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -384,6 +384,25 @@
+ 	return 0;
+ }
+ 
++/* Keep embedded data with its vb2 image buffer until both are returned.
++ * A channel-wide DMA surface can be overwritten by the next frame before
++ * the dequeue worker copies the completed frame's metadata to userspace.
++ * Use vb2 indices, not descriptor indices: descriptor slots can be reused
++ * as soon as capture status is consumed, before vb2 completion finishes.
++ */
++static size_t vi5_embedded_slot_size(const struct tegra_channel *chan)
++{
++	return round_up((size_t)chan->embedded_data_width *
++		chan->embedded_data_height * BPP_MEM, PAGE_SIZE);
++}
++
++static size_t vi5_embedded_offset(const struct tegra_channel *chan,
++	const struct tegra_channel_buffer *buf, unsigned int vi_port)
++{
++	return vi5_embedded_slot_size(chan) *
++		((size_t)buf->buf.vb2_buf.index * chan->valid_ports + vi_port);
++}
++
+ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	struct tegra_channel_buffer *buf, unsigned int descr_index, unsigned int vi_port)
+ {
+@@ -476,7 +495,7 @@
+ 		desc->ch_cfg.frame.embed_y = chan->embedded_data_height;
+ 
+ 		desc_memoryinfo->surface[VI_ATOMP_SURFACE_EMBEDDED].base_address
+-			= chan->emb_buf;
++			= chan->emb_buf + vi5_embedded_offset(chan, buf, vi_port);
+ 		desc_memoryinfo->surface[VI_ATOMP_SURFACE_EMBEDDED].size
+ 			= desc->ch_cfg.frame.embed_x * desc->ch_cfg.frame.embed_y;
+ 
+@@ -493,8 +512,9 @@
+ }
+ 
+ static void vi5_release_metadata_buffer(struct tegra_channel *chan,
+-	struct vb2_v4l2_buffer *vbuf)
+-{
++	struct tegra_channel_buffer *buf)
++{
++	struct vb2_v4l2_buffer *vbuf = &buf->buf;
+ 	struct vb2_buffer *evb = NULL;
+ 	struct vb2_v4l2_buffer *evbuf;
+ 	void* frm_buffer;
+@@ -517,7 +537,8 @@
+ 	if (!frm_buffer)
+ 		return;
+ 
+-	memcpy(frm_buffer, chan->emb_buf_addr, 255);
++	memcpy(frm_buffer, (u8 *)chan->emb_buf_addr +
++		vi5_embedded_offset(chan, buf, 0), 255);
+ 	evbuf = to_vb2_v4l2_buffer(evb);
+ 	evbuf->sequence = vbuf->sequence;
+ 	vb2_set_plane_payload(evb, 0, 255);
+@@ -539,10 +560,13 @@
+ 	vbuf->field = V4L2_FIELD_NONE;
+ 	vb2_set_plane_payload(&vbuf->vb2_buf, 0, chan->format.sizeimage);
+ 
++	/* Copy metadata before waking image userspace, which may immediately
++	 * requeue this vb2 index and let DMA reuse its embedded-data slot.
++	 */
++	if (chan->embedded_data_height == 1 && buf->vb2_state == VB2_BUF_STATE_DONE)
++		vi5_release_metadata_buffer(chan, buf);
++
+ 	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);
+-
+-	if (chan->embedded_data_height == 1 && buf->vb2_state == VB2_BUF_STATE_DONE)
+-		vi5_release_metadata_buffer(chan, vbuf);
+ }
+ 
+ static void vi5_capture_enqueue(struct tegra_channel *chan,
+@@ -1008,7 +1032,7 @@
+ 	struct device_node *node;
+ 	struct sensor_mode_properties *sensor_mode;
+ 	struct camera_common_data *s_data;
+-	unsigned int emb_buf_size = 0;
++	size_t emb_buf_size = 0;
+ 
+ 	/* Skip in bypass mode */
+ 	if (!chan->bypass) {
+@@ -1045,13 +1069,15 @@
+ 							sensor_mode->\
+ 							 image_properties.\
+ 						      embedded_metadata_height;
+-						/* rounding up to page size */
+-						emb_buf_size =
+-							round_up(chan->\
+-							embedded_data_width *
+-								chan->\
+-							embedded_data_height *
+-							BPP_MEM, PAGE_SIZE);
++						/* Include every possible vb2 index, including buffers
++						 * added by CREATE_BUFS, and keep VI ports separate.
++						 */
++						if (check_mul_overflow(vi5_embedded_slot_size(chan),
++							(size_t)vq->max_num_buffers * chan->valid_ports,
++							&emb_buf_size) || emb_buf_size > UINT_MAX) {
++							ret = -EOVERFLOW;
++							goto err_setup;
++						}
+ 					}
+ 				}
+ 				/* Allocate buffer for Embedded Data if need to*/
+@@ -1082,6 +1108,7 @@
+ 						dev_err(&chan->video->dev,
+ 							"Can't allocate memory"
+ 							"for embedded data\n");
++						ret = -ENOMEM;
+ 						goto err_setup;
+ 					}
+ 					chan->emb_buf_size = emb_buf_size;


### PR DESCRIPTION
VI capture descriptors currently point every frame in a channel at one embedded-metadata DMA buffer. If the next frame writes metadata before the dequeue worker copies the previous frame's metadata to userspace, two different image buffers can receive the same frame counter and timestamp.

Give each vb2 image-buffer index its own page-aligned embedded-data slot, with separate slots for ganged VI ports. Reserve space for the queue's maximum buffer count so CREATE_BUFS cannot introduce an unallocated index. Copy metadata before returning the image buffer, preventing userspace from immediately requeuing and reusing its slot during the copy. Check allocation-size overflow and return an error if allocation fails. The change is supplied as the next JP7.2 NVIDIA OOT patch; SDK and firmware are unchanged.

Validation:

- Patched JP7.2 tegra-camera module cross-compiled and was loaded on Orin; loaded build ID verified.
- Original installed RealSense SDK, native YUYV, four 1280x960 streams selected at60 FPS plus accel/gyro each200 Hz, 60-second runs: before, RGB3561 callbacks /2999 distinct metadata counters /562 adjacent duplicate counters; after, RGB3561 callbacks /3561 distinct counters /0 duplicates or counter gaps. Before the fix, all562 duplicate-counter pairs had different sampled image bytes.
- Separate40-second video-only reopen: RGB2398 callbacks /2398 distinct counters /0 duplicates or counter gaps; depth and both infrared outputs each2399 with no duplicate counters.
- The fix applies cleanly after the complete current dev JP7.2 VI patch stack on vendor r39.2 source. Hardware measurements use the existing deployed driver baseline plus this patch, not a rebuild of every unrelated change in current dev.

RGB delivery with IMU remains59.35 FPS; increasing throughput, IMU reception losses and visible RGB corruption are outside this fix. This addresses metadata association and does not establish that every received image is a valid independent exposure.
